### PR TITLE
fix(engine): handles unknown topic scenario for `Engine.ping`, reenables tests

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -25,7 +25,7 @@
     "build:esm": "npx tsc -p tsconfig.esm.json",
     "build": "run-s build:pre build:cjs build:esm build:umd",
     "test:pre": "rm -rf ./test/test.db",
-    "test:run": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 20000 --exit -r ts-node/register ./test/**/*.spec.ts",
+    "test:run": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 10000 --exit -r ts-node/register ./test/**/*.spec.ts",
     "test": "run-s test:pre test:run",
     "watch": "tsc -p tsconfig.json --watch",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -261,6 +261,12 @@ export class Engine extends IEngine {
         else resolve();
       });
       await done();
+    } else {
+      const error = ERROR.NO_MATCHING_TOPIC.format({
+        context: "pairing or session",
+        topic,
+      });
+      throw new Error(error.message);
     }
   };
 

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -96,9 +96,7 @@ describe("Client", () => {
         } = await testConnectMethod(clients);
         await clients.B.ping({ topic });
       });
-      // FIXME: Bug: This is failing because session topics are being restored to `client.pairing`.
-      // Restoring session topics works (see equivalent test below).
-      it.skip("clients can ping each other after restart", async () => {
+      it("clients can ping each other after restart", async () => {
         const beforeClients = await initTwoClients({
           storageOptions: { database: TEST_CLIENT_DATABASE },
         });

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -42,11 +42,10 @@ describe("Client", () => {
         await expect(clients.A.pairing.get(topic)).to.eventually.be.rejectedWith(
           `No matching pairing with topic: ${topic}`,
         );
-        // FIXME: engine.ping is not handling this base case currently, this doesn't throw/reject.
-        // const promise = clients.A.ping({ topic });
-        // await expect(promise).to.eventually.be.rejectedWith(
-        //   `No matching pairing with topic: ${topic}`,
-        // );
+        const promise = clients.A.ping({ topic });
+        await expect(promise).to.eventually.be.rejectedWith(
+          `No matching pairing or session with topic: ${topic}`,
+        );
       });
     });
     describe("session", () => {
@@ -60,22 +59,20 @@ describe("Client", () => {
         await expect(clients.A.session.get(topic)).to.eventually.be.rejectedWith(
           `No matching session with topic: ${topic}`,
         );
-        // FIXME: engine.ping is not handling this base case currently, this doesn't throw/reject.
-        // const promise = clients.A.ping({ topic });
-        // await expect(promise).to.eventually.be.rejectedWith(
-        //   `No matching session settled with topic: ${topic}`,
-        // );
+        const promise = clients.A.ping({ topic });
+        await expect(promise).to.eventually.be.rejectedWith(
+          `No matching pairing or session with topic: ${topic}`,
+        );
       });
     });
   });
 
   describe("ping", () => {
-    // FIXME: engine.ping is not handling this base case currently, this doesn't throw/reject.
-    it.skip("throws if the topic is not a known pairing or session topic", async () => {
+    it("throws if the topic is not a known pairing or session topic", async () => {
       const clients = await initTwoClients();
       const fakeTopic = "nonsense";
       await expect(clients.A.ping({ topic: fakeTopic })).to.eventually.be.rejectedWith(
-        `No matching session with topic: ${fakeTopic}`,
+        `No matching pairing or session with topic: ${fakeTopic}`,
       );
     });
     describe("pairing", () => {

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -1,7 +1,13 @@
 import { ERROR } from "@walletconnect/utils";
 import "mocha";
 import Client from "../src";
-import { expect, initTwoClients, testConnectMethod, TEST_CLIENT_OPTIONS } from "./shared";
+import {
+  expect,
+  initTwoClients,
+  testConnectMethod,
+  TEST_CLIENT_DATABASE,
+  TEST_CLIENT_OPTIONS,
+} from "./shared";
 
 describe("Client", () => {
   it("init", async () => {
@@ -90,9 +96,12 @@ describe("Client", () => {
         } = await testConnectMethod(clients);
         await clients.B.ping({ topic });
       });
-      // TODO: this test requires `engine.ping` to handle unknown topics to avoid false positives.
-      it.skip("clients ping each other after restart", async () => {
-        const beforeClients = await initTwoClients();
+      // FIXME: Bug: This is failing because session topics are being restored to `client.pairing`.
+      // Restoring session topics works (see equivalent test below).
+      it.skip("clients can ping each other after restart", async () => {
+        const beforeClients = await initTwoClients({
+          storageOptions: { database: TEST_CLIENT_DATABASE },
+        });
         const {
           pairingA: { topic },
         } = await testConnectMethod(beforeClients);
@@ -103,7 +112,9 @@ describe("Client", () => {
         delete beforeClients.A;
         delete beforeClients.B;
         // restart
-        const afterClients = await initTwoClients();
+        const afterClients = await initTwoClients({
+          storageOptions: { database: TEST_CLIENT_DATABASE },
+        });
         // ping
         await afterClients.A.ping({ topic });
         await afterClients.A.ping({ topic });
@@ -124,9 +135,10 @@ describe("Client", () => {
         } = await testConnectMethod(clients);
         await clients.B.ping({ topic });
       });
-      // TODO: this test requires `engine.ping` to handle unknown topics to avoid false positives.
-      it.skip("clients ping each other after restart", async () => {
-        const beforeClients = await initTwoClients();
+      it("clients can ping each other after restart", async () => {
+        const beforeClients = await initTwoClients({
+          storageOptions: { database: TEST_CLIENT_DATABASE },
+        });
         const {
           sessionA: { topic },
         } = await testConnectMethod(beforeClients);
@@ -137,7 +149,9 @@ describe("Client", () => {
         delete beforeClients.A;
         delete beforeClients.B;
         // restart
-        const afterClients = await initTwoClients();
+        const afterClients = await initTwoClients({
+          storageOptions: { database: TEST_CLIENT_DATABASE },
+        });
         // ping
         await afterClients.A.ping({ topic });
         await afterClients.A.ping({ topic });

--- a/packages/client/test/shared/init.ts
+++ b/packages/client/test/shared/init.ts
@@ -1,3 +1,4 @@
+import { ClientTypes } from "@walletconnect/types";
 import "mocha";
 // import { expect } from "chai";
 
@@ -10,8 +11,8 @@ export interface Clients {
   B: Client;
 }
 
-export async function initTwoClients() {
-  const A = await Client.init(TEST_CLIENT_OPTIONS_A);
-  const B = await Client.init(TEST_CLIENT_OPTIONS_B);
+export async function initTwoClients(clientOpts: ClientTypes.Options = {}) {
+  const A = await Client.init({ ...TEST_CLIENT_OPTIONS_A, ...clientOpts });
+  const B = await Client.init({ ...TEST_CLIENT_OPTIONS_B, ...clientOpts });
   return { A, B };
 }

--- a/packages/client/test/shared/values.ts
+++ b/packages/client/test/shared/values.ts
@@ -1,4 +1,8 @@
+import path from "path";
 import { ClientTypes, RelayerTypes } from "@walletconnect/types";
+
+// @ts-ignore
+import { ROOT_DIR } from "../../../../ops/js/shared";
 
 export const TEST_RELAY_URL = process.env.TEST_RELAY_URL
   ? process.env.TEST_RELAY_URL
@@ -16,6 +20,8 @@ export const TEST_CLIENT_OPTIONS: ClientTypes.Options = {
     database: ":memory:",
   },
 };
+
+export const TEST_CLIENT_DATABASE = path.join(ROOT_DIR, "packages", "client", "test", "test.db");
 
 export const TEST_CLIENT_NAME_A = "client_a";
 export const TEST_APP_METADATA_A: ClientTypes.Metadata = {


### PR DESCRIPTION
- Added standard error handling for the unknown topic case in `Engine.ping`
- Re-enabled relevant tests since the issue of false positives/passes is now removed.
- Expanded `initTwoClients` test util fn to accept `ClientOptions` overrides
- Found an issue around restoring to `this.client.pairing` from persistence, updated the relevant comment in the tests