### PR TITLE
(react-native-dapp) fix: #470 correct uri handling and connector management on android

### DIFF
--- a/packages/helpers/react-native-dapp/src/providers/WalletConnectProvider.tsx
+++ b/packages/helpers/react-native-dapp/src/providers/WalletConnectProvider.tsx
@@ -51,6 +51,12 @@ export default function WalletConnectProvider({
 
   const open = React.useCallback(async (uri: string, cb: unknown): Promise<unknown> => {
     if (Platform.OS === 'android') {
+      const canOpenURL = await Linking.canOpenURL(uri);
+      if (!canOpenURL) {
+        // Redirect the user to download a wallet.
+        Linking.openURL('https://walletconnect.org/wallets');
+        throw new Error('No wallets found.');
+      }
       await Linking.openURL(uri);
     }
     setState({
@@ -257,7 +263,7 @@ export default function WalletConnectProvider({
   ]);
 
   const value = React.useMemo((): WalletConnectContextValue => {
-    if (connector && state.visible) {
+    if (connector) {
       // Reset the connector.
       return {
         ...intermediateValue,


### PR DESCRIPTION
Corrects `connector` state management on mobile platforms.
- On Android, if a user has no wallets installed, they are redirected to download via `https://walletconnect.org/wallets`.