### PR TITLE
Ensure QR Code not shown in RN Web apps when on a mobile browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "walletconnect-monorepo",
 			"license": "LGPL-3.0",
 			"dependencies": {
 				"@babel/cli": "7.8.3",
@@ -23,6 +24,7 @@
 				"@types/qrcode": "1.3.4",
 				"@types/react": "17.0.0",
 				"@types/react-native": "0.63.45",
+				"@types/ua-parser-js": "0.7.36",
 				"@walletconnect/crypto": "^1.0.1",
 				"@walletconnect/encoding": "^1.0.0",
 				"@walletconnect/jsonrpc-http-connection": "^1.0.0",
@@ -56,6 +58,7 @@
 				"style-loader": "1.2.0",
 				"svg-url-loader": "5.0.0",
 				"ts-loader": "6.2.2",
+				"ua-parser-js": "0.7.28",
 				"use-deep-compare-effect": "1.6.1",
 				"web3": "1.3.5",
 				"web3-provider-engine": "16.0.1",
@@ -5313,6 +5316,11 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
 			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
+		},
+		"node_modules/@types/ua-parser-js": {
+			"version": "0.7.36",
+			"resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz",
+			"integrity": "sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ=="
 		},
 		"node_modules/@types/yargs": {
 			"version": "13.0.12",
@@ -31960,6 +31968,11 @@
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
 			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
 		},
+		"@types/ua-parser-js": {
+			"version": "0.7.36",
+			"resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz",
+			"integrity": "sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ=="
+		},
 		"@types/yargs": {
 			"version": "13.0.12",
 			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
@@ -41656,6 +41669,7 @@
 			"resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.59.0.tgz",
 			"integrity": "sha512-1O3wrnMq4NcPQ1asEcl9lRDn/t+F1Oef6S9WaYVIKEhg9m/EQRGVrrTVP+R6B5Eeaj3+zNKbzM8Dx/NWy1hUbQ==",
 			"requires": {
+				"@babel/core": "^7.0.0",
 				"babel-preset-fbjs": "^3.3.0",
 				"metro-babel-transformer": "0.59.0",
 				"metro-react-native-babel-preset": "0.59.0",

--- a/packages/helpers/react-native-dapp/package.json
+++ b/packages/helpers/react-native-dapp/package.json
@@ -44,7 +44,8 @@
     "keyvaluestorage": "0.7.1",
     "react-native-qrcode-svg": "6.0.6",
     "react-native-svg": "9.6.4",
-    "use-deep-compare-effect": "1.6.1"
+    "use-deep-compare-effect": "1.6.1",
+    "ua-parser-js": "0.7.28"
   },
   "devDependencies": {
     "@babel/cli": "7.8.3",
@@ -62,6 +63,7 @@
     "@types/node": "12.12.14",
     "@types/react": "17.0.0",
     "@types/react-native": "0.63.45",
+    "@types/ua-parser-js": "0.7.36",
     "npm-run-all": "4.1.5",
     "react": "16.13.1",
     "react-native": "0.63.4",

--- a/packages/helpers/react-native-dapp/src/components/QrcodeModal.tsx
+++ b/packages/helpers/react-native-dapp/src/components/QrcodeModal.tsx
@@ -9,6 +9,7 @@ import {
   useWindowDimensions,
   View,
 } from 'react-native';
+import UAParser from 'ua-parser-js';
 
 import { RenderQrcodeModalProps, WalletService } from '../types';
 
@@ -111,7 +112,18 @@ export default function QrcodeModal({
     );
   }, [modalWidth, modalHeight, division, icons, shouldConnectToWalletService]);
 
-  const shouldRenderQrcode = Platform.OS === 'web';
+
+  const shouldRenderQrcode = React.useMemo(() => {
+    if (Platform.OS === 'web' && typeof window !== 'undefined') {
+      const parser = new UAParser(window.navigator.userAgent);
+      const result = parser.getResult();
+
+      // Dont render QR Code if device is mobile or tablet
+      return !(result.device.type === 'mobile' || result.device.type === 'tablet')
+    }
+
+    return Platform.OS === 'web';
+  }, []);
 
   return (
     <Animated.View

--- a/packages/helpers/react-native-dapp/tsconfig.json
+++ b/packages/helpers/react-native-dapp/tsconfig.json
@@ -5,7 +5,7 @@
     "experimentalDecorators": true,
     "declaration": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es6", "esnext"],
+    "lib": ["es6", "esnext", "dom"],
     "module": "esnext",
     "moduleResolution": "node",
     "noImplicitAny": true,


### PR DESCRIPTION
Previously the modal would render a QR code anytime react-native was running on web even if it was running on mobile Safari / Chrome etc. This fixes it by checking if the user agent device type corresponds to a mobile or tablet device (iOS or Android).

Test Plan: Open a react-native-web app with WalletConnect on mobile Safari and ensure a grid of wallet options is shown instead of a QR Code.

### Before and After
<p float="left">
  <img src="https://user-images.githubusercontent.com/7143583/131175076-92f973c9-d9a4-46d0-92e6-5f696c96dfee.PNG" width="360" />
  <img src="https://user-images.githubusercontent.com/7143583/131175070-608e2c84-d0bf-4149-b27f-bd7ce02dbb99.PNG" width="360">
</p>
