### PR TITLE
Move from the Node events module to eventemitter3

### DIFF
--- a/packages/helpers/http-connection/package.json
+++ b/packages/helpers/http-connection/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "@walletconnect/types": "^1.3.2-rc.1",
     "@walletconnect/utils": "^1.3.2-rc.1",
+    "eventemitter3": "^4.0.7",
     "xhr2-cookies": "1.1.0"
   },
   "gitHead": "165f7993c2acc907c653c02847fb02721052c6e7"

--- a/packages/helpers/http-connection/src/index.ts
+++ b/packages/helpers/http-connection/src/index.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "events";
+import EventEmitter from "eventemitter3";
 import { XMLHttpRequest } from "xhr2-cookies";
 import { IError } from "@walletconnect/types";
 import { getFromWindow } from "@walletconnect/utils";


### PR DESCRIPTION
This removes the need for bundlers to polyfill the Node `events` module in order to use `@walletconnect/http-connection`.