### PR TITLE
add optional 'pollingInterval' parameter

### DIFF
--- a/packages/web3-provider/src/index.js
+++ b/packages/web3-provider/src/index.js
@@ -12,7 +12,7 @@ import HTTPConnection from './http'
 
 class WalletConnectProvider extends ProviderEngine {
   constructor (opts) {
-    super()
+    super({ pollingInterval: opts.pollingInterval || 4000 })
 
     this.bridge = opts.bridge || 'https://bridge.walletconnect.org'
 


### PR DESCRIPTION
Adds the ability to pass an optional `pollingInterval` parameter to web3-provider, which passes it directly on to web3-provider-engine.