### PR TITLE
add EIP-1193 'close' event

### DIFF
--- a/packages/web3-provider/src/index.js
+++ b/packages/web3-provider/src/index.js
@@ -209,6 +209,7 @@ class WalletConnectProvider extends ProviderEngine {
     const wc = await this.getWalletConnector()
     await wc.killSession()
     await this.stop()
+    this.emit('close', 1000, 'Connection closed')
   }
 
   async handleRequest (payload) {


### PR DESCRIPTION
Emits a 'close' event from the web3-provider per EIP-1193 when a connection is closed.