### PR TITLE
Rm query-string and use URLSearchParams

### DIFF
--- a/packages/helpers/utils/package.json
+++ b/packages/helpers/utils/package.json
@@ -67,8 +67,7 @@
     "@walletconnect/jsonrpc-utils": "^1.0.0",
     "@walletconnect/types": "^1.6.6",
     "bn.js": "4.11.8",
-    "js-sha3": "0.8.0",
-    "query-string": "6.13.5"
+    "js-sha3": "0.8.0"
   },
   "gitHead": "165f7993c2acc907c653c02847fb02721052c6e7"
 }

--- a/packages/helpers/utils/src/url.ts
+++ b/packages/helpers/utils/src/url.ts
@@ -1,5 +1,3 @@
-import * as queryStringUtils from "query-string";
-
 export function getQueryString(url: string): string {
   const pathEnd: number | undefined = url.indexOf("?") !== -1 ? url.indexOf("?") : undefined;
 
@@ -19,9 +17,10 @@ export function appendToQueryString(queryString: string, newQueryParams: any): s
 }
 
 export function parseQueryString(queryString: string): any {
-  return queryStringUtils.parse(queryString);
+  const params = new URLSearchParams(queryString);
+  return Object.fromEntries(params);
 }
 
 export function formatQueryString(queryParams: any): string {
-  return queryStringUtils.stringify(queryParams);
+  return new URLSearchParams(queryParams).toString();
 }


### PR DESCRIPTION
In the @walletconnect/client@1.6.6, query-string accounts for 4.3% of
the overall bundle size. However, client-side support for
URLSearchParams has reached mainstream and so we can just use it instead
of including more bundle-size-increasing dependencies.

- Fixes #667