### PR TITLE
Automatic git hash

### DIFF
--- a/servers/relay/src/config/index.ts
+++ b/servers/relay/src/config/index.ts
@@ -1,7 +1,18 @@
 import { THIRTY_DAYS } from "../constants";
 import { RelayModes } from "../types";
 
-const GITHASH = process.env.GITHASH || "0000000";
+let GITHASH = process.env.GITHASH
+
+if (!GITHASH) {
+  try {
+    GITHASH = require('child_process')
+      .execSync('git rev-parse HEAD')
+      .toString().trim()
+  } catch {
+    GITHASH = "0000000"
+  }
+}
+
 const VERSION = require("../../package.json").version || "0.0.0";
 const LEVELS = ["trace", "debug", "info", "warn", "error", "fatal", "silent"];
 let logLevel = process.env.LOG_LEVEL || "info";


### PR DESCRIPTION
Hi! I added this piece of code to get the `GITHASH` from `git` if not set in env. I put the config value with more priority than the actual `git`

Ref: https://stackoverflow.com/questions/34518389/get-hash-of-most-recent-git-commit-in-node

```
GITHASH=fromenv npm start
```

<img width="334" alt="Screen Shot 2021-11-04 at 01 33 26" src="https://user-images.githubusercontent.com/36084092/140258841-4c057dbc-2f1d-4226-9489-3ceaaa686e1b.png">

```
npm start
```

<img width="544" alt="Screen Shot 2021-11-04 at 01 33 39" src="https://user-images.githubusercontent.com/36084092/140258853-a97c27f7-afef-4fe6-a65e-75d552c2c5b8.png">

