### PR TITLE
Bump detect-browser in @walletconnect/utils to include ES build files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,11 +117,11 @@
       }
     },
     "@babel/generator": {
-      "version": "7.12.15",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.15.tgz",
-      "integrity": "sha512-6F2xHxBiFXWNSGb7vyCUTBF8RCLY66rS0zEPcP8t/nQyXjha5EuK4z7H5o7fWG8B4M7y6mqVWq1J+1PuwRhecQ==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.17.tgz",
+      "integrity": "sha512-DSA7ruZrY4WI8VxuS1jWSRezFnghEoYEFrZcw9BizQRmOZiUsiHl59+qEARGPqPikwA/GPTyRCi7isuCK/oyqg==",
       "requires": {
-        "@babel/types": "^7.12.13",
+        "@babel/types": "^7.12.17",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
@@ -144,32 +144,32 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.16.tgz",
-      "integrity": "sha512-dBHNEEaZx7F3KoUYqagIhRIeqyyuI65xMndMZ3WwGwEBI609I4TleYQHcrS627vbKyNTXqShoN+fvYD9HuQxAg==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.17.tgz",
+      "integrity": "sha512-5EkibqLVYOuZ89BSg2lv+GG8feywLuvMXNYgf0Im4MssE0mFWPztSpJbildNnUgw0bLI2EsIN4MpSHC2iUJkQA==",
       "requires": {
         "@babel/compat-data": "^7.12.13",
-        "@babel/helper-validator-option": "^7.12.16",
+        "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
         "semver": "^5.5.0"
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.16.tgz",
-      "integrity": "sha512-KbSEj8l9zYkMVHpQqM3wJNxS1d9h3U9vm/uE5tpjMbaj3lTp+0noe3KPsV5dSD9jxKnf9jO9Ip9FX5PKNZCKow==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.17.tgz",
+      "integrity": "sha512-I/nurmTxIxHV0M+rIpfQBF1oN342+yvl2kwZUrQuOClMamHF1w5tknfZubgNOLRoA73SzBFAdFcpb4M9HwOeWQ==",
       "requires": {
         "@babel/helper-function-name": "^7.12.13",
-        "@babel/helper-member-expression-to-functions": "^7.12.16",
+        "@babel/helper-member-expression-to-functions": "^7.12.17",
         "@babel/helper-optimise-call-expression": "^7.12.13",
         "@babel/helper-replace-supers": "^7.12.13",
         "@babel/helper-split-export-declaration": "^7.12.13"
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.16.tgz",
-      "integrity": "sha512-jAcQ1biDYZBdaAxB4yg46/XirgX7jBDiMHDbwYQOgtViLBXGxJpZQ24jutmBqAIB/q+AwB6j+NbBXjKxEY8vqg==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.17.tgz",
+      "integrity": "sha512-p2VGmBu9oefLZ2nQpgnEnG0ZlRPvL8gAGvPUMQwUdaE8k49rOMuZpOwdQoy5qJf6K8jL3bcAMhVUlHAjIgJHUg==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.12.13",
         "regexpu-core": "^4.7.1"
@@ -210,11 +210,11 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.16.tgz",
-      "integrity": "sha512-zYoZC1uvebBFmj1wFAlXwt35JLEgecefATtKp20xalwEK8vHAixLBXTGxNrVGEmTT+gzOThUgr8UEdgtalc1BQ==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.17.tgz",
+      "integrity": "sha512-Bzv4p3ODgS/qpBE0DiJ9qf5WxSmrQ8gVTe8ClMfwwsY2x/rhykxxy3bXzG7AGTnPB2ij37zGJ/Q/6FruxHxsxg==",
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.12.17"
       }
     },
     "@babel/helper-module-imports": {
@@ -226,9 +226,9 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.13.tgz",
-      "integrity": "sha512-acKF7EjqOR67ASIlDTupwkKM1eUisNAjaSduo5Cz+793ikfnpe7p4Q7B7EWU2PCoSTPWsQkR7hRUWEIZPiVLGA==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.17.tgz",
+      "integrity": "sha512-sFL+p6zOCQMm9vilo06M4VHuTxUAwa6IxgL56Tq1DVtA0ziAGTH1ThmJq7xwPqdQlgAbKX3fb0oZNbtRIyA5KQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.12.13",
         "@babel/helper-replace-supers": "^7.12.13",
@@ -236,8 +236,8 @@
         "@babel/helper-split-export-declaration": "^7.12.13",
         "@babel/helper-validator-identifier": "^7.12.11",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13",
+        "@babel/traverse": "^7.12.17",
+        "@babel/types": "^7.12.17",
         "lodash": "^4.17.19"
       }
     },
@@ -305,9 +305,9 @@
       "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
     },
     "@babel/helper-validator-option": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.16.tgz",
-      "integrity": "sha512-uCgsDBPUQDvzr11ePPo4TVEocxj8RXjUVSC/Y8N1YpVAI/XDdUwGJu78xmlGhTxj2ntaWM7n9LQdRtyhOzT2YQ=="
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+      "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
     },
     "@babel/helper-wrap-function": {
       "version": "7.12.13",
@@ -321,13 +321,13 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.13.tgz",
-      "integrity": "sha512-oohVzLRZ3GQEk4Cjhfs9YkJA4TdIDTObdBEZGrd6F/T0GPSnuV6l22eMcxlvcvzVIPH3VTtxbseudM1zIE+rPQ==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.17.tgz",
+      "integrity": "sha512-tEpjqSBGt/SFEsFikKds1sLNChKKGGR17flIgQKXH4fG6m9gTgl3gnOC1giHNyaBCSKuTfxaSzHi7UnvqiVKxg==",
       "requires": {
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/traverse": "^7.12.17",
+        "@babel/types": "^7.12.17"
       }
     },
     "@babel/highlight": {
@@ -370,9 +370,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
-      "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw=="
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.17.tgz",
+      "integrity": "sha512-r1yKkiUTYMQ8LiEI0UcQx5ETw5dpTLn9wijn9hk6KkTtOK95FndDN10M+8/s6k/Ymlbivw0Av9q4SlgF80PtHg=="
     },
     "@babel/plugin-external-helpers": {
       "version": "7.12.13",
@@ -402,9 +402,9 @@
       }
     },
     "@babel/plugin-proposal-dynamic-import": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.16.tgz",
-      "integrity": "sha512-yiDkYFapVxNOCcBfLnsb/qdsliroM+vc3LHiZwS4gh7pFjo5Xq3BDhYBNn3H3ao+hWPvqeeTdU+s+FIvokov+w==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.17.tgz",
+      "integrity": "sha512-ZNGoFZqrnuy9H2izB2jLlnNDAfVPlGl5NhFEiFe4D84ix9GQGygF+CWMGHKuE+bpyS/AOuDQCnkiRNqW2IzS1Q==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/plugin-syntax-dynamic-import": "^7.8.0"
@@ -457,9 +457,9 @@
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.16.tgz",
-      "integrity": "sha512-O3ohPwOhkwji5Mckb7F/PJpJVJY3DpPsrt/F0Bk40+QMk9QpAIqeGusHWqu/mYqsM8oBa6TziL/2mbERWsUZjg==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.17.tgz",
+      "integrity": "sha512-TvxwI80pWftrGPKHNfkvX/HnoeSTR7gC4ezWnAL39PuktYUe6r8kEpOLTYnkBTsaoeazXm2jHJ22EQ81sdgfcA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
@@ -811,15 +811,15 @@
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.16.tgz",
-      "integrity": "sha512-dNu0vAbIk8OkqJfGtYF6ADk6jagoyAl+Ks5aoltbAlfoKv8d6yooi3j+kObeSQaCj9PgN6KMZPB90wWyek5TmQ==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.17.tgz",
+      "integrity": "sha512-mwaVNcXV+l6qJOuRhpdTEj8sT/Z0owAVWf9QujTZ0d2ye9X/K+MTOTSizcgKOj18PGnTc/7g1I4+cIUjsKhBcw==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.12.13",
         "@babel/helper-module-imports": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/plugin-syntax-jsx": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.12.17"
       }
     },
     "@babel/plugin-transform-react-jsx-self": {
@@ -855,9 +855,9 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.12.15",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.15.tgz",
-      "integrity": "sha512-OwptMSRnRWJo+tJ9v9wgAf72ydXWfYSXWhnQjZing8nGZSDFqU1MBleKM3+DriKkcbv7RagA8gVeB0A1PNlNow==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.17.tgz",
+      "integrity": "sha512-s+kIJxnaTj+E9Q3XxQZ5jOo+xcogSe3V78/iFQ5RmoT0jROdpcdxhfGdq/VLqW1hFSzw6VjqN8aQqTaAMixWsw==",
       "requires": {
         "@babel/helper-module-imports": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.12.13",
@@ -906,11 +906,11 @@
       }
     },
     "@babel/plugin-transform-typescript": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.12.16.tgz",
-      "integrity": "sha512-88hep+B6dtDOiEqtRzwHp2TYO+CN8nbAV3eh5OpBGPsedug9J6y1JwLKzXRIGGQZDC8NlpxpQMIIxcfIW96Wgw==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.12.17.tgz",
+      "integrity": "sha512-1bIYwnhRoetxkFonuZRtDZPFEjl1l5r+3ITkxLC3mlMaFja+GQFo94b/WHEPjqWLU9Bc+W4oFZbvCGe9eYMu1g==",
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.12.16",
+        "@babel/helper-create-class-features-plugin": "^7.12.17",
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/plugin-syntax-typescript": "^7.12.13"
       }
@@ -1037,17 +1037,17 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
-      "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
+      "version": "7.12.18",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+      "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.13.tgz",
-      "integrity": "sha512-8fSpqYRETHATtNitsCXq8QQbKJP31/KnDl2Wz2Vtui9nKzjss2ysuZtyVsWjBtvkeEFo346gkwjYPab1hvrXkQ==",
+      "version": "7.12.18",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.18.tgz",
+      "integrity": "sha512-ngR7yhNTjDxxe1VYmhqQqqXZWujGb6g0IoA4qeG6MxNGRnIw2Zo8ImY8HfaQ7l3T6GklWhdNfyhWk0C0iocdVA==",
       "requires": {
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.4"
@@ -1089,16 +1089,16 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.13.tgz",
-      "integrity": "sha512-3Zb4w7eE/OslI0fTp8c7b286/cQps3+vdLW3UcwC8VSJC6GbKn55aeVVu2QJNuCDoeKyptLOFrPq8WqZZBodyA==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.17.tgz",
+      "integrity": "sha512-LGkTqDqdiwC6Q7fWSwQoas/oyiEYw6Hqjve5KOSykXkmFJFqzvGMb9niaUEag3Rlve492Mkye3gLw9FTv94fdQ==",
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.12.13",
+        "@babel/generator": "^7.12.17",
         "@babel/helper-function-name": "^7.12.13",
         "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.12.13",
-        "@babel/types": "^7.12.13",
+        "@babel/parser": "^7.12.17",
+        "@babel/types": "^7.12.17",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
@@ -1143,9 +1143,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.13.tgz",
-      "integrity": "sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.17.tgz",
+      "integrity": "sha512-tNMDjcv/4DIcHxErTgwB9q2ZcYyN0sUfgGKUK/mm1FJK7Wz+KstoEekxrl/tBiNDgLK1HGi+sppj1An/1DR4fQ==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
         "lodash": "^4.17.19",
@@ -2247,28 +2247,46 @@
       }
     },
     "@json-rpc-tools/blockchain": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/blockchain/-/blockchain-1.6.1.tgz",
-      "integrity": "sha512-JCKTv7SyW3TXkKR1gVRfKLDUgUUodkmQISY7z6dVSuRmg/RARZdbk07OnNRToOiYqG/Qb9ZcWpKhI/G7Ik6eng==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/blockchain/-/blockchain-1.6.2.tgz",
+      "integrity": "sha512-vvAsO5wmvXR4FlSqC47EWxFWz+sC9SPmjDsJ+e6eziGGT09yv35KrHsTUL2UpBiD2H/ksTuoRGcBz5TqgDMAxA==",
       "requires": {
-        "@json-rpc-tools/provider": "^1.6.1",
-        "@json-rpc-tools/router": "^1.6.1",
-        "@json-rpc-tools/utils": "^1.6.1",
-        "@json-rpc-tools/validator": "^1.6.1",
+        "@json-rpc-tools/provider": "^1.6.2",
+        "@json-rpc-tools/router": "^1.6.2",
+        "@json-rpc-tools/utils": "^1.6.2",
+        "@json-rpc-tools/validator": "^1.6.2",
         "keyvaluestorage": "^0.7.1"
+      },
+      "dependencies": {
+        "@json-rpc-tools/utils": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.6.2.tgz",
+          "integrity": "sha512-Xf3P5f8Kohzinl3BbPoIoC5i8K7aKHz4AsEupv2O/wPac58abfckgdu1ap0EAx9FcTO9hrnkCYS120YWe5G7zw==",
+          "requires": {
+            "@json-rpc-tools/types": "^1.6.2"
+          }
+        }
       }
     },
     "@json-rpc-tools/provider": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.6.1.tgz",
-      "integrity": "sha512-OVaFsAC/CbGoaXKq9pGn1umwZ4ut9+nqhGkkLPZWd5KY0YpMxMCZ13lHcyzbgx+QTm4OjmH1BMQU/op4YrH6XA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.6.2.tgz",
+      "integrity": "sha512-vn62pkHMdCJztodmAqg0pNVEIed5WxodoYICA58o+PCaIT+SIc6sN4Hr5m0/VP+pZykKJOF4Fn9GfCFiraVNrQ==",
       "requires": {
-        "@json-rpc-tools/utils": "^1.6.1",
+        "@json-rpc-tools/utils": "^1.6.2",
         "axios": "^0.21.0",
         "safe-json-utils": "^1.1.1",
         "ws": "^7.4.0"
       },
       "dependencies": {
+        "@json-rpc-tools/utils": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.6.2.tgz",
+          "integrity": "sha512-Xf3P5f8Kohzinl3BbPoIoC5i8K7aKHz4AsEupv2O/wPac58abfckgdu1ap0EAx9FcTO9hrnkCYS120YWe5G7zw==",
+          "requires": {
+            "@json-rpc-tools/types": "^1.6.2"
+          }
+        },
         "safe-json-utils": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
@@ -2282,19 +2300,29 @@
       }
     },
     "@json-rpc-tools/router": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/router/-/router-1.6.1.tgz",
-      "integrity": "sha512-b/Rdz7N+sjU7E+YqEaNPced4WwEg4pHhandVwhQUFSyk/hOwR0W6s4+fYk/fJu7PVvmJMzsYYPl0vlfyMfv1fw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/router/-/router-1.6.2.tgz",
+      "integrity": "sha512-HcRcXv2ySUCIs1UAxkxZl4B2Rqu+cAXA4jomh1wXKvmUQ7M5fLa4pohH5fKu6oZjhfS/CV0Iohb/kl92NiCtPQ==",
       "requires": {
-        "@json-rpc-tools/utils": "^1.6.1",
-        "@json-rpc-tools/validator": "^1.6.1",
+        "@json-rpc-tools/utils": "^1.6.2",
+        "@json-rpc-tools/validator": "^1.6.2",
         "lodash.difference": "^4.5.0"
+      },
+      "dependencies": {
+        "@json-rpc-tools/utils": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.6.2.tgz",
+          "integrity": "sha512-Xf3P5f8Kohzinl3BbPoIoC5i8K7aKHz4AsEupv2O/wPac58abfckgdu1ap0EAx9FcTO9hrnkCYS120YWe5G7zw==",
+          "requires": {
+            "@json-rpc-tools/types": "^1.6.2"
+          }
+        }
       }
     },
     "@json-rpc-tools/types": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.6.1.tgz",
-      "integrity": "sha512-Fg8Dke0+K92cZaWm0/vFIZgNdHftEI5GXbgT2rwUmmo/GrjlXJn5cPRghq5ee+QGTeZvWcjYmqdwrdGbTGBCMw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.6.2.tgz",
+      "integrity": "sha512-sHeq/WuDJg6b/E/pxKVJYq+oP0qXKUOkCMngkFSA/HbFSUfW6II1YWJue/zZJpbeAsgA3P0vqNF4M/QVwiDvCw==",
       "requires": {
         "keyvaluestorage-interface": "^1.0.0"
       }
@@ -2308,12 +2336,22 @@
       }
     },
     "@json-rpc-tools/validator": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/validator/-/validator-1.6.1.tgz",
-      "integrity": "sha512-aZAN0gb8rGNqCz1aMSG2RUT/oZJnLun5NqFKzSVmrnK9tBHY9Helo2irNBIvzjxddaBdLwVg7U8jvkZXQftFMA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/validator/-/validator-1.6.2.tgz",
+      "integrity": "sha512-1boHw5CtqwOdYFjLOH+ZxXZC9AJejCNO9ByTF3Tyi1yOsu4C+gowsOOdYhZW2uS619+TCAPpOzBlW3skJP+Drw==",
       "requires": {
-        "@json-rpc-tools/utils": "^1.6.1",
+        "@json-rpc-tools/utils": "^1.6.2",
         "jsonschema": "^1.4.0"
+      },
+      "dependencies": {
+        "@json-rpc-tools/utils": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.6.2.tgz",
+          "integrity": "sha512-Xf3P5f8Kohzinl3BbPoIoC5i8K7aKHz4AsEupv2O/wPac58abfckgdu1ap0EAx9FcTO9hrnkCYS120YWe5G7zw==",
+          "requires": {
+            "@json-rpc-tools/types": "^1.6.2"
+          }
+        }
       }
     },
     "@lerna/add": {
@@ -3677,9 +3715,9 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "mime": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.0.tgz",
-          "integrity": "sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag=="
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
         },
         "shell-quote": {
           "version": "1.6.1",
@@ -6016,14 +6054,14 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30001187",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001187.tgz",
-      "integrity": "sha512-P+BN7x0wUbn8S/qSZ0UMQFJFckm8LOQEwdXCFTGPzdCve9828qEQ1KdzdOf8fLrrS3jJJZCbgT7fu8FrvbmAxA=="
+      "version": "1.0.30001189",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001189.tgz",
+      "integrity": "sha512-j51O0iGPH64Yr0BxPTafQCWUyKduDBGBrE78Vizid15ch66wI+Qgd7NVnJktfL6WhyBxoAGm1UwQl+qbrslkOg=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001187",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001187.tgz",
-      "integrity": "sha512-w7/EP1JRZ9552CyrThUnay2RkZ1DXxKe/Q2swTC4+LElLh9RRYrL1Z+27LlakB8kzY0fSmHw9mc7XYDUKAKWMA=="
+      "version": "1.0.30001189",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001189.tgz",
+      "integrity": "sha512-BSfxClP/UWCD0RX1h1L+vLDexNSJY7SfOtbJtW10bcnatfj3BcoietUFYNwWreOCk+SNvGUaNapGqUNPiGAiSA=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -6971,16 +7009,16 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
-      "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q=="
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.0.tgz",
+      "integrity": "sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ=="
     },
     "core-js-compat": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.3.tgz",
-      "integrity": "sha512-1sCb0wBXnBIL16pfFG1Gkvei6UzvKyTNYpiC41yrdjEv0UoJoq9E/abTMzyYJ6JpTkAj15dLjbqifIzEBDVvog==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.9.0.tgz",
+      "integrity": "sha512-YK6fwFjCOKWwGnjFUR3c544YsnA/7DoLL0ysncuOJ4pwbriAtOpvM2bygdlcXbvQCQZ7bBU9CL4t7tGl7ETRpQ==",
       "requires": {
-        "browserslist": "^4.16.1",
+        "browserslist": "^4.16.3",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -6992,9 +7030,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.3.tgz",
-      "integrity": "sha512-V5qQZVAr9K0xu7jXg1M7qTEwuxUgqr7dUOezGaNa7i+Xn9oXAU/d1fzqD9ObuwpVQOaorO5s70ckyi1woP9lVA=="
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.9.0.tgz",
+      "integrity": "sha512-3pEcmMZC9Cq0D4ZBh3pe2HLtqxpGNJBLXF/kZ2YzK17RbKp94w0HFbdbSx8H8kAlZG5k76hvLrkPm57Uyef+kg=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -7738,9 +7776,9 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-browser": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.1.0.tgz",
-      "integrity": "sha512-WKa9p+/MNwmTiS+V2AS6eGxic+807qvnV3hC+4z2GTY+F42h1n8AynVTMMc4EJBC32qMs6yjOTpeDEQQt/AVqQ=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
+      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
     },
     "detect-file": {
       "version": "1.0.0",
@@ -7940,9 +7978,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.664",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.664.tgz",
-      "integrity": "sha512-yb8LrTQXQnh9yhnaIHLk6CYugF/An50T20+X0h++hjjhVfgSp1DGoMSYycF8/aD5eiqS4QwaNhiduFvK8rifRg=="
+      "version": "1.3.669",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.669.tgz",
+      "integrity": "sha512-VNj10fmGC6SbE7s4tKG7y2OopVXYoTIfjE1MetflPd77KmeRuHtkl+HYsfF00BGg5hyaorTUn6lTToEHaciOSw=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -9580,9 +9618,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.2.0.tgz",
-          "integrity": "sha512-M/u37b4oSGlusaU8ZB96BfFPWQ8MbsZYXB+kXGMiDj6IKinkcNaQvmirBuWj8mAXqP6LYn1rQvbTYum3yPhaOA=="
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.3.0.tgz",
+          "integrity": "sha512-rgPIqOdfK/4J9FhiVrZ3cveAjRRo5rsQBAIhnylX874y1DX/kEKSVdLsnuHB6l1KTjHyU01VjiMBHgU2adejyg=="
         }
       }
     },
@@ -22845,9 +22883,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.52.tgz",
-          "integrity": "sha512-bKnO8Rcj03i6JTzweabq96k29uVNcXGB0bkwjVQTFagDgxxNged18281AZ0nTMHl+aFpPPWyPrk4Z3+NtW/z5w=="
+          "version": "10.17.53",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.53.tgz",
+          "integrity": "sha512-q1igVlMUU+10kzjxNlcLDH7gekuvFK1nevnp7MAyc6sqvK5siWSS37EuvKX9fM8d49SBcoP0iP9tqVHmdAjNhQ=="
         }
       }
     },
@@ -23443,9 +23481,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
-      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.1.tgz",
+      "integrity": "sha512-IEmN/ZfmMw6G1hgZpVd0LuZXOQDisrMOZrzYd5x3RAK4bMPlJohKUZWZ9t/QsTvH0dV9TbPDcc2OSuIDcihnHA=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/packages/helpers/utils/package.json
+++ b/packages/helpers/utils/package.json
@@ -60,7 +60,7 @@
     "@json-rpc-tools/utils": "1.6.1",
     "@walletconnect/types": "^1.3.6",
     "bn.js": "4.11.8",
-    "detect-browser": "5.1.0",
+    "detect-browser": "5.2.0",
     "enc-utils": "3.0.0",
     "js-sha3": "0.8.0",
     "query-string": "6.13.5",


### PR DESCRIPTION
There's a problem with the 5.1.0 version of detect-browser that it has `module: "es/index.js`, but doesn't actually include it and it results in an error with developer tools that use only modules (vite for example):

It was fixed in detect-browser@5.2.0

**Before**
<img width="612" alt="Screenshot 2021-02-19 at 16 40 53" src="https://user-images.githubusercontent.com/16622558/108505707-3fdb4c80-72d1-11eb-806d-e7983f16b532.png">

**After**
<img width="524" alt="Screenshot 2021-02-19 at 16 42 04" src="https://user-images.githubusercontent.com/16622558/108505806-67cab000-72d1-11eb-9df2-3602b1634dc2.png">
