### PR TITLE
Fix signing methods name

### DIFF
--- a/packages/helpers/utils/src/index.ts
+++ b/packages/helpers/utils/src/index.ts
@@ -652,8 +652,8 @@ export const signingMethods = [
   "eth_signTransaction",
   "eth_sign",
   "eth_signTypedData",
-  "eth_signTypedData_v1",
   "eth_signTypedData_v3",
+  "eth_signTypedData_v4",
   "personal_sign",
 ];
 


### PR DESCRIPTION
AFAIK v1 doesn't exist and v4 is the latest implementation