### PR TITLE
Changed check for RPC JSON response success [v1.0]

### DIFF
--- a/packages/clients/core/src/index.ts
+++ b/packages/clients/core/src/index.ts
@@ -1003,7 +1003,7 @@ class Connector implements IConnector {
         this._handleSessionResponse(error.message);
         return;
       }
-      if (payload.result) {
+      if (isJsonRpcResponseSuccess(payload)) {
         this._handleSessionResponse(errorMsg, payload.result);
       } else if (payload.error && payload.error.message) {
         this._handleSessionResponse(payload.error.message);
@@ -1020,7 +1020,7 @@ class Connector implements IConnector {
           reject(error);
           return;
         }
-        if (payload.result) {
+        if (isJsonRpcResponseSuccess(payload)) {
           resolve(payload.result);
         } else if (payload.error && payload.error.message) {
           reject(new Error(payload.error.message));


### PR DESCRIPTION

Fixes  #930

According to[ RPC JSON format 2.0 ](https://www.jsonrpc.org/specification#response_object)

```
This member MUST NOT exist if there was an error invoking the method.
```

The condition `if(payload.result)` would fail if the result is `null` which is true for many success cases.

for example for [wallet_switchEthereumChain](https://docs.metamask.io/guide/rpc-api.html#wallet-switchethereumchain)



