### PR TITLE
add: public transportClose that allow to close the transport without killing the session

### DIFF
--- a/packages/clients/core/src/index.ts
+++ b/packages/clients/core/src/index.ts
@@ -760,6 +760,10 @@ class Connector implements IConnector {
     }
   }
 
+  public transportClose() {
+    this._transport.close();
+  }
+
   // -- private --------------------------------------------------------- //
 
   protected async _sendRequest(
@@ -881,7 +885,7 @@ class Connector implements IConnector {
       params: [{ message }],
     });
     this._removeStorageSession();
-    this._transport.close();
+    this.transportClose();
   }
 
   private _handleSessionResponse(errorMsg: string, sessionParams?: ISessionParams) {


### PR DESCRIPTION
**What do we need?**
We need the ability to close the socket connection without killing the session.

**Why do we need it?**
If a user has two accounts in my wallet app, account A and account B. When the user logs out from account A and then log in with account B, we have to close socket connections from account A without killing the session (no `killSession`), because if the user logs in again with account A, we want to be able to connect to their last walletconnect sessions.

**How we solve it?**
Let's create a new method `transportClose` that closes the transport but doesn't kill the session. We'll call `transportClose` when a user logs out from our wallet app.

Fix this issue -- #481