### PR TITLE
Optional Callback when Connect Fails

### DIFF
--- a/packages/helpers/react-native-dapp/README.md
+++ b/packages/helpers/react-native-dapp/README.md
@@ -38,7 +38,7 @@ export default function App(): JSX.Element {
     <WalletConnectProvider
       redirectUrl={Platform.OS === 'web' ? window.location.origin : 'yourappscheme://'}
       storageOptions= {{
-        asyncStorage AsyncStorage,
+        asyncStorage: AsyncStorage,
       }}>
       <>{/* awesome app here */}</>
     </WalletConnectProvider>
@@ -51,6 +51,9 @@ Above, we pass the [`WalletConnectProvider`](./src/providers/WalletConnectProvid
   - The `redirectUrl` is used to help control navigation between external wallets and your application. On the `web`, you only need to specify a valid application route; whereas on mobile platforms, you must [**specify a deep link URI scheme**](https://docs.expo.io/workflow/linking/#universaldeep-links-without-a-custom-scheme).
   - The `storageOptions` prop allows you to specify the storage engine which must be used to persist session data.
     - Although in our examples we use [`@react-native-async-storage/async-storage`](https://github.com/react-native-async-storage/async-storage), this can be which engine you please, provided it conforms to the [`IAsyncStorage`](https://github.com/pedrouid/keyvaluestorage) generic storage interface declaration.
+  - The optional `onConnectFail` callback gets executed only when there are no applications installed on the device that support opening the WalletConnect link.
+    - This is due to the oberved problem on Android where `Linking.canOpenURL(url)` produces `false` for WalletConnect URIs even when there are Wallet applications installed on the device that can handle opening the link.
+    - Defaults to `(uri) => Linking.openURL("https://walletconnect.org/wallets"`.
 
 Notably, the [`WalletConnectProvider`](./src/providers/WalletConnectProvider.tsx) optionally accepts `WalletConnect` configuration arguments as defined by the [`IWalletConnectOptions`](https://github.com/WalletConnect/walletconnect-monorepo/tree/next/packages/helpers/utils) interface:
 
@@ -71,8 +74,9 @@ export default function App(): JSX.Element {
       }}
       redirectUrl={Platform.OS === 'web' ? window.location.origin : 'yourappscheme://'}
       storageOptions= {{
-        asyncStorage AsyncStorage,
-      }}>
+        asyncStorage: AsyncStorage,
+      }}
+      onConnectFail={() => Linking.openURL("https://walletconnect.org/wallets"})>
       <>{/* awesome app here */}</>
     </WalletConnectProvider>
   );
@@ -132,7 +136,7 @@ function App(): JSX.Element {
 export default withWalletConnect(App, {
   redirectUrl: Platform.OS === 'web' ? window.location.origin : 'yourappscheme://',
   storageOptions: {
-    asyncStorage AsyncStorage,
+    asyncStorage: AsyncStorage,
   },
 });
 ```
@@ -179,7 +183,7 @@ function App(): JSX.Element {
 export default withWalletConnect(App, {
   redirectUrl: Platform.OS === 'web' ? window.location.origin : 'yourappscheme://',
   storageOptions: {
-    asyncStorage AsyncStorage,
+    asyncStorage: AsyncStorage,
   },
   renderQrcodeModal: (props: RenderQrcodeModalProps): JSX.Element => (
     <CustomBottomSheet {...props} />

--- a/packages/helpers/react-native-dapp/src/contexts/WalletConnectContext.ts
+++ b/packages/helpers/react-native-dapp/src/contexts/WalletConnectContext.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Linking } from "react-native";
 
 import { WalletConnectContextValue, WalletService } from "../types";
 
@@ -13,6 +14,9 @@ const defaultValue: Partial<WalletConnectContextValue> = Object.freeze({
   storageOptions: {
     rootStorageKey: "@walletconnect/qrcode-modal-react-native",
   },
+  // By default, redirect the user to download a wallet.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onConnectFail: (uri: string) => Linking.openURL("https://walletconnect.org/wallets"),
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   connectToWalletService: async (walletService: WalletService, uri?: string) => Promise.reject(new Error(
     "[WalletConnect]: It looks like you have forgotten to wrap your application with a <WalletConnectProvider />.",

--- a/packages/helpers/react-native-dapp/src/providers/WalletConnectProvider.tsx
+++ b/packages/helpers/react-native-dapp/src/providers/WalletConnectProvider.tsx
@@ -51,12 +51,6 @@ export default function WalletConnectProvider({
 
   const open = React.useCallback(async (uri: string, cb: unknown): Promise<unknown> => {
     if (Platform.OS === 'android') {
-      const canOpenURL = await Linking.canOpenURL(uri);
-      if (!canOpenURL) {
-        // Redirect the user to download a wallet.
-        Linking.openURL('https://walletconnect.org/wallets');
-        throw new Error('No wallets found.');
-      }
       await Linking.openURL(uri);
     }
     setState({

--- a/packages/helpers/react-native-dapp/src/providers/WalletConnectProvider.tsx
+++ b/packages/helpers/react-native-dapp/src/providers/WalletConnectProvider.tsx
@@ -49,9 +49,15 @@ export default function WalletConnectProvider({
       : defaultRenderQrcodeModal
   ), [maybeRenderQrcodeModal]);
 
+  const { storageOptions, redirectUrl, onConnectFail } = intermediateValue;
+
   const open = React.useCallback(async (uri: string, cb: unknown): Promise<unknown> => {
     if (Platform.OS === 'android') {
-      await Linking.openURL(uri);
+      try {
+          await Linking.openURL(uri);
+      } catch (error) {
+          onConnectFail(uri);
+      }
     }
     setState({
       uri,
@@ -79,7 +85,7 @@ export default function WalletConnectProvider({
     close,
   }), [open, close]);
 
-  const { storageOptions, redirectUrl } = intermediateValue;
+ 
 
   const createStorage = React.useCallback((storageOptions: ReactNativeStorageOptions): KeyValueStorage => {
     return new KeyValueStorage(storageOptions);

--- a/packages/helpers/react-native-dapp/src/providers/WalletConnectProvider.tsx
+++ b/packages/helpers/react-native-dapp/src/providers/WalletConnectProvider.tsx
@@ -85,8 +85,6 @@ export default function WalletConnectProvider({
     close,
   }), [open, close]);
 
- 
-
   const createStorage = React.useCallback((storageOptions: ReactNativeStorageOptions): KeyValueStorage => {
     return new KeyValueStorage(storageOptions);
   }, []);

--- a/packages/helpers/react-native-dapp/src/types/index.ts
+++ b/packages/helpers/react-native-dapp/src/types/index.ts
@@ -51,6 +51,7 @@ export type WalletConnectStorageOptions = ReactNativeStorageOptions & {
 export type WalletConnectOptions = IWalletConnectOptions & {
   readonly redirectUrl: string;
   readonly storageOptions: Partial<WalletConnectStorageOptions>;
+  readonly onConnectFail?: (uri: string) => unknown;
 };
 
 export type ConnectToWalletServiceCallback = (walletService: WalletService, uri?: string) => Promise<void>;


### PR DESCRIPTION
# Connect Fail Fallback
> primarily for Android

This PR adds an optional callback to the Provider that gets invoked when opening the link fails.

On Android, by now many people have observed that for some reason React Native does not detect that `wc:..` links can be open by an installed app as `Linking.canOpenUrl(url)` produces `false` instead of `true` even when a registered app to open the link with is installed. With the current behavior, this leads to the library defaulting to open the Wallet Connect homepage, with the supported wallet page.

This PR gives the library user a choice to supply a custom callback that gets invoked instead.

The issue was originally raised here:
* https://github.com/WalletConnect/walletconnect-monorepo/issues/588
* https://github.com/WalletConnect/walletconnect-monorepo/pull/589

The idea for the custom callback originated here: https://github.com/WalletConnect/walletconnect-monorepo/issues/588#issuecomment-905824044