### PR TITLE
add `"tslib"` as a dependency to fix #482

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -31,8 +31,8 @@
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
   },
   "dependencies": {
-    "@walletconnect/events": "^1.0.0",
     "@walletconnect/encoding": "^1.0.0",
+    "@walletconnect/events": "^1.0.0",
     "@walletconnect/heartbeat": "^1.0.0",
     "@walletconnect/jsonrpc-provider": "^1.0.1",
     "@walletconnect/jsonrpc-utils": "^1.0.0",
@@ -43,6 +43,7 @@
     "@walletconnect/time": "^1.0.1",
     "@walletconnect/types": "^2.0.0-beta.23",
     "@walletconnect/utils": "^2.0.0-beta.23",
+    "tslib": "^2.3.1",
     "ws": "^8.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This change should resolve an issue where `import WalletConnect from '@walletconnect/client';` fails in `node`.

This pull request might also fix #482 if we merge it.

cc @DanBurton

```js
// index.mjs
import WalletConnect from '@walletconnect/client';

console.log(WalletConnect);
console.log("Hello world!");
```


This is `package.json`.
```json
{
  "dependencies": {
    "@walletconnect/client": "^1.7.3"
  }
}
```

```
$ node index.mjs 
node:internal/modules/cjs/loader:933
  const err = new Error(message);
              ^

Error: Cannot find module 'tslib'
Require stack:
- /home/hamir/repositories/walletconnect-modulenotfound-reproduce/node_modules/@walletconnect/client/dist/cjs/index.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/home/hamir/repositories/walletconnect-modulenotfound-reproduce/node_modules/@walletconnect/client/dist/cjs/index.js:3:17)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1155:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:168:29) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/hamir/repositories/walletconnect-modulenotfound-reproduce/node_modules/@walletconnect/client/dist/cjs/index.js'
  ]
}
$ npm install tslib

added 1 package, and audited 38 packages in 371ms

2 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
$ node index.mjs 
{ default: [class WalletConnect extends Connector] }
Hello world!
$ 
```