### PR TITLE
Update Aktionariat wallet universal link

### DIFF
--- a/packages/helpers/mobile-registry/registry.json
+++ b/packages/helpers/mobile-registry/registry.json
@@ -284,7 +284,7 @@
     "shortName": "Aktionariat",
     "color": "rgb(10, 20, 20)",
     "logo": "./logos/aktionariat.png",
-    "universalLink": "https://aktionariat.com/app",
+    "universalLink": "https://app.aktionariat.com",
     "deepLink": "aktionariat:"
   }
 ]


### PR DESCRIPTION
Updating UL because iOS doesn't trigger it when linked from a page under the same domain.
Thank you.