### PR TITLE
add i18n

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4274,12 +4274,12 @@
       }
     },
     "browserslist": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.1.tgz",
-      "integrity": "sha512-WMjXwFtPskSW1pQUDJRxvRKRkeCr7usN0O/Za76N+F4oadaTdQHotSGcX9jT/Hs7mSKPkyMFNvqawB/1HzYDKQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.2.tgz",
+      "integrity": "sha512-MfZaeYqR8StRZdstAK9hCKDd2StvePCYp5rHzQCPicUjfFliDgmuaBNPHYUTpAywBN8+Wc/d7NYVFkO0aqaBUw==",
       "requires": {
         "caniuse-lite": "^1.0.30001088",
-        "electron-to-chromium": "^1.3.481",
+        "electron-to-chromium": "^1.3.483",
         "escalade": "^3.0.1",
         "node-releases": "^1.1.58"
       }
@@ -14057,9 +14057,9 @@
       "integrity": "sha512-WKrRpCSwL2t3tpOOGhf2WfTpcmbpxaWtDbdJdKdjd0aEiTkvOmS4NBkG6kzlaAHI9AkQ3iVqbFWM3Ei7mZ4o1Q=="
     },
     "prebuild-install": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.4.tgz",
-      "integrity": "sha512-AkKN+pf4fSEihjapLEEj8n85YIw/tN6BQqkhzbDc0RvEZGdkpJBGMUYx66AAMcPG2KzmPQS7Cm16an4HVBRRMA==",
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.5.tgz",
+      "integrity": "sha512-YmMO7dph9CYKi5IR/BzjOJlRzpxGGVo1EsLSUZ0mt/Mq0HWZIHOKHHcHdT69yG54C9m6i45GpItwRHpk0Py7Uw==",
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",

--- a/packages/helpers/qrcode-modal/src/browser/assets/style.css
+++ b/packages/helpers/qrcode-modal/src/browser/assets/style.css
@@ -278,7 +278,7 @@
   font-size: 20px;
   font-weight: 700;
   margin: 0;
-  padding: 0 42px 3px 0;
+  padding-bottom: 3px;
 }
 
 .walletconnect-modal__base__row__right {
@@ -316,6 +316,11 @@
 .walletconnect-modal__footer a {
   color: #898d97;
   font-size: 15px;
+}
+
+.walletconnect-connect__buttons__wrapper {
+  max-height: 44vh;
+  overflow: scroll;
 }
 
 .walletconnect-connect__buttons__wrapper__android {

--- a/packages/helpers/qrcode-modal/src/browser/assets/style.ts
+++ b/packages/helpers/qrcode-modal/src/browser/assets/style.ts
@@ -278,7 +278,7 @@ export const WALLETCONNECT_STYLE_SHEET = `:root {
   font-size: 20px;
   font-weight: 700;
   margin: 0;
-  padding: 0 42px 3px 0;
+  padding-bottom: 3px;
 }
 
 .walletconnect-modal__base__row__right {
@@ -316,6 +316,11 @@ export const WALLETCONNECT_STYLE_SHEET = `:root {
 .walletconnect-modal__footer a {
   color: #898d97;
   font-size: 15px;
+}
+
+.walletconnect-connect__buttons__wrapper {
+  max-height: 44vh;
+  overflow: scroll;
 }
 
 .walletconnect-connect__buttons__wrapper__android {

--- a/packages/helpers/qrcode-modal/src/browser/components/DeepLinkDisplay.tsx
+++ b/packages/helpers/qrcode-modal/src/browser/components/DeepLinkDisplay.tsx
@@ -33,6 +33,7 @@ interface IDeeplinkInfo {
   href: string;
 }
 interface DeepLinkDisplayProps {
+  text: { [key: string]: string };
   uri: string;
 }
 
@@ -41,7 +42,7 @@ function DeepLinkDisplay(props: DeepLinkDisplayProps) {
   return (
     <div>
       <p id={WALLETCONNECT_CTA_TEXT_ID} className="walletconnect-qrcode__text">
-        {ios ? "Choose your preferred wallet" : "Connect to Mobile Wallet"}
+        {ios ? props.text.choose_preferred_wallet : props.text.connect_mobile_wallet}
       </p>
       <div className={`walletconnect-connect__buttons__wrapper${!ios && "__android"}`}>
         {ios ? (
@@ -66,7 +67,7 @@ function DeepLinkDisplay(props: DeepLinkDisplayProps) {
           })
         ) : (
           <ConnectButton
-            name={"Connect"}
+            name={props.text.connect}
             color={DEFAULT_BUTTON_COLOR}
             href={props.uri}
             onClick={React.useCallback(() => {

--- a/packages/helpers/qrcode-modal/src/browser/components/DeepLinkDisplay.tsx
+++ b/packages/helpers/qrcode-modal/src/browser/components/DeepLinkDisplay.tsx
@@ -44,7 +44,7 @@ function DeepLinkDisplay(props: DeepLinkDisplayProps) {
       <p id={WALLETCONNECT_CTA_TEXT_ID} className="walletconnect-qrcode__text">
         {ios ? props.text.choose_preferred_wallet : props.text.connect_mobile_wallet}
       </p>
-      <div className={`walletconnect-connect__buttons__wrapper${!ios && "__android"}`}>
+      <div className={`walletconnect-connect__buttons__wrapper${!ios ? "__android" : ""}`}>
         {ios ? (
           MobileRegistry.map((entry: IMobileRegistryEntry) => {
             const { color, name, logo } = entry;

--- a/packages/helpers/qrcode-modal/src/browser/components/Modal.tsx
+++ b/packages/helpers/qrcode-modal/src/browser/components/Modal.tsx
@@ -17,6 +17,8 @@ interface ModalProps {
 }
 
 function Modal(props: ModalProps) {
+  const { text, uri } = props;
+  const displayProps = { text, uri };
   const mobile = isMobile();
   const [displayQRCode, setDisplayQRCode] = React.useState(!mobile);
   return (
@@ -34,9 +36,9 @@ function Modal(props: ModalProps) {
         </div>
         <div>
           {displayQRCode ? (
-            <QRCodeDisplay text={props.text} uri={props.uri} />
+            <QRCodeDisplay {...displayProps} />
           ) : (
-            <DeepLinkDisplay text={props.text} uri={props.uri} />
+            <DeepLinkDisplay {...displayProps} />
           )}
         </div>
         {mobile && (

--- a/packages/helpers/qrcode-modal/src/browser/components/Modal.tsx
+++ b/packages/helpers/qrcode-modal/src/browser/components/Modal.tsx
@@ -11,6 +11,7 @@ import { WALLETCONNECT_MODAL_ID, WALLETCONNECT_CLOSE_BUTTON_ID } from "../consta
 import { WALLETCONNECT_LOGO_SVG_URL } from "../assets/logo";
 
 interface ModalProps {
+  text: { [key: string]: string };
   uri: string;
   onClose: any;
 }
@@ -23,7 +24,7 @@ function Modal(props: ModalProps) {
       <div className="walletconnect-modal__base">
         <div className="walletconnect-modal__header">
           <img src={WALLETCONNECT_LOGO_SVG_URL} className="walletconnect-modal__headerLogo" />
-          <p>WalletConnect</p>
+          <p>{"WalletConnect"}</p>
           <div className="walletconnect-modal__close__wrapper" onClick={props.onClose}>
             <div id={WALLETCONNECT_CLOSE_BUTTON_ID} className="walletconnect-modal__close__icon">
               <div className="walletconnect-modal__close__line1"></div>
@@ -32,12 +33,16 @@ function Modal(props: ModalProps) {
           </div>
         </div>
         <div>
-          {displayQRCode ? <QRCodeDisplay uri={props.uri} /> : <DeepLinkDisplay uri={props.uri} />}
+          {displayQRCode ? (
+            <QRCodeDisplay text={props.text} uri={props.uri} />
+          ) : (
+            <DeepLinkDisplay text={props.text} uri={props.uri} />
+          )}
         </div>
         {mobile && (
           <div className="walletconnect-modal__footer">
             <a onClick={() => setDisplayQRCode(!displayQRCode)}>
-              {displayQRCode ? "Return to mobile wallet options" : "View QR code instead"}
+              {displayQRCode ? props.text.return_to_mobile_options : props.text.view_qrcode_option}
             </a>
           </div>
         )}

--- a/packages/helpers/qrcode-modal/src/browser/components/QRCodeDisplay.tsx
+++ b/packages/helpers/qrcode-modal/src/browser/components/QRCodeDisplay.tsx
@@ -13,6 +13,7 @@ async function formatQRCodeImage(data: string) {
 }
 
 interface QRCodeDisplayProps {
+  text: { [key: string]: string };
   uri: string;
 }
 
@@ -26,7 +27,7 @@ function QRCodeDisplay(props: QRCodeDisplayProps) {
   return (
     <div>
       <p id={WALLETCONNECT_CTA_TEXT_ID} className="walletconnect-qrcode__text">
-        {"Scan QR code with a WalletConnect-compatible wallet"}
+        {props.text.scan_qrcode_with_wallet}
       </p>
       <div dangerouslySetInnerHTML={{ __html: svg }}></div>
     </div>

--- a/packages/helpers/qrcode-modal/src/browser/index.tsx
+++ b/packages/helpers/qrcode-modal/src/browser/index.tsx
@@ -2,11 +2,12 @@
 import * as React from "react";
 // @ts-ignore
 import * as ReactDOM from "react-dom";
-import { getDocument } from "@walletconnect/utils";
+import { getDocument, getNavigator } from "@walletconnect/utils";
 
 import { WALLETCONNECT_STYLE_SHEET } from "./assets/style";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import Modal from "./components/Modal";
+import Languages from "./languages";
 import {
   ANIMATION_DURATION,
   WALLETCONNECT_WRAPPER_ID,
@@ -57,11 +58,15 @@ function getWrappedCallback(cb: any): any {
   };
 }
 
+function getText() {
+  const lang = getNavigator().language.split("-")[0] || "en";
+  return Languages[lang] || Languages["en"];
+}
+
 export function open(uri: string, cb: any) {
   injectStyleSheet();
   const wrapper = renderWrapper();
-  const onClose = getWrappedCallback(cb);
-  ReactDOM.render(<Modal uri={uri} onClose={onClose} />, wrapper);
+  ReactDOM.render(<Modal text={getText()} uri={uri} onClose={getWrappedCallback(cb)} />, wrapper);
 }
 
 export function close() {

--- a/packages/helpers/qrcode-modal/src/browser/languages/de.ts
+++ b/packages/helpers/qrcode-modal/src/browser/languages/de.ts
@@ -1,8 +1,8 @@
 export default {
-  choose_preferred_wallet: "Wähle bevorzugten Wallet",
+  choose_preferred_wallet: "Wähle bevorzugte Wallet",
   connect_mobile_wallet: "Verbinde mit Mobile Wallet",
-  scan_qrcode_with_wallet: "Scanne den QR Code mit einem WalletConnect-kompatiblen Wallet",
-  return_to_mobile_options: "Zurück zur Mobile Wallet Option",
-  view_qrcode_option: "Zeige QR code",
+  scan_qrcode_with_wallet: "Scanne den QR-code mit einer WalletConnect kompatiblen Wallet",
+  return_to_mobile_options: "Zurück zur Wallet-Anbieter Übersicht",
+  view_qrcode_option: "QR-code Anzeigen",
   connect: "Verbinden",
 };

--- a/packages/helpers/qrcode-modal/src/browser/languages/de.ts
+++ b/packages/helpers/qrcode-modal/src/browser/languages/de.ts
@@ -1,0 +1,8 @@
+export default {
+  choose_preferred_wallet: "Wähle bevorzugten Wallet",
+  connect_mobile_wallet: "Verbinde mit Mobile Wallet",
+  scan_qrcode_with_wallet: "Scanne den QR Code mit einem WalletConnect-kompatiblen Wallet",
+  return_to_mobile_options: "Zurück zur Mobile Wallet Option",
+  view_qrcode_option: "Zeige QR code",
+  connect: "Verbinden",
+};

--- a/packages/helpers/qrcode-modal/src/browser/languages/en.ts
+++ b/packages/helpers/qrcode-modal/src/browser/languages/en.ts
@@ -1,0 +1,8 @@
+export default {
+  choose_preferred_wallet: "Choose your preferred wallet",
+  connect_mobile_wallet: "Connect to Mobile Wallet",
+  scan_qrcode_with_wallet: "Scan QR code with a WalletConnect-compatible wallet",
+  return_to_mobile_options: "Return to mobile wallet options",
+  view_qrcode_option: "View QR code instead",
+  connect: "Connect",
+};

--- a/packages/helpers/qrcode-modal/src/browser/languages/en.ts
+++ b/packages/helpers/qrcode-modal/src/browser/languages/en.ts
@@ -3,6 +3,6 @@ export default {
   connect_mobile_wallet: "Connect to Mobile Wallet",
   scan_qrcode_with_wallet: "Scan QR code with a WalletConnect-compatible wallet",
   return_to_mobile_options: "Return to mobile wallet options",
-  view_qrcode_option: "View QR code instead",
+  view_qrcode_option: "View QR code",
   connect: "Connect",
 };

--- a/packages/helpers/qrcode-modal/src/browser/languages/es.ts
+++ b/packages/helpers/qrcode-modal/src/browser/languages/es.ts
@@ -1,8 +1,8 @@
 export default {
-  choose_preferred_wallet: "Elige tu cartera preferida",
-  connect_mobile_wallet: "Conectar a cartera móvil",
-  scan_qrcode_with_wallet: "Escanee el código QR con una cartera compatible con WalletConnect",
-  return_to_mobile_options: "Regresar a las opciones de cartera móvil",
+  choose_preferred_wallet: "Elige tu billetra preferida",
+  connect_mobile_wallet: "Conectar a billetra móvil",
+  scan_qrcode_with_wallet: "Escanea el código QR con una billetra compatible con WalletConnect",
+  return_to_mobile_options: "Regresar a las opciones de billetra móvil",
   view_qrcode_option: "Ver código QR en vez",
   connect: "Conectar",
 };

--- a/packages/helpers/qrcode-modal/src/browser/languages/es.ts
+++ b/packages/helpers/qrcode-modal/src/browser/languages/es.ts
@@ -1,0 +1,8 @@
+export default {
+  choose_preferred_wallet: "Elige tu cartera preferida",
+  connect_mobile_wallet: "Conectar a cartera móvil",
+  scan_qrcode_with_wallet: "Escanee el código QR con una cartera compatible con WalletConnect",
+  return_to_mobile_options: "Regresar a las opciones de cartera móvil",
+  view_qrcode_option: "Ver código QR en vez",
+  connect: "Conectar",
+};

--- a/packages/helpers/qrcode-modal/src/browser/languages/es.ts
+++ b/packages/helpers/qrcode-modal/src/browser/languages/es.ts
@@ -1,8 +1,8 @@
 export default {
-  choose_preferred_wallet: "Elige tu billetra preferida",
-  connect_mobile_wallet: "Conectar a billetra móvil",
-  scan_qrcode_with_wallet: "Escanea el código QR con una billetra compatible con WalletConnect",
-  return_to_mobile_options: "Regresar a las opciones de billetra móvil",
-  view_qrcode_option: "Ver código QR en vez",
+  choose_preferred_wallet: "Elige tu billetera preferida",
+  connect_mobile_wallet: "Conectar a billetera móvil",
+  scan_qrcode_with_wallet: "Escanea el código QR con una billetera compatible con WalletConnect",
+  return_to_mobile_options: "Regresar a las opciones de billetera móvil",
+  view_qrcode_option: "Ver código QR",
   connect: "Conectar",
 };

--- a/packages/helpers/qrcode-modal/src/browser/languages/fr.ts
+++ b/packages/helpers/qrcode-modal/src/browser/languages/fr.ts
@@ -1,0 +1,8 @@
+export default {
+  choose_preferred_wallet: "Choisissez votre portefeuille préféré",
+  connect_mobile_wallet: "Se connecter au portefeuille mobile",
+  scan_qrcode_with_wallet: "Scannez le QR code avec un portefeuille compatible WalletConnect",
+  return_to_mobile_options: "Retour aux options du portefeuille mobile",
+  view_qrcode_option: "Voir le QR code",
+  connect: "Se connecter",
+};

--- a/packages/helpers/qrcode-modal/src/browser/languages/index.ts
+++ b/packages/helpers/qrcode-modal/src/browser/languages/index.ts
@@ -1,4 +1,9 @@
+import de from "./de";
 import en from "./en";
 import es from "./es";
+import fr from "./fr";
+import ko from "./ko";
+import pt from "./pt";
+import zh from "./zh";
 
-export default { en, es };
+export default { de, en, es, fr, ko, pt, zh };

--- a/packages/helpers/qrcode-modal/src/browser/languages/index.ts
+++ b/packages/helpers/qrcode-modal/src/browser/languages/index.ts
@@ -1,0 +1,4 @@
+import en from "./en";
+import es from "./es";
+
+export default { en, es };

--- a/packages/helpers/qrcode-modal/src/browser/languages/ko.ts
+++ b/packages/helpers/qrcode-modal/src/browser/languages/ko.ts
@@ -1,0 +1,8 @@
+export default {
+  choose_preferred_wallet: "원하는 지갑을 선택하세요",
+  connect_mobile_wallet: "모바일 지갑과 연결",
+  scan_qrcode_with_wallet: "WalletConnect 지원 지갑에서 QR코드를 스캔하세요",
+  return_to_mobile_options: "모바일 지갑 옵션으로 돌아가기",
+  view_qrcode_option: "QR 코드 보기",
+  connect: "연결",
+};

--- a/packages/helpers/qrcode-modal/src/browser/languages/pt.ts
+++ b/packages/helpers/qrcode-modal/src/browser/languages/pt.ts
@@ -1,0 +1,8 @@
+export default {
+  choose_preferred_wallet: "Escolha sua carteira preferida",
+  connect_mobile_wallet: "Conetar-se à carteira móvel",
+  scan_qrcode_with_wallet: "Digitalize o código QR com uma carteira compatível com WalletConnect",
+  return_to_mobile_options: "Regressar às opções de carteira móvel",
+  view_qrcode_option: "Ver código QR",
+  connect: "Conectar",
+};

--- a/packages/helpers/qrcode-modal/src/browser/languages/pt.ts
+++ b/packages/helpers/qrcode-modal/src/browser/languages/pt.ts
@@ -1,8 +1,8 @@
 export default {
   choose_preferred_wallet: "Escolha sua carteira preferida",
-  connect_mobile_wallet: "Conetar-se à carteira móvel",
-  scan_qrcode_with_wallet: "Digitalize o código QR com uma carteira compatível com WalletConnect",
-  return_to_mobile_options: "Regressar às opções de carteira móvel",
-  view_qrcode_option: "Ver código QR",
+  connect_mobile_wallet: "Conectar-se à carteira móvel",
+  scan_qrcode_with_wallet: "Ler o código QR com uma carteira compatível com WalletConnect",
+  return_to_mobile_options: "Voltar às opções de carteira móvel",
+  view_qrcode_option: "Ver o código QR",
   connect: "Conectar",
 };

--- a/packages/helpers/qrcode-modal/src/browser/languages/zh.ts
+++ b/packages/helpers/qrcode-modal/src/browser/languages/zh.ts
@@ -1,0 +1,8 @@
+export default {
+  choose_preferred_wallet: "选择你的钱包",
+  connect_mobile_wallet: "连接至移动端钱包",
+  scan_qrcode_with_wallet: "使用兼容 WalletConnect 的钱包扫描二维码",
+  return_to_mobile_options: "回到移动端钱包选项",
+  view_qrcode_option: "查看二维码",
+  connect: "连接",
+};


### PR DESCRIPTION
Fix #248 

- [x] Add i18n support
- [x] Add English text
- [x] Add Spanish text
- [x] Add French text
- [x] Add German text
- [ ] Add Russian text
- [x] Add Korean text
- [x] Add Chinese text
- [x] Add Portuguese text
- [ ] Add Romanian text

If you would like to add your own translation, here is the original text in English

```jsonc
{
  choose_preferred_wallet: "Choose your preferred wallet",
  connect_mobile_wallet: "Connect to Mobile Wallet",
  scan_qrcode_with_wallet: "Scan QR code with a WalletConnect-compatible wallet",
  return_to_mobile_options: "Return to mobile wallet options",
  view_qrcode_option: "View QR code",
  connect: "Connect",
}
```