### PR TITLE
Increase default z-index to fix overlapping

### DIFF
--- a/packages/qrcode-modal/src/style.ts
+++ b/packages/qrcode-modal/src/style.ts
@@ -29,7 +29,7 @@ export default {
         position:relative;
         top:50%;
         display:inline-block;
-        z-index:101;
+        z-index: 2147483000;
         background:#fff;
         transform:translateY(-50%);
         margin:0 auto;
@@ -89,7 +89,7 @@ export default {
       top: 0;
       width:100%;
       height:100%;
-      z-index:100;
+      z-index: 2147482999;
       background-color:rgba(0,0,0,0.5);
       text-align:center;
     `,


### PR DESCRIPTION
A lot of websites might have a header that is a higher `z-index` than 100, in the case of making sure that something is higher than the rest of the content.

It makes sense to have the z-index for the modal as high as possible.

The value its set to is the same value as Intercom uses to make sure the Intercom messenger is always on top.