### PR TITLE
fix(web3-provider): stop createSession after close

### DIFF
--- a/packages/providers/web3-provider/src/index.ts
+++ b/packages/providers/web3-provider/src/index.ts
@@ -34,6 +34,7 @@ class WalletConnectProvider extends ProviderEngine {
   public chainId = 1;
   public networkId = 1;
   public rpcUrl = "";
+  private enabled = false;
 
   constructor(opts: IWalletConnectProviderOptions) {
     super({ pollingInterval: opts.pollingInterval || 8000 });
@@ -78,6 +79,7 @@ class WalletConnectProvider extends ProviderEngine {
   // Connect with a wallet and return the addresses of all available
   // accounts.
   enable = async (): Promise<string[]> => {
+    this.enabled = true;
     const wc = await this.getWalletConnector();
     if (wc) {
       this.start();
@@ -137,6 +139,7 @@ class WalletConnectProvider extends ProviderEngine {
   }
 
   async close() {
+    this.enabled = false;
     const wc = await this.getWalletConnector({ disableSessionCreation: true });
     await wc.killSession();
     await this.onDisconnect();
@@ -215,7 +218,7 @@ class WalletConnectProvider extends ProviderEngine {
       const wc = this.wc;
       if (this.isConnecting) {
         this.onConnect((x: any) => resolve(x));
-      } else if (!wc.connected && !disableSessionCreation) {
+      } else if (!wc.connected && !disableSessionCreation && this.enabled) {
         this.isConnecting = true;
         const sessionRequestOpions = this.chainId ? { chainId: this.chainId } : undefined;
         wc.on("modal_closed", () => {


### PR DESCRIPTION
Fixes #436 
`enabled` flag stops `getWalletConnector` from creating session after `close`.
Otherwise, `getWalletConnector` call (from `handleRequest`) ends up calling `wc.createSession`.

I think `handleRequest` might be being continually triggered because of the block polling of `Web3ProviderEngine`:
https://github.com/MetaMask/web3-provider-engine/blob/c8d9a8e46703ab417aeeeba583694057f38cfdf7/index.js#L24

I think the block polling should be stopped by the call to `stop` in `onDisconnect`, but I think this call may not be effective...

An alternative solution could be to have `close` remove the providers added during `initialize` (as then `handleRequest` wouldn't get called). The providers could then be re-added if `enable` is called again.