### PR TITLE
QRCode click to copy URI

### DIFF
--- a/packages/helpers/qrcode-modal/src/browser/components/QRCodeDisplay.tsx
+++ b/packages/helpers/qrcode-modal/src/browser/components/QRCodeDisplay.tsx
@@ -19,17 +19,28 @@ interface QRCodeDisplayProps {
 
 function QRCodeDisplay(props: QRCodeDisplayProps) {
   const [svg, setSvg] = React.useState("");
+
   React.useEffect(() => {
     (async () => {
       setSvg(await formatQRCodeImage(props.uri));
     })();
   }, []);
+
+  const copyToClipboard = () => {
+    const tmp = document.createElement("input");
+    tmp.value = props.uri;
+    document.body.appendChild(tmp);
+    tmp.select();
+    document.execCommand("copy");
+    tmp.remove();
+  }
+
   return (
     <div>
       <p id={WALLETCONNECT_CTA_TEXT_ID} className="walletconnect-qrcode__text">
         {props.text.scan_qrcode_with_wallet}
       </p>
-      <div dangerouslySetInnerHTML={{ __html: svg }}></div>
+      <div onClick={copyToClipboard} dangerouslySetInnerHTML={{ __html: svg }}></div>
     </div>
   );
 }


### PR DESCRIPTION
Not sure if there's already an existing way of doing this but when using WalletConnect where the dapp and wallet are on the same device and browser (e.g. interacting with dapp on mobile browser while using a browser based-wallet), there needs to be an easy way to view or copy the connection URI to the clipboard since the QRCode image can't be scanned.

This simple PR copies the connection URI to the clipboard when the QRCode image is clicked.