### PR TITLE
Reduce utils file size

### DIFF
--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@walletconnect/browser",
-	"version": "1.0.0-beta.23",
+	"version": "1.0.0-beta.24",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1327,9 +1327,9 @@
 			"dev": true
 		},
 		"bluebird": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-			"integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
 			"dev": true
 		},
 		"bn.js": {
@@ -1790,9 +1790,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-					"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.0.tgz",
+					"integrity": "sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ==",
 					"dev": true
 				}
 			}
@@ -2028,9 +2028,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.136",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.136.tgz",
-			"integrity": "sha512-xHkYkbEi4kI+2w5v6yBGCQTRXL7N0PWscygTFZu/1bArnPSo2WR9xjdw4m06RR4J5PncrWJcuOVv+MAG2mK5JQ==",
+			"version": "1.3.137",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz",
+			"integrity": "sha512-kGi32g42a8vS/WnYE7ELJyejRT7hbr3UeOOu0WeuYuQ29gCpg9Lrf6RdcTQVXSt/v0bjCfnlb/EWOOsiKpTmkw==",
 			"dev": true
 		},
 		"elliptic": {
@@ -4059,9 +4059,9 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "1.1.20",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.20.tgz",
-			"integrity": "sha512-YnC3NemTLgzOkQTmR4+0yl/7pIsXZcfWXoquNp0Dql03GQ+CYURhnjUDFsSJxpX/Q9nw8lAjLFdnACQoKs6h5w==",
+			"version": "1.1.21",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.21.tgz",
+			"integrity": "sha512-TwnURTCjc8a+ElJUjmDqU6+12jhli1Q61xOQmdZ7ECZVBZuQpN/1UnembiIHDM1wCcfLvh5wrWXUF5H6ufX64Q==",
 			"dev": true,
 			"requires": {
 				"semver": "^5.3.0"
@@ -5093,9 +5093,9 @@
 			"dev": true
 		},
 		"terser": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-			"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.0.0.tgz",
+			"integrity": "sha512-dOapGTU0hETFl1tCo4t56FN+2jffoKyER9qBGoUFyZ6y7WLoKT0bF+lAYi6B6YsILcGF3q1C2FBh8QcKSCgkgA==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
@@ -5112,18 +5112,19 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.4.tgz",
-			"integrity": "sha512-64IiILNQlACWZLzFlpzNaG0bpQ4ytaB7fwOsbpsdIV70AfLUmIGGeuKL0YV2WmtcrURjE2aOvHD4/lrFV3Rg+Q==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz",
+			"integrity": "sha512-W2YWmxPjjkUcOWa4pBEv4OP4er1aeQJlSo2UhtCFQCuRXEHjOFscO8VyWHj9JLlA0RzQb8Y2/Ta78XZvT54uGg==",
 			"dev": true,
 			"requires": {
 				"cacache": "^11.3.2",
 				"find-cache-dir": "^2.0.0",
 				"is-wsl": "^1.1.0",
+				"loader-utils": "^1.2.3",
 				"schema-utils": "^1.0.0",
 				"serialize-javascript": "^1.7.0",
 				"source-map": "^0.6.1",
-				"terser": "^3.17.0",
+				"terser": "^4.0.0",
 				"webpack-sources": "^1.3.0",
 				"worker-farm": "^1.7.0"
 			},
@@ -5475,9 +5476,9 @@
 			}
 		},
 		"webpack": {
-			"version": "4.32.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.32.1.tgz",
-			"integrity": "sha512-R0S2tfWP2tZ8ZC2dwgnUVfa9LPvhGWJXjqfgIQ6jply+9ncBbt8IZ9p83uVeqsZ/s8zKA3XyepciWNHnSxxnHg==",
+			"version": "4.32.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.32.2.tgz",
+			"integrity": "sha512-F+H2Aa1TprTQrpodRAWUMJn7A8MgDx82yQiNvYMaj3d1nv3HetKU0oqEulL9huj8enirKi8KvEXQ3QtuHF89Zg==",
 			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@walletconnect/core",
-	"version": "1.0.0-beta.23",
+	"version": "1.0.0-beta.24",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1327,9 +1327,9 @@
 			"dev": true
 		},
 		"bluebird": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-			"integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
 			"dev": true
 		},
 		"bn.js": {
@@ -1790,9 +1790,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-					"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.0.tgz",
+					"integrity": "sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ==",
 					"dev": true
 				}
 			}
@@ -2022,9 +2022,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.136",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.136.tgz",
-			"integrity": "sha512-xHkYkbEi4kI+2w5v6yBGCQTRXL7N0PWscygTFZu/1bArnPSo2WR9xjdw4m06RR4J5PncrWJcuOVv+MAG2mK5JQ==",
+			"version": "1.3.137",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz",
+			"integrity": "sha512-kGi32g42a8vS/WnYE7ELJyejRT7hbr3UeOOu0WeuYuQ29gCpg9Lrf6RdcTQVXSt/v0bjCfnlb/EWOOsiKpTmkw==",
 			"dev": true
 		},
 		"elliptic": {
@@ -4010,9 +4010,9 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "1.1.20",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.20.tgz",
-			"integrity": "sha512-YnC3NemTLgzOkQTmR4+0yl/7pIsXZcfWXoquNp0Dql03GQ+CYURhnjUDFsSJxpX/Q9nw8lAjLFdnACQoKs6h5w==",
+			"version": "1.1.21",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.21.tgz",
+			"integrity": "sha512-TwnURTCjc8a+ElJUjmDqU6+12jhli1Q61xOQmdZ7ECZVBZuQpN/1UnembiIHDM1wCcfLvh5wrWXUF5H6ufX64Q==",
 			"dev": true,
 			"requires": {
 				"semver": "^5.3.0"
@@ -5044,9 +5044,9 @@
 			"dev": true
 		},
 		"terser": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-			"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.0.0.tgz",
+			"integrity": "sha512-dOapGTU0hETFl1tCo4t56FN+2jffoKyER9qBGoUFyZ6y7WLoKT0bF+lAYi6B6YsILcGF3q1C2FBh8QcKSCgkgA==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
@@ -5063,18 +5063,19 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.4.tgz",
-			"integrity": "sha512-64IiILNQlACWZLzFlpzNaG0bpQ4ytaB7fwOsbpsdIV70AfLUmIGGeuKL0YV2WmtcrURjE2aOvHD4/lrFV3Rg+Q==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz",
+			"integrity": "sha512-W2YWmxPjjkUcOWa4pBEv4OP4er1aeQJlSo2UhtCFQCuRXEHjOFscO8VyWHj9JLlA0RzQb8Y2/Ta78XZvT54uGg==",
 			"dev": true,
 			"requires": {
 				"cacache": "^11.3.2",
 				"find-cache-dir": "^2.0.0",
 				"is-wsl": "^1.1.0",
+				"loader-utils": "^1.2.3",
 				"schema-utils": "^1.0.0",
 				"serialize-javascript": "^1.7.0",
 				"source-map": "^0.6.1",
-				"terser": "^3.17.0",
+				"terser": "^4.0.0",
 				"webpack-sources": "^1.3.0",
 				"worker-farm": "^1.7.0"
 			},
@@ -5426,9 +5427,9 @@
 			}
 		},
 		"webpack": {
-			"version": "4.32.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.32.1.tgz",
-			"integrity": "sha512-R0S2tfWP2tZ8ZC2dwgnUVfa9LPvhGWJXjqfgIQ6jply+9ncBbt8IZ9p83uVeqsZ/s8zKA3XyepciWNHnSxxnHg==",
+			"version": "4.32.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.32.2.tgz",
+			"integrity": "sha512-F+H2Aa1TprTQrpodRAWUMJn7A8MgDx82yQiNvYMaj3d1nv3HetKU0oqEulL9huj8enirKi8KvEXQ3QtuHF89Zg==",
 			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",

--- a/packages/qrcode-modal/package-lock.json
+++ b/packages/qrcode-modal/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@walletconnect/qrcode-modal",
-	"version": "1.0.0-beta.23",
+	"version": "1.0.0-beta.24",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1342,9 +1342,9 @@
 			"dev": true
 		},
 		"bluebird": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-			"integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
 			"dev": true
 		},
 		"bn.js": {
@@ -1805,9 +1805,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-					"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.0.tgz",
+					"integrity": "sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ==",
 					"dev": true
 				}
 			}
@@ -2037,9 +2037,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.136",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.136.tgz",
-			"integrity": "sha512-xHkYkbEi4kI+2w5v6yBGCQTRXL7N0PWscygTFZu/1bArnPSo2WR9xjdw4m06RR4J5PncrWJcuOVv+MAG2mK5JQ==",
+			"version": "1.3.137",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz",
+			"integrity": "sha512-kGi32g42a8vS/WnYE7ELJyejRT7hbr3UeOOu0WeuYuQ29gCpg9Lrf6RdcTQVXSt/v0bjCfnlb/EWOOsiKpTmkw==",
 			"dev": true
 		},
 		"elliptic": {
@@ -4025,9 +4025,9 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "1.1.20",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.20.tgz",
-			"integrity": "sha512-YnC3NemTLgzOkQTmR4+0yl/7pIsXZcfWXoquNp0Dql03GQ+CYURhnjUDFsSJxpX/Q9nw8lAjLFdnACQoKs6h5w==",
+			"version": "1.1.21",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.21.tgz",
+			"integrity": "sha512-TwnURTCjc8a+ElJUjmDqU6+12jhli1Q61xOQmdZ7ECZVBZuQpN/1UnembiIHDM1wCcfLvh5wrWXUF5H6ufX64Q==",
 			"dev": true,
 			"requires": {
 				"semver": "^5.3.0"
@@ -5064,9 +5064,9 @@
 			"dev": true
 		},
 		"terser": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-			"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.0.0.tgz",
+			"integrity": "sha512-dOapGTU0hETFl1tCo4t56FN+2jffoKyER9qBGoUFyZ6y7WLoKT0bF+lAYi6B6YsILcGF3q1C2FBh8QcKSCgkgA==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
@@ -5083,18 +5083,19 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.4.tgz",
-			"integrity": "sha512-64IiILNQlACWZLzFlpzNaG0bpQ4ytaB7fwOsbpsdIV70AfLUmIGGeuKL0YV2WmtcrURjE2aOvHD4/lrFV3Rg+Q==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz",
+			"integrity": "sha512-W2YWmxPjjkUcOWa4pBEv4OP4er1aeQJlSo2UhtCFQCuRXEHjOFscO8VyWHj9JLlA0RzQb8Y2/Ta78XZvT54uGg==",
 			"dev": true,
 			"requires": {
 				"cacache": "^11.3.2",
 				"find-cache-dir": "^2.0.0",
 				"is-wsl": "^1.1.0",
+				"loader-utils": "^1.2.3",
 				"schema-utils": "^1.0.0",
 				"serialize-javascript": "^1.7.0",
 				"source-map": "^0.6.1",
-				"terser": "^3.17.0",
+				"terser": "^4.0.0",
 				"webpack-sources": "^1.3.0",
 				"worker-farm": "^1.7.0"
 			},
@@ -5446,9 +5447,9 @@
 			}
 		},
 		"webpack": {
-			"version": "4.32.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.32.1.tgz",
-			"integrity": "sha512-R0S2tfWP2tZ8ZC2dwgnUVfa9LPvhGWJXjqfgIQ6jply+9ncBbt8IZ9p83uVeqsZ/s8zKA3XyepciWNHnSxxnHg==",
+			"version": "4.32.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.32.2.tgz",
+			"integrity": "sha512-F+H2Aa1TprTQrpodRAWUMJn7A8MgDx82yQiNvYMaj3d1nv3HetKU0oqEulL9huj8enirKi8KvEXQ3QtuHF89Zg==",
 			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",

--- a/packages/react-native/package-lock.json
+++ b/packages/react-native/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@walletconnect/react-native",
-	"version": "1.0.0-beta.23",
+	"version": "1.0.0-beta.24",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -924,9 +924,9 @@
 			}
 		},
 		"@types/react-native": {
-			"version": "0.57.58",
-			"resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.57.58.tgz",
-			"integrity": "sha512-SshKU18ajdpQQ5RZrHyUTI3e++pMo4fcrWnnbGFjzgp5ykYhbfUQ005Q93a/UV9ObsAmRppHVuq11d3b4tiDug==",
+			"version": "0.57.60",
+			"resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.57.60.tgz",
+			"integrity": "sha512-zObrnRsCbpM7qDm97d8+5qiSIMMYRaWgpqu6orjbjzLUAcJaKnpBMXgW6bRXWkFBjHgm3hjDAdVVGMWlrYJBdw==",
 			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
@@ -1365,9 +1365,9 @@
 			"dev": true
 		},
 		"bluebird": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-			"integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
 			"dev": true
 		},
 		"bn.js": {
@@ -1828,9 +1828,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-					"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.0.tgz",
+					"integrity": "sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ==",
 					"dev": true
 				}
 			}
@@ -2066,9 +2066,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.136",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.136.tgz",
-			"integrity": "sha512-xHkYkbEi4kI+2w5v6yBGCQTRXL7N0PWscygTFZu/1bArnPSo2WR9xjdw4m06RR4J5PncrWJcuOVv+MAG2mK5JQ==",
+			"version": "1.3.137",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz",
+			"integrity": "sha512-kGi32g42a8vS/WnYE7ELJyejRT7hbr3UeOOu0WeuYuQ29gCpg9Lrf6RdcTQVXSt/v0bjCfnlb/EWOOsiKpTmkw==",
 			"dev": true
 		},
 		"elliptic": {
@@ -4054,9 +4054,9 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "1.1.20",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.20.tgz",
-			"integrity": "sha512-YnC3NemTLgzOkQTmR4+0yl/7pIsXZcfWXoquNp0Dql03GQ+CYURhnjUDFsSJxpX/Q9nw8lAjLFdnACQoKs6h5w==",
+			"version": "1.1.21",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.21.tgz",
+			"integrity": "sha512-TwnURTCjc8a+ElJUjmDqU6+12jhli1Q61xOQmdZ7ECZVBZuQpN/1UnembiIHDM1wCcfLvh5wrWXUF5H6ufX64Q==",
 			"dev": true,
 			"requires": {
 				"semver": "^5.3.0"
@@ -5088,9 +5088,9 @@
 			"dev": true
 		},
 		"terser": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-			"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.0.0.tgz",
+			"integrity": "sha512-dOapGTU0hETFl1tCo4t56FN+2jffoKyER9qBGoUFyZ6y7WLoKT0bF+lAYi6B6YsILcGF3q1C2FBh8QcKSCgkgA==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
@@ -5107,18 +5107,19 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.4.tgz",
-			"integrity": "sha512-64IiILNQlACWZLzFlpzNaG0bpQ4ytaB7fwOsbpsdIV70AfLUmIGGeuKL0YV2WmtcrURjE2aOvHD4/lrFV3Rg+Q==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz",
+			"integrity": "sha512-W2YWmxPjjkUcOWa4pBEv4OP4er1aeQJlSo2UhtCFQCuRXEHjOFscO8VyWHj9JLlA0RzQb8Y2/Ta78XZvT54uGg==",
 			"dev": true,
 			"requires": {
 				"cacache": "^11.3.2",
 				"find-cache-dir": "^2.0.0",
 				"is-wsl": "^1.1.0",
+				"loader-utils": "^1.2.3",
 				"schema-utils": "^1.0.0",
 				"serialize-javascript": "^1.7.0",
 				"source-map": "^0.6.1",
-				"terser": "^3.17.0",
+				"terser": "^4.0.0",
 				"webpack-sources": "^1.3.0",
 				"worker-farm": "^1.7.0"
 			},
@@ -5470,9 +5471,9 @@
 			}
 		},
 		"webpack": {
-			"version": "4.32.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.32.1.tgz",
-			"integrity": "sha512-R0S2tfWP2tZ8ZC2dwgnUVfa9LPvhGWJXjqfgIQ6jply+9ncBbt8IZ9p83uVeqsZ/s8zKA3XyepciWNHnSxxnHg==",
+			"version": "4.32.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.32.2.tgz",
+			"integrity": "sha512-F+H2Aa1TprTQrpodRAWUMJn7A8MgDx82yQiNvYMaj3d1nv3HetKU0oqEulL9huj8enirKi8KvEXQ3QtuHF89Zg==",
 			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",

--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@walletconnect/utils",
-	"version": "1.0.0-beta.23",
+	"version": "1.0.0-beta.24",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -883,6 +883,86 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@ethersproject/address": {
+			"version": "5.0.0-beta.125",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.0-beta.125.tgz",
+			"integrity": "sha512-X742o0xmcpnv9X5pXKdzTmPfFdmMjQ21iu7LT3Hua2vPa/o6Ve0GQI295PhxUh/YoWdyH95FO4dK9KkAtl2r3Q==",
+			"requires": {
+				"@ethersproject/bignumber": ">5.0.0-beta.0",
+				"@ethersproject/bytes": ">5.0.0-beta.0",
+				"@ethersproject/errors": ">5.0.0-beta.0",
+				"@ethersproject/keccak256": ">5.0.0-beta.0",
+				"@ethersproject/rlp": ">5.0.0-beta.0",
+				"bn.js": "^4.4.0"
+			}
+		},
+		"@ethersproject/bignumber": {
+			"version": "5.0.0-beta.126",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.0-beta.126.tgz",
+			"integrity": "sha512-my8+9Y09R4DJblaLrOc/ssbZjT7dRkbAoJUGCmT43GB4eRB0ViSVAeI+VoCoUZYvMlteZhH943VkS2CW5WcYbA==",
+			"requires": {
+				"@ethersproject/bytes": ">5.0.0-beta.0",
+				"@ethersproject/errors": ">5.0.0-beta.0",
+				"@ethersproject/properties": ">5.0.0-beta.0",
+				"bn.js": "^4.4.0"
+			}
+		},
+		"@ethersproject/bytes": {
+			"version": "5.0.0-beta.126",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.0-beta.126.tgz",
+			"integrity": "sha512-MWBM1F2uypiDb3ROUJjBRtR0DGYvjAHqlOoaGBsTqq2DgF3swASF6Pfbqj+dS0zpY6XoO3w41e4+RCdjiAr0Jw==",
+			"requires": {
+				"@ethersproject/errors": ">5.0.0-beta.0"
+			}
+		},
+		"@ethersproject/constants": {
+			"version": "5.0.0-beta.126",
+			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.0-beta.126.tgz",
+			"integrity": "sha512-wU1KhoSxxhCESX6JRVks/NAaB/WdIeMmEKDVu4tSsTG/IBogjxQY/jmVRhqKOw7eLvqOf6eTxcQ+11w/kU6HHg==",
+			"requires": {
+				"@ethersproject/bignumber": ">5.0.0-beta.0"
+			}
+		},
+		"@ethersproject/errors": {
+			"version": "5.0.0-beta.125",
+			"resolved": "https://registry.npmjs.org/@ethersproject/errors/-/errors-5.0.0-beta.125.tgz",
+			"integrity": "sha512-cj+hfWNE/N6+kSmwxGJHtLGhvfW/jyPm0uCqzOK2jRFaUpcLoAbxiSampNOs0W1LtrdpYQ9Cel66G9W4h9a92A=="
+		},
+		"@ethersproject/keccak256": {
+			"version": "5.0.0-beta.124",
+			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.0-beta.124.tgz",
+			"integrity": "sha512-rCEsQwjr27aZAsZiBlWAbYnmctPD3JKXVUfvXV02NNtyU6Q9hycUZG2Ca0PCUHQs9vDH4U8y+0A9njMKnQop6Q==",
+			"requires": {
+				"@ethersproject/bytes": ">5.0.0-beta.0",
+				"js-sha3": "0.5.7"
+			}
+		},
+		"@ethersproject/properties": {
+			"version": "5.0.0-beta.125",
+			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.0-beta.125.tgz",
+			"integrity": "sha512-ZzM82h0KDwwb4/MMPvxH5QGYg5D1P7MdsxIieexzZHZ72JEc/N5HfxTijcEAyBB481KNz42DkiJJuhbIK56vnQ==",
+			"requires": {
+				"@ethersproject/errors": ">5.0.0-beta.0"
+			}
+		},
+		"@ethersproject/rlp": {
+			"version": "5.0.0-beta.124",
+			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.0-beta.124.tgz",
+			"integrity": "sha512-XRjIyOflY6VzSy62iBplESUWgRVJh9ImUwxILpMXLRxtTa7IGtu2Poe1L+O8LEm6gXvTOFd1uzrk/mXnkBoyHQ==",
+			"requires": {
+				"@ethersproject/bytes": ">5.0.0-beta.0"
+			}
+		},
+		"@ethersproject/strings": {
+			"version": "5.0.0-beta.125",
+			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.0-beta.125.tgz",
+			"integrity": "sha512-UQ4w+38bFAbbikk/Wtq1YayhIPGFP80ICJDxy0wtNW7U4k4rs6+tIFVOx6PnmqOJG4cDuxItlFsn4+1rIJcJ6Q==",
+			"requires": {
+				"@ethersproject/bytes": ">5.0.0-beta.0",
+				"@ethersproject/constants": ">5.0.0-beta.0",
+				"@ethersproject/errors": ">5.0.0-beta.0"
+			}
+		},
 		"@types/chai": {
 			"version": "4.1.7",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
@@ -890,9 +970,9 @@
 			"dev": true
 		},
 		"@types/lodash": {
-			"version": "4.14.130",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.130.tgz",
-			"integrity": "sha512-H++wk0tbneBsRVfLkgAAd0IIpmpVr2Bj4T0HncoOsQf3/xrJexRYQK2Tqo0Ej3pFslM8GkMgdis9bu6xIb1ycw==",
+			"version": "4.14.132",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.132.tgz",
+			"integrity": "sha512-RNUU1rrh85NgUJcjOOr96YXr+RHwInGbaQCZmlitqOaCKXffj8bh+Zxwuq5rjDy5OgzFldDVoqk4pyLEDiwxIw==",
 			"dev": true
 		},
 		"@types/lodash.isnumber": {
@@ -913,7 +993,8 @@
 		"@types/node": {
 			"version": "10.14.7",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
-			"integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A=="
+			"integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A==",
+			"dev": true
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.8.5",
@@ -1114,11 +1195,6 @@
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
 			"integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
 			"dev": true
-		},
-		"aes-js": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-			"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
 		},
 		"ajv": {
 			"version": "6.10.0",
@@ -1352,9 +1428,9 @@
 			"dev": true
 		},
 		"bluebird": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-			"integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
 			"dev": true
 		},
 		"bn.js": {
@@ -1404,7 +1480,8 @@
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+			"dev": true
 		},
 		"browser-stdout": {
 			"version": "1.3.1",
@@ -1813,9 +1890,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-					"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.0.tgz",
+					"integrity": "sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ==",
 					"dev": true
 				}
 			}
@@ -2045,20 +2122,24 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.136",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.136.tgz",
-			"integrity": "sha512-xHkYkbEi4kI+2w5v6yBGCQTRXL7N0PWscygTFZu/1bArnPSo2WR9xjdw4m06RR4J5PncrWJcuOVv+MAG2mK5JQ==",
+			"version": "1.3.137",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz",
+			"integrity": "sha512-kGi32g42a8vS/WnYE7ELJyejRT7hbr3UeOOu0WeuYuQ29gCpg9Lrf6RdcTQVXSt/v0bjCfnlb/EWOOsiKpTmkw==",
 			"dev": true
 		},
 		"elliptic": {
-			"version": "6.3.3",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
-			"integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+			"integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
 				"hash.js": "^1.0.0",
-				"inherits": "^2.0.1"
+				"hmac-drbg": "^1.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
 		"emojis-list": {
@@ -2166,23 +2247,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
-		},
-		"ethers": {
-			"version": "4.0.27",
-			"resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.27.tgz",
-			"integrity": "sha512-+DXZLP/tyFnXWxqr2fXLT67KlGUfLuvDkHSOtSC9TUVG9OIj6yrG5JPeXRMYo15xkOYwnjgdMKrXp5V94rtjJA==",
-			"requires": {
-				"@types/node": "^10.3.2",
-				"aes-js": "3.0.0",
-				"bn.js": "^4.4.0",
-				"elliptic": "6.3.3",
-				"hash.js": "1.1.3",
-				"js-sha3": "0.5.7",
-				"scrypt-js": "2.0.4",
-				"setimmediate": "1.0.4",
-				"uuid": "2.0.1",
-				"xmlhttprequest": "1.8.0"
-			}
 		},
 		"events": {
 			"version": "3.0.0",
@@ -3210,12 +3274,13 @@
 			}
 		},
 		"hash.js": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.0"
+				"minimalistic-assert": "^1.0.1"
 			}
 		},
 		"he": {
@@ -3223,6 +3288,17 @@
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
 			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
 			"dev": true
+		},
+		"hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"dev": true,
+			"requires": {
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
 		},
 		"homedir-polyfill": {
 			"version": "1.0.3",
@@ -3295,7 +3371,8 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"ini": {
 			"version": "1.3.5",
@@ -3783,7 +3860,14 @@
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+			"dev": true
+		},
+		"minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
@@ -4031,9 +4115,9 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "1.1.20",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.20.tgz",
-			"integrity": "sha512-YnC3NemTLgzOkQTmR4+0yl/7pIsXZcfWXoquNp0Dql03GQ+CYURhnjUDFsSJxpX/Q9nw8lAjLFdnACQoKs6h5w==",
+			"version": "1.1.21",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.21.tgz",
+			"integrity": "sha512-TwnURTCjc8a+ElJUjmDqU6+12jhli1Q61xOQmdZ7ECZVBZuQpN/1UnembiIHDM1wCcfLvh5wrWXUF5H6ufX64Q==",
 			"dev": true,
 			"requires": {
 				"semver": "^5.3.0"
@@ -4697,11 +4781,6 @@
 				"ajv-keywords": "^3.1.0"
 			}
 		},
-		"scrypt-js": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-			"integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
-		},
 		"semver": {
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
@@ -4744,9 +4823,10 @@
 			}
 		},
 		"setimmediate": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-			"integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true
 		},
 		"sha.js": {
 			"version": "2.4.11",
@@ -5069,9 +5149,9 @@
 			"dev": true
 		},
 		"terser": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-			"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.0.0.tgz",
+			"integrity": "sha512-dOapGTU0hETFl1tCo4t56FN+2jffoKyER9qBGoUFyZ6y7WLoKT0bF+lAYi6B6YsILcGF3q1C2FBh8QcKSCgkgA==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
@@ -5088,18 +5168,19 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.4.tgz",
-			"integrity": "sha512-64IiILNQlACWZLzFlpzNaG0bpQ4ytaB7fwOsbpsdIV70AfLUmIGGeuKL0YV2WmtcrURjE2aOvHD4/lrFV3Rg+Q==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz",
+			"integrity": "sha512-W2YWmxPjjkUcOWa4pBEv4OP4er1aeQJlSo2UhtCFQCuRXEHjOFscO8VyWHj9JLlA0RzQb8Y2/Ta78XZvT54uGg==",
 			"dev": true,
 			"requires": {
 				"cacache": "^11.3.2",
 				"find-cache-dir": "^2.0.0",
 				"is-wsl": "^1.1.0",
+				"loader-utils": "^1.2.3",
 				"schema-utils": "^1.0.0",
 				"serialize-javascript": "^1.7.0",
 				"source-map": "^0.6.1",
-				"terser": "^3.17.0",
+				"terser": "^4.0.0",
 				"webpack-sources": "^1.3.0",
 				"worker-farm": "^1.7.0"
 			},
@@ -5415,11 +5496,6 @@
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"dev": true
 		},
-		"uuid": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-			"integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-		},
 		"v8-compile-cache": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
@@ -5456,9 +5532,9 @@
 			}
 		},
 		"webpack": {
-			"version": "4.32.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.32.1.tgz",
-			"integrity": "sha512-R0S2tfWP2tZ8ZC2dwgnUVfa9LPvhGWJXjqfgIQ6jply+9ncBbt8IZ9p83uVeqsZ/s8zKA3XyepciWNHnSxxnHg==",
+			"version": "4.32.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.32.2.tgz",
+			"integrity": "sha512-F+H2Aa1TprTQrpodRAWUMJn7A8MgDx82yQiNvYMaj3d1nv3HetKU0oqEulL9huj8enirKi8KvEXQ3QtuHF89Zg==",
 			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
@@ -5606,11 +5682,6 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
-		},
-		"xmlhttprequest": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-			"integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
 		},
 		"xtend": {
 			"version": "4.0.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -55,8 +55,11 @@
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
-    "@walletconnect/types": "^1.0.0-beta.23",
-    "ethers": "^4.0.27"
+    "@ethersproject/address": "^5.0.0-beta.125",
+    "@ethersproject/bignumber": "^5.0.0-beta.126",
+    "@ethersproject/bytes": "^5.0.0-beta.126",
+    "@ethersproject/strings": "^5.0.0-beta.125",
+    "@walletconnect/types": "^1.0.0-beta.23"
   },
   "gitHead": "165f7993c2acc907c653c02847fb02721052c6e7"
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,7 @@
-import { utils } from 'ethers'
+import { BigNumber } from '@ethersproject/bignumber'
+import { isHexString,hexlify,arrayify } from '@ethersproject/bytes'
+import { getAddress } from '@ethersproject/address'
+import { toUtf8Bytes,toUtf8String } from '@ethersproject/strings'
 
 import {
   ITxData,
@@ -20,7 +23,7 @@ export function convertArrayBufferToBuffer (arrayBuffer: ArrayBuffer): Buffer {
 }
 
 export function convertArrayBufferToUtf8 (arrayBuffer: ArrayBuffer): string {
-  const utf8 = utils.toUtf8String(new Uint8Array(arrayBuffer))
+  const utf8 = toUtf8String(new Uint8Array(arrayBuffer))
   return utf8
 }
 
@@ -28,7 +31,7 @@ export function convertArrayBufferToHex (
   arrayBuffer: ArrayBuffer,
   noPrefix?: boolean
 ): string {
-  let hex = utils.hexlify(new Uint8Array(arrayBuffer))
+  let hex = hexlify(new Uint8Array(arrayBuffer))
   if (noPrefix) {
     hex = removeHexPrefix(hex)
   }
@@ -83,7 +86,7 @@ export function concatBuffers (...args: Buffer[]): Buffer {
 // -- Utf8 ------------------------------------------------- //
 
 export function convertUtf8ToArrayBuffer (utf8: string): ArrayBuffer {
-  const arrayBuffer = utils.toUtf8Bytes(utf8).buffer
+  const arrayBuffer = toUtf8Bytes(utf8).buffer
   return arrayBuffer
 }
 
@@ -99,7 +102,7 @@ export function convertUtf8ToHex (utf8: string, noPrefix?: boolean): string {
 }
 
 export function convertUtf8ToNumber (utf8: string): number {
-  const num = utils.bigNumberify(utf8).toNumber()
+  const num = BigNumber.from(utf8).toNumber()
   return num
 }
 
@@ -118,12 +121,12 @@ export function convertNumberToArrayBuffer (num: number): ArrayBuffer {
 }
 
 export function convertNumberToUtf8 (num: number): string {
-  const utf8 = utils.bigNumberify(num).toString()
+  const utf8 = BigNumber.from(num).toString()
   return utf8
 }
 
 export function convertNumberToHex (num: number, noPrefix?: boolean): string {
-  let hex = utils.bigNumberify(num).toHexString()
+  let hex = BigNumber.from(num).toHexString()
   if (noPrefix) {
     hex = removeHexPrefix(hex)
   }
@@ -140,7 +143,7 @@ export function convertHexToBuffer (hex: string): Buffer {
 
 export function convertHexToArrayBuffer (hex: string): ArrayBuffer {
   hex = addHexPrefix(hex)
-  const arrayBuffer = utils.arrayify(hex).buffer
+  const arrayBuffer = arrayify(hex).buffer
   return arrayBuffer
 }
 
@@ -151,7 +154,7 @@ export function convertHexToUtf8 (hex: string): string {
 }
 
 export function convertHexToNumber (hex: string): number {
-  const num = utils.bigNumberify(hex).toNumber()
+  const num = BigNumber.from(hex).toNumber()
   return num
 }
 
@@ -203,7 +206,7 @@ export function uuid (): string {
 }
 
 export const toChecksumAddress = (address: string) => {
-  return utils.getAddress(address)
+  return getAddress(address)
 }
 
 export const isValidAddress = (address?: string) => {
@@ -444,7 +447,7 @@ export function promisify (
 }
 
 export function parsePersonalSign (params: string[]): string[] {
-  if (!utils.isHexString(params[1])) {
+  if (!isHexString(params[1])) {
     params[1] = convertUtf8ToHex(params[1])
   }
   return params
@@ -459,7 +462,7 @@ export function parseTransactionData (
 
   function parseHexValues (value: number | string) {
     let result = value
-    if (!utils.isHexString(value)) {
+    if (!isHexString(value)) {
       if (typeof value === 'string') {
         value = convertUtf8ToNumber(value)
       }

--- a/packages/web3-provider/package-lock.json
+++ b/packages/web3-provider/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@walletconnect/web3-provider",
-	"version": "1.0.0-beta.23",
+	"version": "1.0.0-beta.24",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -2100,9 +2100,9 @@
 			}
 		},
 		"bluebird": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-			"integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
 			"dev": true
 		},
 		"bn.js": {
@@ -2602,9 +2602,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-					"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.0.tgz",
+					"integrity": "sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ=="
 				}
 			}
 		},
@@ -2914,9 +2914,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.136",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.136.tgz",
-			"integrity": "sha512-xHkYkbEi4kI+2w5v6yBGCQTRXL7N0PWscygTFZu/1bArnPSo2WR9xjdw4m06RR4J5PncrWJcuOVv+MAG2mK5JQ=="
+			"version": "1.3.137",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz",
+			"integrity": "sha512-kGi32g42a8vS/WnYE7ELJyejRT7hbr3UeOOu0WeuYuQ29gCpg9Lrf6RdcTQVXSt/v0bjCfnlb/EWOOsiKpTmkw=="
 		},
 		"elliptic": {
 			"version": "6.4.1",
@@ -5606,9 +5606,9 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "1.1.20",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.20.tgz",
-			"integrity": "sha512-YnC3NemTLgzOkQTmR4+0yl/7pIsXZcfWXoquNp0Dql03GQ+CYURhnjUDFsSJxpX/Q9nw8lAjLFdnACQoKs6h5w==",
+			"version": "1.1.21",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.21.tgz",
+			"integrity": "sha512-TwnURTCjc8a+ElJUjmDqU6+12jhli1Q61xOQmdZ7ECZVBZuQpN/1UnembiIHDM1wCcfLvh5wrWXUF5H6ufX64Q==",
 			"requires": {
 				"semver": "^5.3.0"
 			}
@@ -6849,9 +6849,9 @@
 			}
 		},
 		"terser": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-			"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.0.0.tgz",
+			"integrity": "sha512-dOapGTU0hETFl1tCo4t56FN+2jffoKyER9qBGoUFyZ6y7WLoKT0bF+lAYi6B6YsILcGF3q1C2FBh8QcKSCgkgA==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
@@ -6878,18 +6878,19 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.4.tgz",
-			"integrity": "sha512-64IiILNQlACWZLzFlpzNaG0bpQ4ytaB7fwOsbpsdIV70AfLUmIGGeuKL0YV2WmtcrURjE2aOvHD4/lrFV3Rg+Q==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz",
+			"integrity": "sha512-W2YWmxPjjkUcOWa4pBEv4OP4er1aeQJlSo2UhtCFQCuRXEHjOFscO8VyWHj9JLlA0RzQb8Y2/Ta78XZvT54uGg==",
 			"dev": true,
 			"requires": {
 				"cacache": "^11.3.2",
 				"find-cache-dir": "^2.0.0",
 				"is-wsl": "^1.1.0",
+				"loader-utils": "^1.2.3",
 				"schema-utils": "^1.0.0",
 				"serialize-javascript": "^1.7.0",
 				"source-map": "^0.6.1",
-				"terser": "^3.17.0",
+				"terser": "^4.0.0",
 				"webpack-sources": "^1.3.0",
 				"worker-farm": "^1.7.0"
 			},
@@ -7314,9 +7315,9 @@
 			}
 		},
 		"webpack": {
-			"version": "4.32.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.32.1.tgz",
-			"integrity": "sha512-R0S2tfWP2tZ8ZC2dwgnUVfa9LPvhGWJXjqfgIQ6jply+9ncBbt8IZ9p83uVeqsZ/s8zKA3XyepciWNHnSxxnHg==",
+			"version": "4.32.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.32.2.tgz",
+			"integrity": "sha512-F+H2Aa1TprTQrpodRAWUMJn7A8MgDx82yQiNvYMaj3d1nv3HetKU0oqEulL9huj8enirKi8KvEXQ3QtuHF89Zg==",
 			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",

--- a/packages/web3-subprovider/package-lock.json
+++ b/packages/web3-subprovider/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@walletconnect/web3-subprovider",
-	"version": "1.0.0-beta.23",
+	"version": "1.0.0-beta.24",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -2100,9 +2100,9 @@
 			}
 		},
 		"bluebird": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-			"integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
 			"dev": true
 		},
 		"bn.js": {
@@ -2602,9 +2602,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-					"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.0.tgz",
+					"integrity": "sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ=="
 				}
 			}
 		},
@@ -2914,9 +2914,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.136",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.136.tgz",
-			"integrity": "sha512-xHkYkbEi4kI+2w5v6yBGCQTRXL7N0PWscygTFZu/1bArnPSo2WR9xjdw4m06RR4J5PncrWJcuOVv+MAG2mK5JQ=="
+			"version": "1.3.137",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz",
+			"integrity": "sha512-kGi32g42a8vS/WnYE7ELJyejRT7hbr3UeOOu0WeuYuQ29gCpg9Lrf6RdcTQVXSt/v0bjCfnlb/EWOOsiKpTmkw=="
 		},
 		"elliptic": {
 			"version": "6.4.1",
@@ -5606,9 +5606,9 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "1.1.20",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.20.tgz",
-			"integrity": "sha512-YnC3NemTLgzOkQTmR4+0yl/7pIsXZcfWXoquNp0Dql03GQ+CYURhnjUDFsSJxpX/Q9nw8lAjLFdnACQoKs6h5w==",
+			"version": "1.1.21",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.21.tgz",
+			"integrity": "sha512-TwnURTCjc8a+ElJUjmDqU6+12jhli1Q61xOQmdZ7ECZVBZuQpN/1UnembiIHDM1wCcfLvh5wrWXUF5H6ufX64Q==",
 			"requires": {
 				"semver": "^5.3.0"
 			}
@@ -6849,9 +6849,9 @@
 			}
 		},
 		"terser": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-			"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.0.0.tgz",
+			"integrity": "sha512-dOapGTU0hETFl1tCo4t56FN+2jffoKyER9qBGoUFyZ6y7WLoKT0bF+lAYi6B6YsILcGF3q1C2FBh8QcKSCgkgA==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
@@ -6878,18 +6878,19 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.4.tgz",
-			"integrity": "sha512-64IiILNQlACWZLzFlpzNaG0bpQ4ytaB7fwOsbpsdIV70AfLUmIGGeuKL0YV2WmtcrURjE2aOvHD4/lrFV3Rg+Q==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz",
+			"integrity": "sha512-W2YWmxPjjkUcOWa4pBEv4OP4er1aeQJlSo2UhtCFQCuRXEHjOFscO8VyWHj9JLlA0RzQb8Y2/Ta78XZvT54uGg==",
 			"dev": true,
 			"requires": {
 				"cacache": "^11.3.2",
 				"find-cache-dir": "^2.0.0",
 				"is-wsl": "^1.1.0",
+				"loader-utils": "^1.2.3",
 				"schema-utils": "^1.0.0",
 				"serialize-javascript": "^1.7.0",
 				"source-map": "^0.6.1",
-				"terser": "^3.17.0",
+				"terser": "^4.0.0",
 				"webpack-sources": "^1.3.0",
 				"worker-farm": "^1.7.0"
 			},
@@ -7314,9 +7315,9 @@
 			}
 		},
 		"webpack": {
-			"version": "4.32.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.32.1.tgz",
-			"integrity": "sha512-R0S2tfWP2tZ8ZC2dwgnUVfa9LPvhGWJXjqfgIQ6jply+9ncBbt8IZ9p83uVeqsZ/s8zKA3XyepciWNHnSxxnHg==",
+			"version": "4.32.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.32.2.tgz",
+			"integrity": "sha512-F+H2Aa1TprTQrpodRAWUMJn7A8MgDx82yQiNvYMaj3d1nv3HetKU0oqEulL9huj8enirKi8KvEXQ3QtuHF89Zg==",
 			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",


### PR DESCRIPTION
Introduce ethers v5 which is based on lerna. This enables us to pick only what we need.

```Hash: 5309e201454a21775d44
Version: webpack 4.32.1
Time: 12847ms
Built at: 05/24/2019 9:35:44 AM
         Asset      Size  Chunks             Chunk Names
    index.d.ts  2.89 KiB          [emitted]  
index.d.ts.map  2.38 KiB          [emitted]  
      index.js   112 KiB       0  [emitted]  index
  index.js.map   424 KiB       0  [emitted]  index
Entrypoint index = index.js index.js.map
 [2] (webpack)/buildin/global.js 472 bytes {0} [built]
 [7] ./src/index.ts 15.5 KiB {0} [built]
[13] (webpack)/buildin/module.js 497 bytes {0} [built]
[14] buffer (ignored) 15 bytes {0} [optional] [built]
```