### PR TITLE
Fix add id and jsonrpc fields to EIP-1193 request payloads

### DIFF
--- a/packages/providers/web3-provider/src/index.ts
+++ b/packages/providers/web3-provider/src/index.ts
@@ -169,7 +169,11 @@ class WalletConnectProvider extends ProviderEngine {
   }
 
   async request(payload: any): Promise<any> {
-    return this.send(payload);
+    return this.send({
+      id: 42,
+      jsonrpc: "2.0",
+      ...payload,
+    });
   }
 
   async send(payload: any, callback?: any): Promise<any> {


### PR DESCRIPTION
This fixes the issue of EIP-1193 requests being invalid due to missing required fields.