### PR TITLE
refactor(controllers): use `this.name` to form `storageKey` suffix

### DIFF
--- a/packages/client/src/controllers/expirer.ts
+++ b/packages/client/src/controllers/expirer.ts
@@ -2,7 +2,7 @@ import { HEARTBEAT_EVENTS } from "@walletconnect/heartbeat";
 import { generateChildLogger, getLoggerContext } from "@walletconnect/logger";
 import { toMiliseconds } from "@walletconnect/time";
 import { ExpirerTypes, ICore, IExpirer } from "@walletconnect/types";
-import { ERROR, formatStorageKeyName } from "@walletconnect/utils";
+import { ERROR } from "@walletconnect/utils";
 import { EventEmitter } from "events";
 import { Logger } from "pino";
 import { EXPIRER_CONTEXT, EXPIRER_EVENTS, EXPIRER_STORAGE_VERSION } from "../constants";
@@ -30,7 +30,7 @@ export class Expirer extends IExpirer {
   }
 
   get storageKey(): string {
-    return this.core.storagePrefix + this.version + "//" + formatStorageKeyName(this.context);
+    return this.core.storagePrefix + this.version + "//" + this.name;
   }
 
   get length(): number {

--- a/packages/client/src/controllers/history.ts
+++ b/packages/client/src/controllers/history.ts
@@ -1,7 +1,7 @@
 import { formatJsonRpcRequest, isJsonRpcError } from "@walletconnect/jsonrpc-utils";
 import { generateChildLogger, getLoggerContext } from "@walletconnect/logger";
 import { IJsonRpcHistory, JsonRpcRecord, RequestEvent, ICore } from "@walletconnect/types";
-import { ERROR, formatStorageKeyName } from "@walletconnect/utils";
+import { ERROR } from "@walletconnect/utils";
 import { EventEmitter } from "events";
 import { Logger } from "pino";
 import { HISTORY_CONTEXT, HISTORY_EVENTS, HISTORY_STORAGE_VERSION } from "../constants";
@@ -29,7 +29,7 @@ export class JsonRpcHistory extends IJsonRpcHistory {
   }
 
   get storageKey(): string {
-    return this.core.storagePrefix + this.version + "//" + formatStorageKeyName(this.context);
+    return this.core.storagePrefix + this.version + "//" + this.name;
   }
 
   get size(): number {

--- a/packages/core/src/controllers/keychain.ts
+++ b/packages/core/src/controllers/keychain.ts
@@ -1,7 +1,7 @@
 import { Logger } from "pino";
 import { generateChildLogger, getLoggerContext } from "@walletconnect/logger";
 import { ICore, IKeyChain } from "@walletconnect/types";
-import { ERROR, formatStorageKeyName, mapToObj, objToMap } from "@walletconnect/utils";
+import { ERROR, mapToObj, objToMap } from "@walletconnect/utils";
 
 import { KEYCHAIN_CONTEXT, KEYCHAIN_STORAGE_VERSION } from "../constants";
 
@@ -22,7 +22,7 @@ export class KeyChain implements IKeyChain {
   }
 
   get storageKey() {
-    return this.core.storagePrefix + this.version + "//" + formatStorageKeyName(this.context);
+    return this.core.storagePrefix + this.version + "//" + this.name;
   }
 
   public init: IKeyChain["init"] = async () => {

--- a/packages/core/src/controllers/messages.ts
+++ b/packages/core/src/controllers/messages.ts
@@ -1,6 +1,6 @@
 import { generateChildLogger, getLoggerContext } from "@walletconnect/logger";
 import { ICore, IMessageTracker, MessageRecord } from "@walletconnect/types";
-import { formatStorageKeyName, hashMessage, mapToObj, objToMap } from "@walletconnect/utils";
+import { hashMessage, mapToObj, objToMap } from "@walletconnect/utils";
 import { Logger } from "pino";
 import { MESSAGES_CONTEXT, MESSAGES_STORAGE_VERSION } from "../constants";
 
@@ -22,7 +22,7 @@ export class MessageTracker extends IMessageTracker {
   }
 
   get storageKey(): string {
-    return this.core.storagePrefix + this.version + "//" + formatStorageKeyName(this.context);
+    return this.core.storagePrefix + this.version + "//" + this.name;
   }
 
   public init: IMessageTracker["init"] = async () => {

--- a/packages/core/src/controllers/store.ts
+++ b/packages/core/src/controllers/store.ts
@@ -1,11 +1,6 @@
 import { generateChildLogger, getLoggerContext } from "@walletconnect/logger";
 import { ICore, IStore, PairingTypes, ProposalTypes, SessionTypes } from "@walletconnect/types";
-import {
-  ERROR,
-  formatStorageKeyName,
-  isProposalStruct,
-  isSessionStruct,
-} from "@walletconnect/utils";
+import { ERROR, isProposalStruct, isSessionStruct } from "@walletconnect/utils";
 import { Logger } from "pino";
 import { STORE_STORAGE_VERSION } from "../constants";
 
@@ -33,7 +28,7 @@ export class Store<Key, Data extends StoreStruct> extends IStore<Key, Data> {
   }
 
   get storageKey(): string {
-    return this.core.storagePrefix + this.version + "//" + formatStorageKeyName(this.context);
+    return this.core.storagePrefix + this.version + "//" + this.name;
   }
 
   get length(): number {

--- a/packages/core/src/controllers/subscriber.ts
+++ b/packages/core/src/controllers/subscriber.ts
@@ -11,12 +11,7 @@ import {
   SubscriberEvents,
   SubscriberTypes,
 } from "@walletconnect/types";
-import {
-  ERROR,
-  formatStorageKeyName,
-  getRelayProtocolApi,
-  getRelayProtocolName,
-} from "@walletconnect/utils";
+import { ERROR, getRelayProtocolApi, getRelayProtocolName } from "@walletconnect/utils";
 
 import {
   RELAYER_PROVIDER_EVENTS,
@@ -58,9 +53,7 @@ export class Subscriber extends ISubscriber {
   }
 
   get storageKey(): string {
-    return (
-      this.relayer.core.storagePrefix + this.version + "//" + formatStorageKeyName(this.context)
-    );
+    return this.relayer.core.storagePrefix + this.version + "//" + this.name;
   }
 
   get length(): number {

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -119,10 +119,6 @@ export function formatMessageContext(context: string): string {
   return parseContextNames(context).join(EMPTY_SPACE);
 }
 
-export function formatStorageKeyName(context: string): string {
-  return parseContextNames(context).join(COLON);
-}
-
 // -- array ------------------------------------------------- //
 
 export function hasOverlap(a: any[], b: any[]): boolean {


### PR DESCRIPTION
Also:
- chore(utils): removes now unused `formatStorageKeyName`

Since the keys are no longer based on parent context, this changes the storage key suffix in the following ways:

```
crypto:keychain -> keychain
relayer:messages -> messages
relayer:subscription -> subscription
...
```