### PR TITLE
feat: Adds QuickNode support to `getRpcUrl`

### DIFF
--- a/packages/ethereum-provider/src/index.ts
+++ b/packages/ethereum-provider/src/index.ts
@@ -20,7 +20,7 @@ export const signerMethods = [
   "personal_sign",
 ];
 
-export const infuraNetworks = {
+export const networks = {
   1: "mainnet",
   3: "ropsten",
   4: "rinkeby",
@@ -35,8 +35,14 @@ export const providerEvents = {
   },
 };
 
+export interface QuickNodeConfig {
+  token: string;
+  subdomain: string;
+}
+
 export interface EthereumRpcConfig {
   infuraId?: string;
+  quicknodeConfig?: QuickNodeConfig;
   custom?: {
     [chainId: number]: string;
   };
@@ -44,20 +50,36 @@ export interface EthereumRpcConfig {
 
 export function getInfuraRpcUrl(chainId: number, infuraId?: string): string | undefined {
   let rpcUrl: string | undefined;
-  const network = infuraNetworks[chainId];
+  const network = networks[chainId];
   if (network) {
     rpcUrl = `https://${network}.infura.io/v3/${infuraId}`;
   }
   return rpcUrl;
 }
 
+export function getQuickNodeRpcUrl(
+  chainId: number,
+  quickNodeConfig: QuickNodeConfig,
+): string | undefined {
+  let rpcUrl: string | undefined;
+  const network = networks[chainId];
+  const { token, subdomain } = quickNodeConfig;
+  if (network && network !== "mainnet") {
+    rpcUrl = `https://${subdomain}.${network}.quiknode.pro/${token}/`;
+  } else if (network) {
+    rpcUrl = `https://${subdomain}.quiknode.pro/${token}/`;
+  }
+  return rpcUrl;
+}
+
 export function getRpcUrl(chainId: number, rpc?: EthereumRpcConfig): string | undefined {
   let rpcUrl: string | undefined;
-  const infuraUrl = getInfuraRpcUrl(chainId, rpc?.infuraId);
   if (rpc && rpc.custom) {
     rpcUrl = rpc.custom[chainId];
-  } else if (infuraUrl) {
-    rpcUrl = infuraUrl;
+  } else if (rpc?.quicknodeConfig) {
+    rpcUrl = getQuickNodeRpcUrl(chainId, rpc?.quicknodeConfig);
+  } else if (rpc?.infuraId) {
+    rpcUrl = getInfuraRpcUrl(chainId, rpc?.infuraId);
   }
   return rpcUrl;
 }

--- a/packages/ethereum-provider/test/index.spec.ts
+++ b/packages/ethereum-provider/test/index.spec.ts
@@ -12,7 +12,7 @@ import {
 
 import { WalletClient } from "./shared";
 
-import EthereumProvider from "../src";
+import EthereumProvider, { getRpcUrl } from "../src";
 
 const CHAIN_ID = 123;
 const PORT = 8545;
@@ -80,6 +80,33 @@ const TEST_ETH_TRANSFER = {
   value: utils.parseEther("1").toHexString(),
   data: "0x",
 };
+
+describe("getRpcUrl", function() {
+  it("getRpcUrl with quicknode config and mainnet", function() {
+    const rpcUrl = getRpcUrl(1, {
+      quicknodeConfig: { subdomain: "lost-blue-arc", token: "something-secret" },
+    });
+    expect(rpcUrl).to.eql("https://lost-blue-arc.quiknode.pro/something-secret/");
+  });
+  it("getRpcUrl with quicknode config and kovan", function() {
+    const rpcUrl = getRpcUrl(42, {
+      quicknodeConfig: { subdomain: "lost-blue-arc", token: "something-secret" },
+    });
+    expect(rpcUrl).to.eql("https://lost-blue-arc.kovan.quiknode.pro/something-secret/");
+  });
+  it("getRpcUrl with infura id", function() {
+    const rpcUrl = getRpcUrl(1, {
+      infuraId: "12345",
+    });
+    expect(rpcUrl).to.eql("https://mainnet.infura.io/v3/12345");
+  });
+  it("getRpcUrl with custom url", function() {
+    const rpcUrl = getRpcUrl(1, {
+      custom: { 1: "https://custom.url" },
+    });
+    expect(rpcUrl).to.eql("https://custom.url");
+  });
+});
 
 describe("EthereumProvider", function() {
   this.timeout(30_000);


### PR DESCRIPTION
## Summary

* Rename `infuraNetworks` to `networks`
* Create `QuickNodeConfig`
* Create `getQuickNodeRpcUrl`
* Use QuickNode URL if `quicknodeConfig` is set, otherwise use Infura URL if `infuraId` is set
* Wrote some unit tests