### PR TITLE
Fix event listener in web3-provider

### DIFF
--- a/packages/providers/web3-provider/src/index.ts
+++ b/packages/providers/web3-provider/src/index.ts
@@ -330,7 +330,7 @@ class WalletConnectProvider extends ProviderEngine {
 
   async subscribeWalletConnector() {
     const wc = await this.getWalletConnector();
-    wc.on("disconnetect", error => {
+    wc.on("disconnect", error => {
       if (error) {
         this.emit("error", error);
         return;


### PR DESCRIPTION
There is a typo in event name. 
As a result provider never disconnects fully.

Also currently it calls `this.stop` on `L388`, which results in `'stop'` event from `web3-provider-engine`. But` 'close'` event is never emitted. Shouldn't it call `this.close()` instead of `this.stop()` or at least emit `'close'`?