### PR TITLE
Import EventEmitter as named import instead of default

### DIFF
--- a/packages/helpers/http-connection/package.json
+++ b/packages/helpers/http-connection/package.json
@@ -48,7 +48,7 @@
     "@babel/register": "7.8.3",
     "@types/jest": "22.2.3",
     "@types/lodash.isnumber": "3.0.6",
-    "@types/node": "12.12.14",
+    "@types/node": "14.6.3",
     "npm-run-all": "4.1.5",
     "tsdx": "0.12.3",
     "typescript": "3.7.5",

--- a/packages/helpers/http-connection/src/index.ts
+++ b/packages/helpers/http-connection/src/index.ts
@@ -1,4 +1,4 @@
-import EventEmitter from "events";
+import { EventEmitter } from "events";
 import { XMLHttpRequest } from "xhr2-cookies";
 import { IError } from "@walletconnect/types";
 import { unsafeGetFromWindow } from "@walletconnect/utils";

--- a/packages/helpers/utils/package-lock.json
+++ b/packages/helpers/utils/package-lock.json
@@ -1056,73 +1056,71 @@
       }
     },
     "@ethersproject/address": {
-      "version": "5.0.0-beta.134",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.0-beta.134.tgz",
-      "integrity": "sha512-FHhUVJTUIg2pXvOOhIt8sB1cQbcwrzZKzf9CPV7JM1auli20nGoYhyMFYGK7u++GXzTMJduIkU1OwlIBupewDw==",
+      "version": "5.0.0-beta.135",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.0-beta.135.tgz",
+      "integrity": "sha512-y9r/ajYBCDVM1ZD6kKgTRHBOxgURcQ24qTolw3oGyK373XHNrcY9ufDgZ5KR8h0OvLvczb4SGzYhahYvBnyZwA==",
+      "dev": true,
       "requires": {
-        "@ethersproject/bignumber": ">=5.0.0-beta.130",
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/keccak256": ">=5.0.0-beta.127",
-        "@ethersproject/logger": ">=5.0.0-beta.129",
-        "@ethersproject/rlp": ">=5.0.0-beta.126",
+        "@ethersproject/bignumber": ">=5.0.0-beta.138",
+        "@ethersproject/bytes": ">=5.0.0-beta.137",
+        "@ethersproject/keccak256": ">=5.0.0-beta.131",
+        "@ethersproject/logger": ">=5.0.0-beta.137",
+        "@ethersproject/rlp": ">=5.0.0-beta.132",
         "bn.js": "^4.4.0"
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.0.0-beta.136",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.0-beta.136.tgz",
-      "integrity": "sha512-G5fYkkMUpmQd7Qcxa7YdwavBkiSb44wI7GsZls/7eGFMYl2ySgmwOBMw3kj1lhheXbF73jfBfOBHvKYrN/p7pQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
+      "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+      "dev": true,
       "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/logger": ">=5.0.0-beta.129",
-        "@ethersproject/properties": ">=5.0.0-beta.131",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
         "bn.js": "^4.4.0"
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.0.0-beta.138",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.0-beta.138.tgz",
-      "integrity": "sha512-q4vaIthv89RJQ0V6gdzh1xuluJE1uYbnfzBUYTegicaXX6jRTCjDDhyiQhyEnNi7pKrGtuOrR3v3+7WtAR8Imw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+      "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+      "dev": true,
       "requires": {
-        "@ethersproject/logger": ">=5.0.0-beta.137"
-      },
-      "dependencies": {
-        "@ethersproject/logger": {
-          "version": "5.0.0-beta.137",
-          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.0-beta.137.tgz",
-          "integrity": "sha512-H36iMhWOY+tco1+o2NZUdQT8Gc6Y9795RSPgvluatvjvyt3X6mHtWXes4F8Rc5N/95px++a/ODYVSkSmlr68+A=="
-        }
+        "@ethersproject/logger": "^5.0.5"
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.0.0-beta.131",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.0-beta.131.tgz",
-      "integrity": "sha512-KQnqMwGV0IMOjAr/UTFO8DuLrmN1uaMvcV3zh9hiXhh3rCuY+WXdeUh49w1VQ94kBKmaP0qfGb7z4SdhUWUHjw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.3.tgz",
+      "integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
+      "dev": true,
       "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
+        "@ethersproject/bytes": "^5.0.4",
         "js-sha3": "0.5.7"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+          "dev": true
+        }
       }
     },
     "@ethersproject/logger": {
-      "version": "5.0.0-beta.136",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.0-beta.136.tgz",
-      "integrity": "sha512-baWK/4ccsVcyUU20nhp7k+hoRYsiaOfURYlyvQCoUUFKD3mpSRQCH42wxCosZZSCWz4rTHgASLQDdKkBtNVz1w=="
-    },
-    "@ethersproject/properties": {
-      "version": "5.0.0-beta.138",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.0-beta.138.tgz",
-      "integrity": "sha512-vLVftNTxonJ0SkkcMcpXHN9pABD84clh+Cz3TV79qvh+lc0MFX3dnYL1JinBdFnqLPXU9vw2LbTrBhwQY8bzCQ==",
-      "requires": {
-        "@ethersproject/logger": ">=5.0.0-beta.129"
-      }
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+      "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+      "dev": true
     },
     "@ethersproject/rlp": {
-      "version": "5.0.0-beta.132",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.0-beta.132.tgz",
-      "integrity": "sha512-P2oZkSMMazvMB0OaOM9GJnmLzHHSeCKqOp9bPAAY/rb65ICdtNjQMRYhOwinBFabrdV2z5TKWpwA9KIBkI0rTg==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.3.tgz",
+      "integrity": "sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==",
+      "dev": true,
       "requires": {
-        "@ethersproject/bytes": ">=5.0.0-beta.129",
-        "@ethersproject/logger": ">=5.0.0-beta.129"
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5"
       }
     },
     "@jest/console": {
@@ -1672,9 +1670,6 @@
           "dev": true
         }
       }
-    },
-    "@walletconnect/types": {
-      "version": "1.0.0-beta.97"
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
@@ -6680,9 +6675,9 @@
       "dev": true
     },
     "js-sha3": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
     "js-tokens": {
       "version": "4.0.0",


### PR DESCRIPTION
We import `EventEmitter` from `events` using a named import instead of using the default export. Before, this would break when using `@types/node@14`. Moreover this would break when using [rollup][1] together with [`rollup-plugin-node-polyfills`][2].

[1]: https://rollupjs.org/
[2]: https://github.com/ionic-team/rollup-plugin-node-polyfills