### PR TITLE
Remove check that prevents linking on Android

### DIFF
--- a/packages/helpers/react-native-dapp/src/providers/WalletConnectProvider.tsx
+++ b/packages/helpers/react-native-dapp/src/providers/WalletConnectProvider.tsx
@@ -51,12 +51,6 @@ export default function WalletConnectProvider({
 
   const open = React.useCallback(async (uri: string, cb: unknown): Promise<unknown> => {
     if (Platform.OS === 'android') {
-      const canOpenURL = await Linking.canOpenURL(uri);
-      if (!canOpenURL) {
-        // Redirect the user to download a wallet.
-        Linking.openURL('https://walletconnect.org/wallets');
-        throw new Error('No wallets found.');
-      }
       await Linking.openURL(uri);
     }
     setState({


### PR DESCRIPTION
This PR removes a check that causes the app to open a web link instead of linking to a wallet app on Android, with React Native.

The problem is described in detail here
https://github.com/WalletConnect/walletconnect-monorepo/issues/588
and is experienced by other people as well: https://github.com/WalletConnect/walletconnect-monorepo/issues/563

Removing this check causes the app to simply open the link on a supported wallet app on the same device.