### PR TITLE
BUG: Can't read property "disableSessionCreation" of undefined

### DIFF
--- a/packages/web3-provider/src/index.js
+++ b/packages/web3-provider/src/index.js
@@ -283,7 +283,9 @@ class WalletConnectProvider extends ProviderEngine {
 
   // disableSessionCreation - if true, getWalletConnector won't try to create a new session
   // in case the connector is disconnected
-  getWalletConnector ({ disableSessionCreation = false }) {
+  getWalletConnector (opts = {}) {
+    const { disableSessionCreation = false } = opts
+
     return new Promise((resolve, reject) => {
       const wc = this.wc
 


### PR DESCRIPTION
I accidentally broke walletconnect web3-provider with this PR by not checking if options object is defined: https://github.com/WalletConnect/walletconnect-monorepo/pull/208

This PR fixes that
<img width="505" alt="Screenshot 2019-12-19 at 11 51 00" src="https://user-images.githubusercontent.com/16622558/71155191-ad679500-2256-11ea-8d30-23a114d58ccd.png">

