### PR TITLE
refactor(client): removes `storage` from top-level `ClientOptions`, use `@walletconnect/keyvaluestorage`

### DIFF
--- a/ops/package/Dockerfile-dev
+++ b/ops/package/Dockerfile-dev
@@ -10,8 +10,9 @@ FROM base as build
 WORKDIR /monorepo
 
 COPY ./ ./
-RUN npm install 
-RUN npm run bootstrap
+RUN npm ci
+RUN npm run bootstrap -- --ci
 RUN npm run build
 
 CMD ["node", "-v"]
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
 				"@walletconnect/jsonrpc-types": "^1.0.0",
 				"@walletconnect/jsonrpc-utils": "^1.0.0",
 				"@walletconnect/jsonrpc-ws-connection": "^1.0.0",
+				"@walletconnect/keyvaluestorage": "^1.0.0",
 				"@walletconnect/logger": "^1.0.0",
 				"@walletconnect/relay-api": "^1.0.2",
 				"@walletconnect/safe-json": "^1.0.0",
@@ -65,7 +66,6 @@
 				"ethereum-test-network": "^0.1.6",
 				"ethers": "^5.3.1",
 				"eventemitter3": "^4.0.7",
-				"keyvaluestorage": "^0.7.1",
 				"lodash.union": "^4.6.0",
 				"microbundle": "^0.11.0",
 				"mocha": "^8.2.1",
@@ -5469,6 +5469,27 @@
 				}
 			}
 		},
+		"node_modules/@walletconnect/keyvaluestorage": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.0.0.tgz",
+			"integrity": "sha512-dlIrX/pCjuXMUprkLdy0hw0Ibr3To9nCdG19mPqd/lRdRWsPItBL+79LClVplMxb0cuF3qlTuGTNx/hmUKYmWA==",
+			"dependencies": {
+				"localStorage": "^1.0.4",
+				"safe-json-utils": "^1.1.1"
+			},
+			"peerDependencies": {
+				"@react-native-async-storage/async-storage": "1.x",
+				"better-sqlite3": "7.x"
+			},
+			"peerDependenciesMeta": {
+				"@react-native-async-storage/async-storage": {
+					"optional": true
+				},
+				"better-sqlite3": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@walletconnect/logger": {
 			"version": "1.0.0",
 			"license": "MIT",
@@ -6348,6 +6369,8 @@
 			"version": "7.5.0",
 			"hasInstallScript": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"bindings": "^1.5.0",
 				"prebuild-install": "^7.0.0"
@@ -6377,6 +6400,8 @@
 		"node_modules/bindings": {
 			"version": "1.5.0",
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"file-uri-to-path": "1.0.0"
 			}
@@ -8373,6 +8398,8 @@
 		"node_modules/decompress-response": {
 			"version": "6.0.0",
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"mimic-response": "^3.1.0"
 			},
@@ -11112,7 +11139,9 @@
 		},
 		"node_modules/file-uri-to-path": {
 			"version": "1.0.0",
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/filename-regex": {
 			"version": "2.0.1",
@@ -14153,16 +14182,6 @@
 				"json-buffer": "3.0.0"
 			}
 		},
-		"node_modules/keyvaluestorage": {
-			"version": "0.7.1",
-			"license": "MIT",
-			"dependencies": {
-				"better-sqlite3": "^7.1.2",
-				"keyvaluestorage-interface": "^1.0.0",
-				"localStorage": "^1.0.4",
-				"safe-json-utils": "^1.1.1"
-			}
-		},
 		"node_modules/keyvaluestorage-interface": {
 			"version": "1.0.0",
 			"license": "MIT"
@@ -15918,6 +15937,8 @@
 		"node_modules/mimic-response": {
 			"version": "3.1.0",
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -16623,6 +16644,8 @@
 		"node_modules/node-abi": {
 			"version": "3.5.0",
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"semver": "^7.3.5"
 			},
@@ -16633,6 +16656,8 @@
 		"node_modules/node-abi/node_modules/lru-cache": {
 			"version": "6.0.0",
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
@@ -16643,6 +16668,8 @@
 		"node_modules/node-abi/node_modules/semver": {
 			"version": "7.3.5",
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -16655,7 +16682,9 @@
 		},
 		"node_modules/node-abi/node_modules/yallist": {
 			"version": "4.0.0",
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/node-addon-api": {
 			"version": "2.0.2",
@@ -19385,6 +19414,8 @@
 		"node_modules/prebuild-install": {
 			"version": "7.0.0",
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"detect-libc": "^1.0.3",
 				"expand-template": "^2.0.3",
@@ -22623,6 +22654,8 @@
 				}
 			],
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"decompress-response": "^6.0.0",
 				"once": "^1.3.1",
@@ -29806,6 +29839,15 @@
 				}
 			}
 		},
+		"@walletconnect/keyvaluestorage": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.0.0.tgz",
+			"integrity": "sha512-dlIrX/pCjuXMUprkLdy0hw0Ibr3To9nCdG19mPqd/lRdRWsPItBL+79LClVplMxb0cuF3qlTuGTNx/hmUKYmWA==",
+			"requires": {
+				"localStorage": "^1.0.4",
+				"safe-json-utils": "^1.1.1"
+			}
+		},
 		"@walletconnect/logger": {
 			"version": "1.0.0",
 			"requires": {
@@ -30403,6 +30445,8 @@
 		},
 		"better-sqlite3": {
 			"version": "7.5.0",
+			"optional": true,
+			"peer": true,
 			"requires": {
 				"bindings": "^1.5.0",
 				"prebuild-install": "^7.0.0"
@@ -30419,6 +30463,8 @@
 		},
 		"bindings": {
 			"version": "1.5.0",
+			"optional": true,
+			"peer": true,
 			"requires": {
 				"file-uri-to-path": "1.0.0"
 			}
@@ -31806,6 +31852,8 @@
 		},
 		"decompress-response": {
 			"version": "6.0.0",
+			"optional": true,
+			"peer": true,
 			"requires": {
 				"mimic-response": "^3.1.0"
 			}
@@ -33608,7 +33656,9 @@
 			}
 		},
 		"file-uri-to-path": {
-			"version": "1.0.0"
+			"version": "1.0.0",
+			"optional": true,
+			"peer": true
 		},
 		"filename-regex": {
 			"version": "2.0.1"
@@ -35571,15 +35621,6 @@
 				"json-buffer": "3.0.0"
 			}
 		},
-		"keyvaluestorage": {
-			"version": "0.7.1",
-			"requires": {
-				"better-sqlite3": "^7.1.2",
-				"keyvaluestorage-interface": "^1.0.0",
-				"localStorage": "^1.0.4",
-				"safe-json-utils": "^1.1.1"
-			}
-		},
 		"keyvaluestorage-interface": {
 			"version": "1.0.0"
 		},
@@ -36785,7 +36826,9 @@
 			"version": "1.2.0"
 		},
 		"mimic-response": {
-			"version": "3.1.0"
+			"version": "3.1.0",
+			"optional": true,
+			"peer": true
 		},
 		"min-document": {
 			"version": "2.19.0",
@@ -37260,24 +37303,32 @@
 		},
 		"node-abi": {
 			"version": "3.5.0",
+			"optional": true,
+			"peer": true,
 			"requires": {
 				"semver": "^7.3.5"
 			},
 			"dependencies": {
 				"lru-cache": {
 					"version": "6.0.0",
+					"optional": true,
+					"peer": true,
 					"requires": {
 						"yallist": "^4.0.0"
 					}
 				},
 				"semver": {
 					"version": "7.3.5",
+					"optional": true,
+					"peer": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
 				},
 				"yallist": {
-					"version": "4.0.0"
+					"version": "4.0.0",
+					"optional": true,
+					"peer": true
 				}
 			}
 		},
@@ -39151,6 +39202,8 @@
 		},
 		"prebuild-install": {
 			"version": "7.0.0",
+			"optional": true,
+			"peer": true,
 			"requires": {
 				"detect-libc": "^1.0.3",
 				"expand-template": "^2.0.3",
@@ -41380,6 +41433,8 @@
 		},
 		"simple-get": {
 			"version": "4.0.0",
+			"optional": true,
+			"peer": true,
 			"requires": {
 				"decompress-response": "^6.0.0",
 				"once": "^1.3.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -25,7 +25,7 @@
     "build:esm": "npx tsc -p tsconfig.esm.json",
     "build": "run-s build:pre build:cjs build:esm build:umd",
     "test:pre": "rm -rf ./test/test.db",
-    "test:run": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.spec.ts",
+    "test:run": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 20000 --exit -r ts-node/register ./test/**/*.spec.ts",
     "test": "run-s test:pre test:run",
     "watch": "tsc -p tsconfig.json --watch",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -37,7 +37,7 @@
     "@walletconnect/jsonrpc-provider": "^1.0.3",
     "@walletconnect/jsonrpc-utils": "^1.0.0",
     "@walletconnect/jsonrpc-ws-connection": "^1.0.0",
-    "@walletconnect/keyvaluestorage": "^0.7.1",
+    "@walletconnect/keyvaluestorage": "^1.0.0",
     "@walletconnect/logger": "^1.0.0",
     "@walletconnect/relay-api": "^1.0.2",
     "@walletconnect/safe-json": "^1.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -37,6 +37,7 @@
     "@walletconnect/jsonrpc-provider": "^1.0.3",
     "@walletconnect/jsonrpc-utils": "^1.0.0",
     "@walletconnect/jsonrpc-ws-connection": "^1.0.0",
+    "@walletconnect/keyvaluestorage": "^0.7.1",
     "@walletconnect/logger": "^1.0.0",
     "@walletconnect/relay-api": "^1.0.2",
     "@walletconnect/safe-json": "^1.0.0",

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -86,7 +86,7 @@ export class Client extends IClient {
 
     this.crypto = new Crypto(this, this.logger, opts?.keychain);
 
-    this.storage = new KeyValueStorage();
+    this.storage = new KeyValueStorage(opts?.storageOptions);
 
     this.relayUrl = formatRelayRpcUrl(
       this.protocol,

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "events";
 import pino, { Logger } from "pino";
-import KeyValueStorage, { IKeyValueStorage } from "keyvaluestorage";
+import KeyValueStorage, { IKeyValueStorage } from "@walletconnect/keyvaluestorage";
 import {
   IClient,
   ClientOptions,
@@ -32,7 +32,6 @@ import {
   CLIENT_DEFAULT,
   CLIENT_SHORT_TIMEOUT,
   CLIENT_EVENTS,
-  CLIENT_STORAGE_OPTIONS,
   PAIRING_DEFAULT_TTL,
   PAIRING_EVENTS,
   PAIRING_SIGNAL_METHOD_URI,
@@ -87,9 +86,7 @@ export class Client extends IClient {
 
     this.crypto = new Crypto(this, this.logger, opts?.keychain);
 
-    const storageOptions = { ...CLIENT_STORAGE_OPTIONS, ...opts?.storageOptions };
-
-    this.storage = opts?.storage || new KeyValueStorage(storageOptions);
+    this.storage = new KeyValueStorage();
 
     this.relayUrl = formatRelayRpcUrl(
       this.protocol,

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -42,6 +42,7 @@ import {
   SESSION_EVENTS,
   SESSION_JSONRPC,
   SESSION_SIGNAL_METHOD_PAIRING,
+  CLIENT_STORAGE_OPTIONS,
 } from "./constants";
 
 export class Client extends IClient {
@@ -86,7 +87,7 @@ export class Client extends IClient {
 
     this.crypto = new Crypto(this, this.logger, opts?.keychain);
 
-    this.storage = new KeyValueStorage(opts?.storageOptions);
+    this.storage = new KeyValueStorage({ ...CLIENT_STORAGE_OPTIONS, ...opts?.storageOptions });
 
     this.relayUrl = formatRelayRpcUrl(
       this.protocol,

--- a/packages/client/src/constants/client.ts
+++ b/packages/client/src/constants/client.ts
@@ -32,3 +32,7 @@ export const CLIENT_EVENTS = {
     sync: "session_sync",
   },
 };
+
+export const CLIENT_STORAGE_OPTIONS = {
+  database: ":memory:",
+};

--- a/packages/client/src/constants/client.ts
+++ b/packages/client/src/constants/client.ts
@@ -32,7 +32,3 @@ export const CLIENT_EVENTS = {
     sync: "session_sync",
   },
 };
-
-export const CLIENT_STORAGE_OPTIONS = {
-  database: ":memory:",
-};

--- a/packages/client/test/pairing.spec.ts
+++ b/packages/client/test/pairing.spec.ts
@@ -1,6 +1,6 @@
 import "mocha";
 import sinon from "sinon";
-import { KeyValueStorage } from "keyvaluestorage";
+import { KeyValueStorage } from "@walletconnect/keyvaluestorage";
 import { PairingTypes } from "@walletconnect/types";
 
 import {
@@ -27,9 +27,9 @@ describe("Pairing", function() {
     await clients.b.pairing.ping(topic, TEST_TIMEOUT_DURATION);
   });
   it("clients ping each other after restart", async () => {
-    const storage = new KeyValueStorage({ database: TEST_CLIENT_DATABASE });
+    const storageOptions = { database: TEST_CLIENT_DATABASE };
     // setup
-    const before = await setupClientsForTesting({ shared: { options: { storage } } });
+    const before = await setupClientsForTesting({ shared: { options: { storageOptions } } });
     // pair
     const topic = await testPairingWithoutSession(before.clients);
     // ping
@@ -38,7 +38,7 @@ describe("Pairing", function() {
     // delete
     delete before.clients;
     // restart
-    const after = await setupClientsForTesting({ shared: { options: { storage } } });
+    const after = await setupClientsForTesting({ shared: { options: { storageOptions } } });
     // ping
     await after.clients.a.pairing.ping(topic, TEST_TIMEOUT_DURATION);
     await after.clients.b.pairing.ping(topic, TEST_TIMEOUT_DURATION);

--- a/packages/client/test/pairing.spec.ts
+++ b/packages/client/test/pairing.spec.ts
@@ -1,6 +1,5 @@
 import "mocha";
 import sinon from "sinon";
-import { KeyValueStorage } from "@walletconnect/keyvaluestorage";
 import { PairingTypes } from "@walletconnect/types";
 
 import {

--- a/packages/client/test/session.spec.ts
+++ b/packages/client/test/session.spec.ts
@@ -1,6 +1,5 @@
 import "mocha";
 import sinon from "sinon";
-import { KeyValueStorage } from "@walletconnect/keyvaluestorage";
 import { SessionTypes } from "@walletconnect/types";
 import { ONE_DAY, SEVEN_DAYS, THIRTY_DAYS, fromMiliseconds } from "@walletconnect/time";
 import { ERROR, generateRandomBytes32 } from "@walletconnect/utils";

--- a/packages/client/test/session.spec.ts
+++ b/packages/client/test/session.spec.ts
@@ -1,6 +1,6 @@
 import "mocha";
 import sinon from "sinon";
-import { KeyValueStorage } from "keyvaluestorage";
+import { KeyValueStorage } from "@walletconnect/keyvaluestorage";
 import { SessionTypes } from "@walletconnect/types";
 import { ONE_DAY, SEVEN_DAYS, THIRTY_DAYS, fromMiliseconds } from "@walletconnect/time";
 import { ERROR, generateRandomBytes32 } from "@walletconnect/utils";
@@ -260,9 +260,9 @@ describe("Session", function() {
     );
   });
   it("clients ping each other after restart", async () => {
-    const storage = new KeyValueStorage({ database: TEST_CLIENT_DATABASE });
+    const storageOptions = { database: TEST_CLIENT_DATABASE };
     // setup
-    const before = await setupClientsForTesting({ shared: { options: { storage } } });
+    const before = await setupClientsForTesting({ shared: { options: { storageOptions } } });
     // connect
     const topic = await testApproveSession(before.setup, before.clients);
     // ping
@@ -271,7 +271,7 @@ describe("Session", function() {
     // delete
     delete before.clients;
     // restart
-    const after = await setupClientsForTesting({ shared: { options: { storage } } });
+    const after = await setupClientsForTesting({ shared: { options: { storageOptions } } });
     // ping
     await after.clients.a.session.ping(topic, TEST_TIMEOUT_DURATION);
     await after.clients.b.session.ping(topic, TEST_TIMEOUT_DURATION);

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -30,7 +30,7 @@
     "@walletconnect/events": "^1.0.0",
     "@walletconnect/heartbeat": "^1.0.0",
     "@walletconnect/jsonrpc-types": "^1.0.0",
-    "keyvaluestorage": "^0.7.1",
+    "@walletconnect/keyvaluestorage": "^0.7.1",
     "pino": "^6.7.0",
     "pino-pretty": "^4.3.0"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -30,7 +30,7 @@
     "@walletconnect/events": "^1.0.0",
     "@walletconnect/heartbeat": "^1.0.0",
     "@walletconnect/jsonrpc-types": "^1.0.0",
-    "@walletconnect/keyvaluestorage": "^0.7.1",
+    "@walletconnect/keyvaluestorage": "^1.0.0",
     "pino": "^6.7.0",
     "pino-pretty": "^4.3.0"
   },

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -1,5 +1,5 @@
 import { Logger } from "pino";
-import { IKeyValueStorage } from "@walletconnect/keyvaluestorage";
+import { IKeyValueStorage, KeyValueStorageOptions } from "@walletconnect/keyvaluestorage";
 import { IEvents } from "@walletconnect/events";
 import { IHeartBeat } from "@walletconnect/heartbeat";
 import { JsonRpcResponse } from "@walletconnect/jsonrpc-types";
@@ -18,6 +18,7 @@ export interface ClientOptions {
   relayUrl?: string;
   logger?: string | Logger;
   keychain?: IKeyChain;
+  storageOptions?: KeyValueStorageOptions;
 }
 
 export abstract class IClient extends IEvents {

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -1,5 +1,5 @@
 import { Logger } from "pino";
-import { IKeyValueStorage, KeyValueStorageOptions } from "keyvaluestorage";
+import { IKeyValueStorage } from "@walletconnect/keyvaluestorage";
 import { IEvents } from "@walletconnect/events";
 import { IHeartBeat } from "@walletconnect/heartbeat";
 import { JsonRpcResponse } from "@walletconnect/jsonrpc-types";
@@ -18,8 +18,6 @@ export interface ClientOptions {
   relayUrl?: string;
   logger?: string | Logger;
   keychain?: IKeyChain;
-  storage?: IKeyValueStorage;
-  storageOptions?: KeyValueStorageOptions;
 }
 
 export abstract class IClient extends IEvents {


### PR DESCRIPTION
Part of:
- #937 

Depends on:

- [x] https://github.com/WalletConnect/walletconnect-utils/pull/13
- [x] Publishing a version of `@walletconnect/keyvaluestorage` to NPM


### Key changes

- Replace external `keyvaluestorage` pkg with new `@walletconnect/keyvaluestorage@1.0.0`
- Removes `storage` from top-level `ClientOptions` interface
- Updates tests
- Fixes CI by using `npm run bootstrap -- --ci` in the dockerfile, to ensure we install optional peerDeps on CI runs