### PR TITLE
fix: remove rndapp dependence upon walletconnect/mobile-registry

### DIFF
--- a/packages/helpers/react-native-dapp/package.json
+++ b/packages/helpers/react-native-dapp/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "@walletconnect/client": "^1.4.0",
-    "@walletconnect/mobile-registry": "^1.4.0",
     "@walletconnect/types": "^1.4.0",
     "@walletconnect/utils": "^1.4.0",
     "keyvaluestorage": "0.7.1",

--- a/packages/helpers/react-native-dapp/src/components/WalletServiceIcon.tsx
+++ b/packages/helpers/react-native-dapp/src/components/WalletServiceIcon.tsx
@@ -9,6 +9,7 @@ export type WalletServiceIconProps = {
   readonly height: number;
   readonly walletService: WalletService;
   readonly connectToWalletService: (walletService: WalletService) => unknown;
+  readonly size?: 'sm' | 'md' | 'lg'
 };
 
 const styles = StyleSheet.create({
@@ -32,7 +33,11 @@ export default function WalletServiceIcon({
   height,
   walletService,
   connectToWalletService,
+  size = 'md'
 }: WalletServiceIconProps): JSX.Element {
+  const uri = React.useMemo(() => (
+    `https://registry.walletconnect.org/logo/${size}/${walletService.id}.jpeg`
+  ), [walletService, size]);
   const onPress = React.useCallback(() => (
     connectToWalletService(walletService)
   ), [connectToWalletService, walletService]);
@@ -52,7 +57,7 @@ export default function WalletServiceIcon({
             height: height * 0.6,
           },
         ]}
-        source={{ uri: walletService.logo }}
+        source={{ uri }}
       />
       <Text
         style={[styles.title, styles.fullWidth]}

--- a/packages/helpers/react-native-dapp/src/constants/formatWalletServiceUrl.ts
+++ b/packages/helpers/react-native-dapp/src/constants/formatWalletServiceUrl.ts
@@ -3,7 +3,8 @@ import { Platform } from "react-native";
 import { WalletService } from "../types";
 
 export default function formatProviderUrl(walletService: WalletService): string {
-  const { universalLink, deepLink } = walletService;
+  const { mobile } = walletService;
+  const { universal: universalLink, native: deepLink } = mobile;
   if (Platform.OS === "android") {
     return `${deepLink}`;
   }

--- a/packages/helpers/react-native-dapp/src/contexts/WalletConnectContext.ts
+++ b/packages/helpers/react-native-dapp/src/contexts/WalletConnectContext.ts
@@ -1,32 +1,6 @@
-import registry from "@walletconnect/mobile-registry/registry.json";
 import * as React from "react";
-import { Image, Platform } from "react-native";
 
 import { WalletConnectContextValue, WalletService } from "../types";
-
-const walletServices: readonly WalletService[] = registry
-  .filter(({ universalLink, deepLink }) => {
-    /* wc_mobile_valid */
-    if (Platform.OS === "ios") {
-      return typeof universalLink === "string" && !!universalLink.length;
-    } else if (Platform.OS === "android") {
-      return typeof deepLink === "string" && !!deepLink.length;
-    }
-    return Platform.OS === "web";
-  })
-  .map(({
-    logo,
-    ...extras
-  }: WalletService): WalletService => Object.freeze({
-    ...extras,
-    logo:
-      `https://github.com/WalletConnect/walletconnect-monorepo/raw/next/packages/helpers/mobile-registry${
-        logo.substring(1)
-      }`,
-  }));
-
-/* wc_prefetch */
-Promise.all(walletServices.map(({ logo }) => Image.prefetch(logo)));
 
 const defaultValue: Partial<WalletConnectContextValue> = Object.freeze({
   bridge: "https://bridge.walletconnect.org",
@@ -43,7 +17,7 @@ const defaultValue: Partial<WalletConnectContextValue> = Object.freeze({
   connectToWalletService: async (walletService: WalletService, uri?: string) => Promise.reject(new Error(
     "[WalletConnect]: It looks like you have forgotten to wrap your application with a <WalletConnectProvider />.",
   )),
-  walletServices,
+  walletServices: [],
 });
 
 export default React.createContext<Partial<WalletConnectContextValue>>(

--- a/packages/helpers/react-native-dapp/src/hooks/index.ts
+++ b/packages/helpers/react-native-dapp/src/hooks/index.ts
@@ -1,2 +1,3 @@
+export { default as useMobileRegistry } from "./useMobileRegistry";
 export { default as useWalletConnect } from "./useWalletConnect";
 export { default as useWalletConnectContext } from "./useWalletConnectContext";

--- a/packages/helpers/react-native-dapp/src/hooks/useMobileRegistry.ts
+++ b/packages/helpers/react-native-dapp/src/hooks/useMobileRegistry.ts
@@ -1,0 +1,38 @@
+import * as React from "react";
+
+import { WalletService } from "../types";
+
+type State = {
+  readonly data: readonly WalletService[]; // TODO
+  readonly error?: Error;
+  readonly loading: boolean;
+};
+
+const defaultState: State = Object.freeze({
+  data: [],
+  error: null,
+  loading: true,
+});
+
+export default function useMobileRegistry(): State {
+  const [state, setState] = React.useState<State>(defaultState);
+
+  React.useEffect(() => {
+    (async () => {
+      try {
+        const result = await fetch('https://registry.walletconnect.org/data/wallets.json');
+        const data = await result.json();
+        setState({
+          data: Object.values(data) as readonly WalletService[],
+          error: null,
+          loading: false,
+        });
+      } catch (error) {
+        console.error(error);
+        setState({ ...defaultState, error, loading: false });
+      }
+    })();
+  }, [setState]);
+
+  return state;
+}

--- a/packages/helpers/react-native-dapp/src/types/index.ts
+++ b/packages/helpers/react-native-dapp/src/types/index.ts
@@ -10,12 +10,33 @@ export enum ConnectorEvents {
 }
 
 export type WalletService = {
+  readonly id: string;
   readonly name: string;
-  readonly shortName: string;
-  readonly color: string;
-  readonly logo: string;
-  readonly universalLink: string;
-  readonly deepLink: string;
+  readonly homepage: string;
+  readonly chains: readonly string[];
+  readonly app: {
+    readonly browser: string;
+    readonly ios: string;
+    readonly android: string;
+    readonly mac: string;
+    readonly windows: string;
+    readonly linux: string;
+  };
+  readonly mobile: {
+    readonly native: string;
+    readonly universal: string;
+  };
+  readonly desktop: {
+    readonly native: string;
+    readonly universal: string;
+  };
+  readonly metadata: {
+    readonly shortName: string;
+    readonly colors: {
+      readonly primary: string;
+      readonly secondary: string;
+    };
+  };
 };
 
 export type WalletConnectQrcodeModal = {


### PR DESCRIPTION
Removes hardcoded dependence upon `@walletconnect/mobile-registry`, and instead queries `https://registry.walletconnect.org/data/wallets.json` for `WalletService` instances via the `useWalletRegistry` hook at runtime. This prevents the old inventory location from being referenced.


Also updated the default QRCodeModal logo `uri`s to point towards: `https://registry.walletconnect.org/logo/${size}/${walletService.id}.jpeg` using the `md` size. (iOS only).