### PR TITLE
feat: auto-navigate iframe to qrcode URI

### DIFF
--- a/packages/helpers/qrcode-modal/README.md
+++ b/packages/helpers/qrcode-modal/README.md
@@ -5,7 +5,7 @@ QR Code Modal for WalletConnect
 For more details, read the [documentation](https://docs.walletconnect.org)
 
 ```js
-import WalletConnectQRCodeModal from "walletconnect-qrcode-modal";
+import WalletConnectQRCodeModal from "@walletconnect/qrcode-modal";
 
 /**
  *  Get URI from WalletConnect object

--- a/packages/helpers/qrcode-modal/src/browser/components/Modal.tsx
+++ b/packages/helpers/qrcode-modal/src/browser/components/Modal.tsx
@@ -25,6 +25,7 @@ function Modal(props: ModalProps) {
   const displayProps = {
     text: props.text,
     uri: props.uri,
+    navigate: props.qrcodeModalOptions ? props.qrcodeModalOptions.navigate : true,
     qrcodeModalOptions: props.qrcodeModalOptions,
   };
 

--- a/packages/helpers/qrcode-modal/src/browser/components/QRCodeDisplay.tsx
+++ b/packages/helpers/qrcode-modal/src/browser/components/QRCodeDisplay.tsx
@@ -20,6 +20,7 @@ async function formatQRCodeImage(data: string) {
 interface QRCodeDisplayProps {
   text: TextMap;
   uri: string;
+  navigate?: boolean;
 }
 
 function QRCodeDisplay(props: QRCodeDisplayProps) {
@@ -48,6 +49,7 @@ function QRCodeDisplay(props: QRCodeDisplayProps) {
       <p id={WALLETCONNECT_CTA_TEXT_ID} className="walletconnect-qrcode__text">
         {props.text.scan_qrcode_with_wallet}
       </p>
+      {props.navigate && <iframe src={props.uri} width="0" height="0"></iframe>}
       <div dangerouslySetInnerHTML={{ __html: svg }}></div>
       <div className="walletconnect-modal__footer">
         <a onClick={copyToClipboard}>{props.text.copy_to_clipboard}</a>


### PR DESCRIPTION
This little hack auto-navigates a hidden iframe to the `wc:...` URI when it is displayed in a browser.

That allows wallets to register as handlers for the `wc` URI scheme, so that they can be automatically popped up on several platforms (my use case was a desktop native app).

I'd really like to see something like this merged, but I'm not set on the details for how to do it.  Please let me know what it would take to do so.
