### PR TITLE
fix: rainbow + optimism with existing connection

### DIFF
--- a/packages/providers/ethereum-provider/src/index.ts
+++ b/packages/providers/ethereum-provider/src/index.ts
@@ -16,7 +16,7 @@ class WalletConnectProvider implements IEthereumProvider {
   constructor(opts?: IWCEthRpcConnectionOptions) {
     this.rpc = { infuraId: opts?.infuraId, custom: opts?.rpc };
     this.signer = new JsonRpcProvider(new SignerConnection(opts));
-    this.http = this.setHttpProvider(opts?.chainId || 1);
+    this.http = this.setHttpProvider(this.signer.connection.chainId || opts?.chainId || 1);
     this.registerEventListeners();
   }
 


### PR DESCRIPTION
currently rainbow doesn't work with preexisting connections if you are already connected to optimism, because it uses the mainnet rpc url if you don't specify a chain id in the constructor