### PR TITLE
Fix personal sign bug

### DIFF
--- a/packages/walletconnect-core/src/connector.js
+++ b/packages/walletconnect-core/src/connector.js
@@ -446,11 +446,10 @@ export default class Connector {
     let payload = this.checkObject(data, 'payload')
 
     if (payload.id) {
-      delete payload.id
+      payload.id = this.randomId()
     }
 
     return {
-      id: this.randomId(),
       jsonrpc: '2.0',
       params: [],
       ...payload
@@ -486,3 +485,4 @@ export default class Connector {
     return true
   }
 }
+

--- a/packages/walletconnect-core/src/connector.js
+++ b/packages/walletconnect-core/src/connector.js
@@ -445,9 +445,7 @@ export default class Connector {
   formatPayload(data) {
     let payload = this.checkObject(data, 'payload')
 
-    if (payload.id) {
-      payload.id = this.randomId()
-    }
+    payload.id = this.randomId()
 
     return {
       jsonrpc: '2.0',
@@ -485,4 +483,5 @@ export default class Connector {
     return true
   }
 }
+
 

--- a/packages/walletconnect-web3-subprovider/src/index.js
+++ b/packages/walletconnect-web3-subprovider/src/index.js
@@ -79,7 +79,7 @@ export default class WalletConnectSubprovider extends Subprovider {
       case 'personal_sign':
         try {
           const result = await this._walletconnect.createCallRequest(payload)
-          end(null, result)
+          end(null, result.result)
         } catch (err) {
           end(err)
         }

--- a/packages/walletconnect/src/index.js
+++ b/packages/walletconnect/src/index.js
@@ -143,6 +143,24 @@ export default class WalletConnect extends Connector {
   }
 
   //
+  //  Sign Personal Message
+  //
+  async signPersonalMessage(msgParams) {
+    try {
+      const response = await this.createCallRequest({
+        method: 'personal_sign',
+        params: [...msgParams]
+      })
+      if (!response.approved) {
+        throw new Error('Rejected: Signed Personal Message Request')
+      }
+      return response.result
+    } catch (error) {
+      throw error
+    }
+  }
+
+  //
   //  Create call request
   //
   async createCallRequest(payload) {
@@ -263,3 +281,4 @@ export default class WalletConnect extends Connector {
     localStorage.removeItem(localStorageId)
   }
 }
+

--- a/packages/walletconnect/src/index.js
+++ b/packages/walletconnect/src/index.js
@@ -143,24 +143,6 @@ export default class WalletConnect extends Connector {
   }
 
   //
-  //  Sign Personal Message
-  //
-  async signPersonalMessage(msgParams) {
-    try {
-      const response = await this.createCallRequest({
-        method: 'personal_sign',
-        params: [...msgParams]
-      })
-      if (!response.approved) {
-        throw new Error('Rejected: Signed Personal Message Request')
-      }
-      return response.result
-    } catch (error) {
-      throw error
-    }
-  }
-
-  //
   //  Create call request
   //
   async createCallRequest(payload) {
@@ -281,4 +263,3 @@ export default class WalletConnect extends Connector {
     localStorage.removeItem(localStorageId)
   }
 }
-


### PR DESCRIPTION
When send personal sign request, response is invalid, because had delete payload.id. 
```
# requestmanager.js
if (!Jsonrpc.isValidResponse(result)) {
    return callback(errors.InvalidResponse(result));
}
```
Then approveCallRequest in RN, return a object payload like this.
```
{
  result: "",
  approve: true
}
But web3.personal.sign should return a string of signedMessage.

Just solve my problem.