### PR TITLE
Allow provider.request to handle write requests

### DIFF
--- a/packages/providers/web3-provider/src/index.ts
+++ b/packages/providers/web3-provider/src/index.ts
@@ -253,6 +253,7 @@ class WalletConnectProvider extends ProviderEngine {
         case "personal_sign":
         case "personal_sendTransaction":
           response = await this.handleWriteRequests(payload);
+          break;
         default:
           response = await this.handleOtherRequests(payload);
       }

--- a/packages/providers/web3-provider/src/index.ts
+++ b/packages/providers/web3-provider/src/index.ts
@@ -247,6 +247,12 @@ class WalletConnectProvider extends ProviderEngine {
           this.sendAsync(payload, (_: any) => _);
           result = true;
           break;
+        case "eth_sendRawTransaction":
+        case "eth_sendTransaction":
+        case "eth_sign":
+        case "personal_sign":
+        case "personal_sendTransaction":
+          response = await this.handleWriteRequests(payload);
         default:
           response = await this.handleOtherRequests(payload);
       }
@@ -290,6 +296,20 @@ class WalletConnectProvider extends ProviderEngine {
           resolve(response);
         }
       });
+    });
+  }
+  
+  async handleWriteRequests(payload: any): Promise<IJsonRpcResponseSuccess> {
+    return new Promise(resolve => {
+      this.sendAsync(payload,
+          (error: any, response: any) => {
+            if (error) {
+              reject(error);
+            } else {
+              resolve(response);
+            }
+          },
+        );
     });
   }
 


### PR DESCRIPTION
Currently in web3-provider `provider.request` doesn't handle write requests (`eth_sendTransaction` etc.)
Even `provider.send` handles write requests only when given a callback as the second argument, otherwise requests are passed to `handleOtherRequests -> handleReadRequests`

I propose adding a `handleWriteRequests`method for some request.methods.

I'm not sure if `personal_*` request.methods should be handled like write requests (with `this.sendAsync`) or are they supposed to go through [wc.sendCustomRequest](https://github.com/WalletConnect/walletconnect-monorepo/blob/6688db304b/packages/providers/web3-provider/src/index.ts#L276)?

Also maybe more methods should be added, like `eth_signTypedData`?