### PR TITLE
Fix wrong initial state of Web3Provider

### DIFF
--- a/packages/web3-provider/src/index.js
+++ b/packages/web3-provider/src/index.js
@@ -33,6 +33,7 @@ class WalletConnectProvider extends ProviderEngine {
 
     this.wc = new WalletConnect({ bridge: this.bridge })
     this.isConnecting = false
+    this.connected = false
     this.isWalletConnect = true
     this.connectCallbacks = []
     this.accounts = []
@@ -307,6 +308,7 @@ class WalletConnectProvider extends ProviderEngine {
                 WalletConnectQRCodeModal.close()
               }
               this.isConnecting = false
+              this.connected = true
 
               if (payload) {
                 // Handle session update
@@ -324,7 +326,10 @@ class WalletConnectProvider extends ProviderEngine {
             reject(error)
           })
       } else {
-        this.updateState(wc.session)
+        if (!this.connected) {
+          this.connected = true
+          this.updateState(wc.session)
+        }
         resolve(wc)
       }
     })

--- a/packages/web3-provider/src/index.js
+++ b/packages/web3-provider/src/index.js
@@ -324,6 +324,7 @@ class WalletConnectProvider extends ProviderEngine {
             reject(error)
           })
       } else {
+        this.updateState(wc.session)
         resolve(wc)
       }
     })

--- a/packages/web3-provider/src/index.js
+++ b/packages/web3-provider/src/index.js
@@ -300,12 +300,12 @@ class WalletConnectProvider extends ProviderEngine {
               })
             }
             wc.on('connect', (error, payload) => {
+              if (this.qrcode) {
+                WalletConnectQRCodeModal.close()
+              }
               if (error) {
                 this.isConnecting = false
                 return reject(error)
-              }
-              if (this.qrcode) {
-                WalletConnectQRCodeModal.close()
               }
               this.isConnecting = false
               this.connected = true

--- a/packages/web3-provider/src/index.js
+++ b/packages/web3-provider/src/index.js
@@ -298,7 +298,11 @@ class WalletConnectProvider extends ProviderEngine {
                 reject(new Error('User closed WalletConnect modal'))
               })
             }
-            wc.on('connect', payload => {
+            wc.on('connect', (error, payload) => {
+              if (error) {
+                this.isConnecting = false
+                return reject(error)
+              }
               if (this.qrcode) {
                 WalletConnectQRCodeModal.close()
               }


### PR DESCRIPTION
When `web3-provider` is instantiated it assumes `chainId` to be either `1` (default) of whatever is provided as constructor parameter.
After WalletConnect is connected on the wallet side, `web3-provider` should sync its state to account and chain id of the wallet. But the [callback for wc.on('connect'](https://github.com/WalletConnect/walletconnect-monorepo/blob/master/packages/web3-provider/src/index.js#L301) currently has wrong signature, so the state is never updated.

Also if WalletConnector is already connected (`wc.connected === true`, which can be problematic in its own way #193), state is likewise not updated.

State is synced only on `session_update` event if that happens later.

As a result if we connect to, for example, a Rinkeby wallet, `web3-provider` still has `chainId = 1` and HttpConnection (`this.http`) makes requests to `mainnet.infura.io`

This PR solves that by correcting `wc.on'connected` callback and updating state with `wc.session` on initial `getWalletConnector` call.