### PR TITLE
Inherit prototype when wrapping wallet connector in react-native-dapp

### DIFF
--- a/packages/helpers/react-native-dapp/src/providers/WalletConnectProvider.tsx
+++ b/packages/helpers/react-native-dapp/src/providers/WalletConnectProvider.tsx
@@ -269,7 +269,7 @@ export default function WalletConnectProvider({
         ...intermediateValue,
         walletServices,
         connectToWalletService,
-        connector: {
+        connector: Object.assign(Object.create(connector), {
           ...connector,
           connect: async (opts?: ICreateSessionOptions) => {
             if (!walletServices.length) {
@@ -283,7 +283,7 @@ export default function WalletConnectProvider({
             setConnector(nextConnector);
             return nextConnector.connect(opts);
           },
-        } as WalletConnect,
+        } as WalletConnect),
       }
     }
     return {


### PR DESCRIPTION
Fixes #571 

Currently, when the `WalletConnect` connector is wrapped to override the `connect` function for react-native, we use an object splat to carry over the properties from the original `connector`.

However, this **does not** carry over the *prototype* for `connector`, and therefore the new `nextConnector` is missing all the functions from the original `connector`, except the newly wrapped `connect` function. I assume this worked at some point because these functions were probably in the properties (instead of the prototype) in `WalletConnect` when this library was originally written, and at some point recently that must have changed.

This should be merged ASAP, as the library is fully broken at the moment!