### PR TITLE
box-sizing CSS fix

### DIFF
--- a/packages/walletconnect-qrcode-modal/src/style.js
+++ b/packages/walletconnect-qrcode-modal/src/style.js
@@ -108,6 +108,7 @@ export default {
     image: `
       width: 100%;
       padding: 30px;
+      box-sizing: border-box;
     `
   }
 }


### PR DESCRIPTION
QR code in our app was overflowing (hidden) into parent div due to `box-sizing: border-box` not being present. Fixes this