### PR TITLE
Fix JSON-RPC error handling in handleRequest

### DIFF
--- a/packages/providers/web3-provider/src/index.ts
+++ b/packages/providers/web3-provider/src/index.ts
@@ -376,8 +376,8 @@ class WalletConnectProvider extends ProviderEngine {
     this.addProvider({
       handleRequest: async (payload: IJsonRpcRequest, next: any, end: any) => {
         try {
-          const { result } = await this.handleRequest(payload);
-          end(null, result);
+          const { error, result } = await this.handleRequest(payload);
+          end(error, result);
         } catch (error) {
           end(error);
         }


### PR DESCRIPTION
When using [web3-react](https://github.com/NoahZinsmeister/web3-react) and the WalletConnect provider, if a call reverts and the node returns a JSON-RPC error (having props `id`, `error` and `jsonrpc` but no `result`), that error is not properly parsed in the `handleRequest` function.

The current code behaves correctly if the call succeeds with a result or if completely fails but if the call succeeds with an error message, it tries to get the `result` property and ignores the error, returning an `undefined` to the caller.

This function was previously found buggy in #96, patched in #100 and is the most probable cause of #334.