### PR TITLE
fix(ethereum-provider): adds public sendAsync method to satisfy web3.js provider interface

### DIFF
--- a/packages/ethereum-provider/src/index.ts
+++ b/packages/ethereum-provider/src/index.ts
@@ -113,6 +113,15 @@ class EthereumProvider implements IEthereumProvider {
     return this.http.request(args);
   }
 
+  public sendAsync(
+    args: RequestArguments,
+    callback: (error: Error | null, response: any) => void,
+  ): void {
+    this.request(args)
+      .then(response => callback(null, response))
+      .catch(error => callback(error, undefined));
+  }
+
   get connected(): boolean {
     return (this.signer.connection as SignerConnection).connected;
   }


### PR DESCRIPTION
## Issue

When passing the v2 `EthereumProvider` to the `Web3` constructor, Typescript will currently infer the wrong internal type for the provider (`WebsocketProvider` instead of `AbstractProvider`) and error with the following:

```ts
// Argument of type 'EthereumProvider' is not assignable to parameter of type 'provider'.
// Type 'EthereumProvider' is missing the following properties from type 'WebsocketProvider': 
// isConnecting, requestQueue, responseQueue, connection, and 5 more.
const provider = new Web3(ethereumProvider);
```

This is due to the `web3` library expecting the `sendAsync` method to be defined, while `request` is seen as optional:

```ts
// web3.js 1.7.0
export interface AbstractProvider {
    sendAsync(payload: JsonRpcPayload, callback: (error: Error | null, result?: JsonRpcResponse) => void): void;
    send?(payload: JsonRpcPayload, callback: (error: Error | null, result?: JsonRpcResponse) => void): void;
    request?(args: RequestArguments): Promise<any>;
    connected?: boolean;
  }
```

This issue does not arise when passing `EthereumProvider` to `ethers`, since the interface exposed by `ethers` is fully agnostic to the implemented RPC methods:

```ts
// ethers.js
export type ExternalProvider = {
    isMetaMask?: boolean;
    isStatus?: boolean;
    host?: string;
    path?: string;
    sendAsync?: (request: { method: string, params?: Array<any> }, callback: (error: any, response: any) => void) => void
    send?: (request: { method: string, params?: Array<any> }, callback: (error: any, response: any) => void) => void
    request?: (request: { method: string, params?: Array<any> }) => Promise<any>
}
```

## Solution

By providing a thin, callback-based `sendAsync` wrapper around `EthereumProvider.request`, we can satisfy the interface expectations for the `web3` provider with minimal changes and resolve the misleading type error.