### PR TITLE
Fix signPersonalMessage Bug

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -571,7 +571,7 @@ class Connector {
     }
 
     if (!isHexStrict(params[1])) {
-      params[1] = convertUtf8ToHex(params[1])
+      params[1] = '0x' + convertUtf8ToHex(params[1])
     }
 
     const request = this._formatRequest({
@@ -1037,3 +1037,4 @@ class Connector {
   }
 }
 export default Connector
+


### PR DESCRIPTION
In `signPersonalMessage` function, convert message to hex if message  is not a hex, but return a string without `'0x'` prefix. 

In https://test.walletconnect.org source code
```
export async function signMessage(message: any) {
  if (activeAccount) {
    const result = await activeAccount.signMessage(
      message.substring(0, 2) === "0x"
        ? ethers.utils.arrayify(message)
        : message
    );
    return result;
  } else {
    console.error("No Active Account"); // tslint:disable-line
  }
  return null;
}
```