### PR TITLE
fix(qrcode-modal): use `image_url` directly from registry listing API

### DIFF
--- a/packages/helpers/browser-utils/src/registry.ts
+++ b/packages/helpers/browser-utils/src/registry.ts
@@ -15,7 +15,7 @@ export function formatMobileRegistryEntry(entry: IAppEntry, platform: "mobile" |
     name: entry.name || "",
     shortName: entry.metadata.shortName || "",
     color: entry.metadata.colors.primary || "",
-    logo: entry.image_url.sm ? entry.image_url.sm : "",
+    logo: entry.image_url.sm ?? "",
     universalLink: entry[platform].universal || "",
     deepLink: entry[platform].native || "",
   };

--- a/packages/helpers/browser-utils/src/registry.ts
+++ b/packages/helpers/browser-utils/src/registry.ts
@@ -3,15 +3,11 @@ import { IMobileRegistryEntry, IAppRegistry, IAppEntry } from "@walletconnect/ty
 const API_URL = "https://registry.walletconnect.com";
 
 export function getWalletRegistryUrl(): string {
-  return API_URL + "/api/v1/wallets";
+  return API_URL + "/api/v2/wallets";
 }
 
 export function getDappRegistryUrl(): string {
-  return API_URL + "/api/v1/dapps";
-}
-
-export function getAppLogoUrl(id): string {
-  return API_URL + "/api/v1/logo/sm/" + id;
+  return API_URL + "/api/v2/dapps";
 }
 
 export function formatMobileRegistryEntry(entry: IAppEntry, platform: "mobile" | "desktop" = "mobile"): IMobileRegistryEntry {
@@ -19,7 +15,7 @@ export function formatMobileRegistryEntry(entry: IAppEntry, platform: "mobile" |
     name: entry.name || "",
     shortName: entry.metadata.shortName || "",
     color: entry.metadata.colors.primary || "",
-    logo: entry.id ? getAppLogoUrl(entry.id) : "",
+    logo: entry.image_url.sm ? entry.image_url.sm : "",
     universalLink: entry[platform].universal || "",
     deepLink: entry[platform].native || "",
   };

--- a/packages/helpers/qrcode-modal/src/browser/components/LinkDisplay.tsx
+++ b/packages/helpers/qrcode-modal/src/browser/components/LinkDisplay.tsx
@@ -97,7 +97,7 @@ function LinkDisplay(props: LinkDisplayProps) {
                 <WalletIcon
                   color={color}
                   href={href}
-                  name={shortName}
+                  name={shortName || name}
                   logo={logo}
                   onClick={handleClickIOS}
                 />

--- a/packages/helpers/types/index.d.ts
+++ b/packages/helpers/types/index.d.ts
@@ -402,6 +402,12 @@ export interface IAppEntry {
   name: string;
   homepage: string;
   chains: string[];
+  image_id: string;
+  image_url: {
+    sm: string;
+    md: string;
+    lg: string;
+  }
   app: {
     browser: string;
     ios: string;


### PR DESCRIPTION
As discussed in the team, this fix uses the `image_url` (now attached to each wallet listing in the listing API response) as the logo source to avoid unnecessary request-response latency when resolving logo assets for the modal.