### PR TITLE
Don't use getter for accessing walletconnector in close() method to prevent race condition inside getter when session is already killed

### DIFF
--- a/packages/web3-provider/src/index.js
+++ b/packages/web3-provider/src/index.js
@@ -207,6 +207,10 @@ class WalletConnectProvider extends ProviderEngine {
   }
 
   async close () {
+    // Not using .getWalletConnector() there because if session is already
+    // killed (wc.connected is false), it would try to initialize a new session in the getter
+    // with an invalid wc.uri
+
     const wc = this.wc
     await wc.killSession()
     await this.stop()

--- a/packages/web3-provider/src/index.js
+++ b/packages/web3-provider/src/index.js
@@ -207,7 +207,7 @@ class WalletConnectProvider extends ProviderEngine {
   }
 
   async close () {
-    const wc = await this.getWalletConnector()
+    const wc = this.wc
     await wc.killSession()
     await this.stop()
     this.emit('close', 1000, 'Connection closed')

--- a/packages/web3-provider/src/index.js
+++ b/packages/web3-provider/src/index.js
@@ -207,7 +207,7 @@ class WalletConnectProvider extends ProviderEngine {
   }
 
   async close () {
-    const wc = this.getWalletConnector({ disableSessionCreation: true })
+    const wc = await this.getWalletConnector({ disableSessionCreation: true })
     await wc.killSession()
     await this.stop()
     this.emit('close', 1000, 'Connection closed')


### PR DESCRIPTION
**The bug:**
If you use walletconnect to connect your wallet and then close session from the mobile wallet while currently being inside the dapp, it will show you an invalid QRCode modal.

**Steps to reproduce**:
1. Connect with walletconnect on https://web3connect.com/
2. Close session in the mobile wallet
3. QRCode modal will open, scanning it would do nothing

**The reason for this bug**
When user disconnects the session, `_handleDisconnectSession` method is called inside `@walletconnect/core` and sets property `connected` on walletConnector to `false`. Then whatever uses the core (let's say `web3connect`), receives the disconnect event and wants to perform a cleanup and close walletconnect connection (not actually sure whether this is the best way to handle this, but this is how it's done in the web3connect example app: https://github.com/web3connect/web3connect/blob/master/example/src/App.tsx#L346). It calls `.close()` and close tries to get the walletconnector via `getWalletConnector`, inside this method it checks if `wc.connected` is true and if not, it tries to initialize a new session and shows QRCode modal.

**Background info**
I also thought about handling it inside `subscribeWalletConnector`: https://github.com/WalletConnect/walletconnect-monorepo/blob/0f756f1a2c2a71bdd7681b61bc363a27f48dc26d/packages/web3-provider/src/index.js#L341 but this fix seemed easier and also possibility of the lib trying to start a new session inside `.close` method felt wrong. If I am missing something, please let me know
