### PR TITLE
fix: get valid signature for signMessage

### DIFF
--- a/packages/providers/web3-provider/src/index.ts
+++ b/packages/providers/web3-provider/src/index.ts
@@ -389,7 +389,7 @@ class WalletConnectProvider extends ProviderEngine {
       processMessage: async (msgParams: { from: string; data: string }, cb: any) => {
         try {
           const wc = await this.getWalletConnector();
-          const result = await wc.signMessage([msgParams.from, msgParams.data]);
+          const result = await wc.signPersonalMessage([msgParams.data, msgParams.from]);
           cb(null, result);
         } catch (error) {
           cb(error);


### PR DESCRIPTION
### Issue: Can't get valid signatures for signMessage for web3-provider
Resolve this issue:
 https://github.com/WalletConnect/walletconnect-monorepo/issues/347

It will use `signPersonalMessage` when calling the `signMessage` from web3provider.