### PR TITLE
Adding value to Tx fields.

### DIFF
--- a/example/public/script.js
+++ b/example/public/script.js
@@ -136,6 +136,7 @@ function sendTestTransaction() {
   const tx = {
     from: walletConnector.accounts[0],
     to: walletConnector.accounts[0],
+    value: 0,
     data: '0x' // Required
   }
 


### PR DESCRIPTION
Minor fix for this error:
```
Error: Invalid request: {"id":1560861720953273,"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"from":"0xc44F60A7b9aECFC8f2Ed6dCf097b107AA11EC948","to":"0xc44F60A7b9aECFC8f2Ed6dCf097b107AA11EC948","data":"0x"}]} (value key missing)
```

Btw, in order to run the example, I had to install the both packages with:
```
$ cd packages/browser
$ yarn install
$ yarn build
```
and
```
$ cd packages/qrcode-modal
$ yarn install
$ yarn build
```

Note: Maybe I've missed something in README.