### PR TITLE
Fix read requests never resolving

### DIFF
--- a/packages/providers/web3-provider/src/index.ts
+++ b/packages/providers/web3-provider/src/index.ts
@@ -283,14 +283,7 @@ class WalletConnectProvider extends ProviderEngine {
       this.emit("error", error);
       throw error;
     }
-    this.http.send(payload);
-    return new Promise(resolve => {
-      this.on("payload", (response: IJsonRpcResponseSuccess) => {
-        if (response.id === payload.id) {
-          resolve(response);
-        }
-      });
-    });
+    return this.http.send(payload);
   }
 
   // disableSessionCreation - if true, getWalletConnector won't try to create a new session

--- a/packages/providers/web3-provider/src/index.ts
+++ b/packages/providers/web3-provider/src/index.ts
@@ -283,7 +283,7 @@ class WalletConnectProvider extends ProviderEngine {
       this.emit("error", error);
       throw error;
     }
-    return this.http.send(payload);
+    return this.http.send(payload) as Promise<IJsonRpcResponseSuccess>;
   }
 
   // disableSessionCreation - if true, getWalletConnector won't try to create a new session


### PR DESCRIPTION
`HttpConnection` never emits events, so [event listeners](https://github.com/WalletConnect/walletconnect-monorepo/blob/next/packages/providers/web3-provider/src/index.ts#L409L410) never fire and promises from`handleReadRequests` never resolve.

Maybe also remove  [event listeners](https://github.com/WalletConnect/walletconnect-monorepo/blob/next/packages/providers/web3-provider/src/index.ts#L409L410) if you see fit

Btw, `return this.http.send(payload);` was there previously and was removed at some point between `beta.47 -- beta.61`