### PR TITLE
test(core): sets up test suites for core controllers

### DIFF
--- a/packages/core/test/core.spec.ts
+++ b/packages/core/test/core.spec.ts
@@ -1,14 +1,10 @@
 import "mocha";
 import sinon from "sinon";
 
-import Core, { CORE_CONTEXT, CORE_PROTOCOL, CORE_VERSION } from "../src";
+import Core from "../src";
 import { expect, TEST_CORE_OPTIONS } from "./shared";
 
 describe("Core", () => {
-  it("provides the expected `storagePrefix` format", () => {
-    const core = new Core(TEST_CORE_OPTIONS);
-    expect(core.storagePrefix).to.equal(`${CORE_PROTOCOL}@${CORE_VERSION}:${CORE_CONTEXT}:`);
-  });
   it("does not duplicate initilization if `Core.start()` is called repeatedly", async () => {
     const core = new Core(TEST_CORE_OPTIONS);
     const initSpy = sinon.spy();

--- a/packages/core/test/core.spec.ts
+++ b/packages/core/test/core.spec.ts
@@ -7,11 +7,17 @@ import { expect, TEST_CORE_OPTIONS } from "./shared";
 describe("Core", () => {
   it("does not duplicate initilization if `Core.start()` is called repeatedly", async () => {
     const core = new Core(TEST_CORE_OPTIONS);
-    const initSpy = sinon.spy();
-    // Spy on `crypto.init` as a proxy to the private `Core.initialize`.
-    core.crypto.init = initSpy;
+    const cryptoInitSpy = sinon.spy();
+    const relayerInitSpy = sinon.spy();
+    const heartbeatInitSpy = sinon.spy();
+    // Spy on subcontroller `init` as a proxy to the private `Core.initialize`.
+    core.crypto.init = cryptoInitSpy;
+    core.relayer.init = relayerInitSpy;
+    core.heartbeat.init = heartbeatInitSpy;
     await core.start();
     await core.start();
-    expect(initSpy.callCount).to.equal(1);
+    expect(cryptoInitSpy.callCount).to.equal(1);
+    expect(relayerInitSpy.callCount).to.equal(1);
+    expect(heartbeatInitSpy.callCount).to.equal(1);
   });
 });

--- a/packages/core/test/core.spec.ts
+++ b/packages/core/test/core.spec.ts
@@ -1,9 +1,21 @@
 import "mocha";
+import sinon from "sinon";
 
-// import Core from "../src";
+import Core, { CORE_CONTEXT, CORE_PROTOCOL, CORE_VERSION } from "../src";
+import { expect, TEST_CORE_OPTIONS } from "./shared";
 
 describe("Core", () => {
-  it("needs tests", async () => {
-    // needs tests
+  it("provides the expected `storagePrefix` format", () => {
+    const core = new Core(TEST_CORE_OPTIONS);
+    expect(core.storagePrefix).to.equal(`${CORE_PROTOCOL}@${CORE_VERSION}:${CORE_CONTEXT}:`);
+  });
+  it("does not duplicate initilization if `Core.start()` is called repeatedly", async () => {
+    const core = new Core(TEST_CORE_OPTIONS);
+    const initSpy = sinon.spy();
+    // Spy on `crypto.init` as a proxy to the private `Core.initialize`.
+    core.crypto.init = initSpy;
+    await core.start();
+    await core.start();
+    expect(initSpy.callCount).to.equal(1);
   });
 });

--- a/packages/core/test/keychain.spec.ts
+++ b/packages/core/test/keychain.spec.ts
@@ -1,0 +1,31 @@
+import "mocha";
+import { getDefaultLoggerOptions } from "@walletconnect/logger";
+import pino from "pino";
+
+import {
+  Core,
+  CORE_DEFAULT,
+  CORE_STORAGE_PREFIX,
+  KeyChain,
+  KEYCHAIN_CONTEXT,
+  KEYCHAIN_STORAGE_VERSION,
+} from "../src";
+import { expect, TEST_CORE_OPTIONS } from "./shared";
+import { ICore } from "@walletconnect/types";
+
+describe("Keychain", () => {
+  const logger = pino(getDefaultLoggerOptions({ level: CORE_DEFAULT.logger }));
+
+  let core: ICore;
+
+  beforeEach(() => {
+    core = new Core(TEST_CORE_OPTIONS);
+  });
+
+  it("provides the expected `storageKey` format", () => {
+    const keychain = new KeyChain(core, logger);
+    expect(keychain.storageKey).to.equal(
+      CORE_STORAGE_PREFIX + KEYCHAIN_STORAGE_VERSION + "//" + KEYCHAIN_CONTEXT,
+    );
+  });
+});

--- a/packages/core/test/keychain.spec.ts
+++ b/packages/core/test/keychain.spec.ts
@@ -11,16 +11,10 @@ import {
   KEYCHAIN_STORAGE_VERSION,
 } from "../src";
 import { expect, TEST_CORE_OPTIONS } from "./shared";
-import { ICore } from "@walletconnect/types";
 
 describe("Keychain", () => {
   const logger = pino(getDefaultLoggerOptions({ level: CORE_DEFAULT.logger }));
-
-  let core: ICore;
-
-  beforeEach(() => {
-    core = new Core(TEST_CORE_OPTIONS);
-  });
+  const core = new Core(TEST_CORE_OPTIONS);
 
   it("provides the expected `storageKey` format", () => {
     const keychain = new KeyChain(core, logger);

--- a/packages/core/test/messages.spec.ts
+++ b/packages/core/test/messages.spec.ts
@@ -1,0 +1,31 @@
+import "mocha";
+import { getDefaultLoggerOptions } from "@walletconnect/logger";
+import pino from "pino";
+
+import {
+  Core,
+  CORE_DEFAULT,
+  CORE_STORAGE_PREFIX,
+  MESSAGES_CONTEXT,
+  MESSAGES_STORAGE_VERSION,
+  MessageTracker,
+} from "../src";
+import { expect, TEST_CORE_OPTIONS } from "./shared";
+import { ICore } from "@walletconnect/types";
+
+describe("Messages", () => {
+  const logger = pino(getDefaultLoggerOptions({ level: CORE_DEFAULT.logger }));
+
+  let core: ICore;
+
+  beforeEach(() => {
+    core = new Core(TEST_CORE_OPTIONS);
+  });
+
+  it("provides the expected `storageKey` format", () => {
+    const messages = new MessageTracker(logger, core);
+    expect(messages.storageKey).to.equal(
+      CORE_STORAGE_PREFIX + MESSAGES_STORAGE_VERSION + "//" + MESSAGES_CONTEXT,
+    );
+  });
+});

--- a/packages/core/test/publisher.spec.ts
+++ b/packages/core/test/publisher.spec.ts
@@ -1,0 +1,87 @@
+import "mocha";
+import pino from "pino";
+import Sinon from "sinon";
+import { getDefaultLoggerOptions } from "@walletconnect/logger";
+import { IRelayer } from "@walletconnect/types";
+import { generateRandomBytes32, hashMessage } from "@walletconnect/utils";
+import { Publisher } from "../src/controllers/publisher";
+import { HEARTBEAT_EVENTS } from "@walletconnect/heartbeat";
+
+import { Core, CORE_DEFAULT, PUBLISHER_DEFAULT_TTL, Relayer } from "../src";
+import { expect, TEST_CORE_OPTIONS } from "./shared";
+
+describe("Publisher", () => {
+  const logger = pino(getDefaultLoggerOptions({ level: CORE_DEFAULT.logger }));
+
+  let relayer: IRelayer;
+  let publisher: Publisher;
+
+  beforeEach(() => {
+    const core = new Core(TEST_CORE_OPTIONS);
+    relayer = new Relayer({ core, logger });
+    publisher = new Publisher(relayer, logger);
+  });
+
+  describe("init", () => {
+    it("registers event listeners", () => {
+      const opts = { ttl: 1, prompt: true, relay: { protocol: "waku" } };
+      const itemA = { topic: generateRandomBytes32(), message: "itemA", opts };
+      const itemB = { topic: generateRandomBytes32(), message: "itemB", opts };
+      const requestSpy = Sinon.spy();
+      publisher.relayer.provider.request = requestSpy;
+      // Manually set some items in the queue.
+      publisher.queue.set(hashMessage(itemA.message), itemA);
+      publisher.queue.set(hashMessage(itemB.message), itemB);
+      expect(publisher.queue.size).to.equal(2);
+      // Emit heartbeat pulse event
+      publisher.relayer.core.heartbeat.events.emit(HEARTBEAT_EVENTS.pulse);
+      // Using a timeout here, cannot `await` the private `rpcSubscribe` method.
+      setTimeout(() => {
+        // -> Queue should clear if pulse event is being listened for.
+        expect(publisher.queue.size).to.equal(0);
+        expect(requestSpy.callCount).to.equal(2);
+      }, 500);
+    });
+  });
+
+  describe("publish", () => {
+    let topic: string;
+    let requestSpy: Sinon.SinonSpy;
+
+    beforeEach(() => {
+      requestSpy = Sinon.spy();
+      topic = generateRandomBytes32();
+      publisher.relayer.provider.request = requestSpy;
+    });
+
+    it("calls `provider.request` with the expected request shape", async () => {
+      const message = "test message";
+      await publisher.publish(topic, message);
+      expect(requestSpy.callCount).to.equal(1);
+      expect(requestSpy.getCall(0).args[0]).to.deep.equal({
+        method: "waku_publish",
+        params: {
+          topic,
+          message,
+          prompt: false,
+          ttl: PUBLISHER_DEFAULT_TTL,
+        },
+      });
+    });
+    it("allows overriding of defaults via `opts` param", async () => {
+      const message = "test message";
+      const opts = { ttl: 1, prompt: true, relay: { protocol: "waku" } };
+      await publisher.publish(topic, message, opts);
+      expect(requestSpy.callCount).to.equal(1);
+      expect(requestSpy.getCall(0).args[0]).to.deep.equal({
+        method: "waku_publish",
+        params: {
+          topic,
+          message,
+          prompt: opts.prompt,
+          ttl: opts.ttl,
+        },
+      });
+    });
+  });
+});

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -15,7 +15,6 @@ import { ICore, IRelayer } from "@walletconnect/types";
 import Sinon from "sinon";
 import { JsonRpcRequest } from "@walletconnect/jsonrpc-utils";
 
-// TODO: Test persistence behavior
 describe("Relayer", () => {
   const logger = pino(getDefaultLoggerOptions({ level: CORE_DEFAULT.logger }));
 

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -1,0 +1,139 @@
+import "mocha";
+import { getDefaultLoggerOptions } from "@walletconnect/logger";
+import pino from "pino";
+
+import {
+  Core,
+  CORE_DEFAULT,
+  Relayer,
+  RELAYER_EVENTS,
+  RELAYER_PROVIDER_EVENTS,
+  RELAYER_SUBSCRIBER_SUFFIX,
+} from "../src";
+import { expect, TEST_CORE_OPTIONS } from "./shared";
+import { ICore, IRelayer } from "@walletconnect/types";
+import Sinon from "sinon";
+import { JsonRpcRequest } from "@walletconnect/jsonrpc-utils";
+
+// TODO: Test persistence behavior
+describe("Relayer", () => {
+  const logger = pino(getDefaultLoggerOptions({ level: CORE_DEFAULT.logger }));
+
+  let core: ICore;
+  let relayer: IRelayer;
+
+  beforeEach(() => {
+    core = new Core(TEST_CORE_OPTIONS);
+    relayer = new Relayer({ core, logger });
+  });
+
+  it("registers event listeners when constructed", () => {
+    const emitSpy = Sinon.spy();
+    relayer.events.emit = emitSpy;
+    relayer.provider.events.emit(RELAYER_PROVIDER_EVENTS.connect);
+    expect(emitSpy.calledOnceWith(RELAYER_EVENTS.connect)).to.be.true;
+  });
+
+  describe("init", () => {
+    let initSpy: Sinon.SinonSpy;
+    beforeEach(() => {
+      // Mock `provider.connect` to avoid dependency on relay server here.
+      relayer.provider.connect = () => Promise.resolve();
+      initSpy = Sinon.spy();
+    });
+
+    it("initializes a MessageTracker", async () => {
+      relayer.messages.init = initSpy;
+      await relayer.init();
+      expect(initSpy.calledOnce).to.be.true;
+    });
+    it("initializes a Subscriber", async () => {
+      relayer.subscriber.init = initSpy;
+      await relayer.init();
+      expect(initSpy.calledOnce).to.be.true;
+    });
+    it("initializes a Publisher", async () => {
+      relayer.subscriber.init = initSpy;
+      await relayer.init();
+      expect(initSpy.calledOnce).to.be.true;
+    });
+    it("calls provider.connect", async () => {
+      relayer.provider.connect = initSpy;
+      await relayer.init();
+      expect(initSpy.calledOnce).to.be.true;
+    });
+  });
+
+  describe("publish", () => {
+    const topic = "abc123";
+    const message = "publish me";
+    it("calls `publisher.publish` with provided args", async () => {
+      const spy = Sinon.spy();
+      relayer.publisher.publish = spy;
+      await relayer.publish(topic, message);
+      expect(spy.calledOnceWith(topic, message)).to.be.true;
+    });
+    it("records a message with provided args", async () => {
+      const spy = Sinon.spy();
+      relayer.publisher.publish = () => Promise.resolve();
+      relayer.messages.set = spy;
+      await relayer.publish(topic, message);
+      expect(spy.calledOnceWith(topic, message)).to.be.true;
+    });
+  });
+
+  describe("subscribe", () => {
+    it("returns the id provided by calling `subscriber.subscribe` with the passed topic", async () => {
+      const spy = Sinon.spy(() => "mock-id");
+      relayer.subscriber.subscribe = spy;
+      const id = await relayer.subscribe("abc123");
+      expect(spy.calledOnceWith("abc123")).to.be.true;
+      expect(id).to.eq("mock-id");
+    });
+  });
+
+  describe("unsubscribe", () => {
+    it("calls `subscriber.unsubscribe` with the passed topic", async () => {
+      const spy = Sinon.spy();
+      relayer.subscriber.unsubscribe = spy;
+      await relayer.unsubscribe("abc123");
+      expect(spy.calledOnceWith("abc123")).to.be.true;
+    });
+  });
+
+  describe("onProviderPayload", () => {
+    const validPayload: JsonRpcRequest = {
+      id: 123,
+      jsonrpc: "2.0",
+      method: "mock" + RELAYER_SUBSCRIBER_SUFFIX,
+      params: { id: "abc123", data: { topic: "ababab", message: "deadbeef" } },
+    };
+
+    it("does nothing if payload is not a valid JsonRpcRequest", () => {
+      const spy = Sinon.spy();
+      relayer.events.emit = spy;
+      relayer.provider.events.emit(RELAYER_PROVIDER_EVENTS.payload, {});
+      expect(spy.notCalled).to.be.true;
+    });
+    it(`does nothing if payload.method does not have the ${RELAYER_SUBSCRIBER_SUFFIX} suffix`, () => {
+      const spy = Sinon.spy();
+      relayer.events.emit = spy;
+      relayer.provider.events.emit(RELAYER_PROVIDER_EVENTS.payload, {
+        ...validPayload,
+        method: "mock",
+      });
+      expect(spy.notCalled).to.be.true;
+    });
+    it("emits an event based on `payload.params.id`", () => {
+      const spy = Sinon.spy();
+      relayer.events.emit = spy;
+      relayer.provider.events.emit(RELAYER_PROVIDER_EVENTS.payload, validPayload);
+      expect(
+        spy.calledOnceWith(validPayload.params.id, {
+          topic: validPayload.params.data.topic,
+          message: validPayload.params.data.message,
+        }),
+      ).to.be.true;
+    });
+  });
+});

--- a/packages/core/test/shared/chai.ts
+++ b/packages/core/test/shared/chai.ts
@@ -1,0 +1,6 @@
+import { use } from "chai";
+import chaiAsPromised from "chai-as-promised";
+
+use(chaiAsPromised);
+
+export { expect } from "chai";

--- a/packages/core/test/shared/index.ts
+++ b/packages/core/test/shared/index.ts
@@ -1,0 +1,2 @@
+export * from "./chai";
+export * from "./values";

--- a/packages/core/test/shared/values.ts
+++ b/packages/core/test/shared/values.ts
@@ -1,0 +1,21 @@
+import { CoreTypes } from "@walletconnect/types";
+
+// @ts-ignore
+import { ROOT_DIR } from "../../../../ops/js/shared";
+
+export const TEST_RELAY_URL = process.env.TEST_RELAY_URL
+  ? process.env.TEST_RELAY_URL
+  : "ws://localhost:5555";
+
+export const TEST_PROJECT_ID = process.env.TEST_PROJECT_ID
+  ? process.env.TEST_PROJECT_ID
+  : undefined;
+
+export const TEST_CORE_OPTIONS: CoreTypes.Options = {
+  logger: "fatal",
+  relayUrl: TEST_RELAY_URL,
+  projectId: TEST_PROJECT_ID,
+  storageOptions: {
+    database: ":memory:",
+  },
+};

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -2,7 +2,7 @@ import "mocha";
 import { getDefaultLoggerOptions } from "@walletconnect/logger";
 import pino from "pino";
 
-import { Core, CORE_DEFAULT, Store, STORE_STORAGE_VERSION } from "../src";
+import { Core, CORE_DEFAULT, CORE_STORAGE_PREFIX, Store, STORE_STORAGE_VERSION } from "../src";
 import { expect, TEST_CORE_OPTIONS } from "./shared";
 import { ICore, SessionTypes } from "@walletconnect/types";
 
@@ -21,7 +21,7 @@ describe("Store", () => {
   it("provides the expected `storageKey` format", () => {
     const store = new Store(core, logger, MOCK_STORE_NAME);
     expect(store.storageKey).to.equal(
-      core.storagePrefix + STORE_STORAGE_VERSION + "//" + MOCK_STORE_NAME,
+      CORE_STORAGE_PREFIX + STORE_STORAGE_VERSION + "//" + MOCK_STORE_NAME,
     );
   });
 

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -1,0 +1,99 @@
+import "mocha";
+import { getDefaultLoggerOptions } from "@walletconnect/logger";
+import pino from "pino";
+
+import { Core, CORE_DEFAULT, Store, STORE_STORAGE_VERSION } from "../src";
+import { expect, TEST_CORE_OPTIONS } from "./shared";
+import { ICore, SessionTypes } from "@walletconnect/types";
+
+const MOCK_STORE_NAME = "mock-entity";
+
+// TODO: Test persistence behavior
+describe("Store", () => {
+  const logger = pino(getDefaultLoggerOptions({ level: CORE_DEFAULT.logger }));
+
+  let core: ICore;
+
+  beforeEach(() => {
+    core = new Core(TEST_CORE_OPTIONS);
+  });
+
+  it("provides the expected `storageKey` format", () => {
+    const store = new Store(core, logger, MOCK_STORE_NAME);
+    expect(store.storageKey).to.equal(
+      core.storagePrefix + STORE_STORAGE_VERSION + "//" + MOCK_STORE_NAME,
+    );
+  });
+
+  describe("set", () => {
+    it("creates a new entry for a new key", async () => {
+      const store = new Store(core, logger, MOCK_STORE_NAME);
+      const key = "newKey";
+      const value = {
+        topic: "abc123",
+        expiry: 1000,
+      } as SessionTypes.Struct;
+      await store.set(key, value);
+      expect(store.length).to.equal(1);
+      expect(store.keys.includes(key)).to.be.true;
+      expect(store.values.includes(value)).to.be.true;
+    });
+    it("updates an existing entry for a a known key", async () => {
+      const store = new Store(core, logger, MOCK_STORE_NAME);
+      const key = "key";
+      const value = {
+        topic: "111",
+        expiry: 1000,
+      } as SessionTypes.Struct;
+      const updatedValue = {
+        topic: "222",
+        expiry: 1000,
+      } as SessionTypes.Struct;
+      await store.set(key, value);
+      await store.set(key, updatedValue);
+      expect(store.length).to.equal(1);
+      expect(store.map.has(key)).to.be.true;
+      expect(store.values.some((val: any) => val.topic === updatedValue.topic)).to.be.true;
+    });
+  });
+
+  describe("get", () => {
+    it("returns the value for a known key", async () => {
+      const store = new Store(core, logger, MOCK_STORE_NAME);
+      const key = "key";
+      const value = {
+        topic: "abc123",
+        expiry: 1000,
+      } as SessionTypes.Struct;
+      await store.set(key, value);
+      expect(await store.get(key)).to.equal(value);
+    });
+    it("throws with expected error if passed an unknown key", async () => {
+      const store = new Store(core, logger, MOCK_STORE_NAME);
+      const unknownKey = "unknown";
+      await expect(store.get(unknownKey)).to.eventually.be.rejectedWith(
+        `No matching ${MOCK_STORE_NAME} with topic: ${unknownKey}`,
+      );
+    });
+  });
+
+  describe("delete", () => {
+    it("removes a known key from the map", async () => {
+      const store = new Store(core, logger, MOCK_STORE_NAME);
+      const key = "key";
+      const value = {
+        topic: "abc123",
+        expiry: 1000,
+      } as SessionTypes.Struct;
+      await store.set(key, value);
+      expect(store.length).to.equal(1);
+      await store.delete(key, { code: 0, message: "reason" });
+      expect(store.length).to.equal(0);
+    });
+    it("does nothing if key is unknown", async () => {
+      const store = new Store(core, logger, MOCK_STORE_NAME);
+      await store.delete("key", { code: 0, message: "reason" });
+      expect(store.length).to.equal(0);
+    });
+  });
+});

--- a/packages/core/test/subscriber.spec.ts
+++ b/packages/core/test/subscriber.spec.ts
@@ -1,0 +1,142 @@
+import "mocha";
+import pino from "pino";
+import Sinon from "sinon";
+import { getDefaultLoggerOptions } from "@walletconnect/logger";
+import { IRelayer, ISubscriber } from "@walletconnect/types";
+import { generateRandomBytes32, getRelayProtocolName } from "@walletconnect/utils";
+
+import {
+  Core,
+  CORE_DEFAULT,
+  CORE_STORAGE_PREFIX,
+  MESSAGES_STORAGE_VERSION,
+  Relayer,
+  RELAYER_PROVIDER_EVENTS,
+  Subscriber,
+  SUBSCRIBER_CONTEXT,
+} from "../src";
+import { expect, TEST_CORE_OPTIONS } from "./shared";
+
+describe("Subscriber", () => {
+  const logger = pino(getDefaultLoggerOptions({ level: CORE_DEFAULT.logger }));
+
+  let relayer: IRelayer;
+  let subscriber: ISubscriber;
+
+  beforeEach(async () => {
+    const core = new Core(TEST_CORE_OPTIONS);
+    relayer = new Relayer({ core, logger });
+    subscriber = new Subscriber(relayer, logger);
+    subscriber.relayer.provider.request = () => Promise.resolve({} as any);
+    await subscriber.init();
+  });
+
+  it("provides the expected `storageKey` format", () => {
+    const subscriber = new Subscriber(relayer, logger);
+    expect(subscriber.storageKey).to.equal(
+      CORE_STORAGE_PREFIX + MESSAGES_STORAGE_VERSION + "//" + SUBSCRIBER_CONTEXT,
+    );
+  });
+
+  describe("init", () => {
+    it("registers event listeners", async () => {
+      const topic = generateRandomBytes32();
+      const emitSpy = Sinon.spy();
+      subscriber.events.emit = emitSpy;
+      // subscribe to a topic
+      await subscriber.subscribe(topic);
+      expect(subscriber.subscriptions.size).to.equal(1);
+      expect(subscriber.topics.length).to.equal(1);
+      // relayer.provider emits a `disconnect` event -> should clear both subscriptions and topics.
+      relayer.provider.events.emit(RELAYER_PROVIDER_EVENTS.disconnect);
+      expect(subscriber.subscriptions.size).to.equal(0);
+      expect(subscriber.topics.length).to.equal(0);
+    });
+  });
+
+  describe("subscribe", () => {
+    let topic: string;
+    let requestSpy: Sinon.SinonSpy;
+
+    beforeEach(() => {
+      requestSpy = Sinon.spy(() => "test-id");
+      topic = generateRandomBytes32();
+      subscriber.relayer.provider.request = requestSpy;
+    });
+
+    it("throws if Subscriber was not initialized", async () => {
+      const subscriber = new Subscriber(relayer, logger);
+      await expect(subscriber.subscribe(topic)).to.eventually.be.rejectedWith(
+        "subscription was not initialized",
+      );
+    });
+    it("calls `provider.request` with the expected request shape", async () => {
+      await subscriber.subscribe(topic);
+      expect(
+        requestSpy.calledOnceWith(
+          Sinon.match({
+            method: "waku_subscribe",
+            params: {
+              topic,
+            },
+          }),
+        ),
+      ).to.be.true;
+    });
+    it("returns the subscription id", async () => {
+      const id = await subscriber.subscribe(topic);
+      expect(id).to.equal("test-id");
+    });
+  });
+
+  describe("unsubscribe", () => {
+    let topic: string;
+    let requestSpy: Sinon.SinonSpy;
+    let messageDeleteSpy: Sinon.SinonSpy;
+
+    beforeEach(() => {
+      requestSpy = Sinon.spy();
+      messageDeleteSpy = Sinon.spy();
+      topic = generateRandomBytes32();
+      subscriber.relayer.provider.request = requestSpy;
+      subscriber.relayer.messages.del = messageDeleteSpy;
+    });
+    it("throws if Subscriber was not initialized", async () => {
+      const subscriber = new Subscriber(relayer, logger);
+      await expect(subscriber.unsubscribe(topic)).to.eventually.be.rejectedWith(
+        "subscription was not initialized",
+      );
+    });
+    it("unsubscribes by individual id if `opts.id` is provided", async () => {
+      const id = "test-id";
+      await subscriber.unsubscribe(topic, { id, relay: getRelayProtocolName() });
+      expect(messageDeleteSpy.calledOnceWith(topic)).to.be.true;
+      expect(
+        requestSpy.calledOnceWith(
+          Sinon.match({
+            method: "waku_unsubscribe",
+            params: {
+              topic,
+            },
+          }),
+        ),
+      ).to.be.true;
+    });
+    it("unsubscribes by topic by default", async () => {
+      await subscriber.subscribe(topic);
+      expect(subscriber.topics.length).to.equal(1);
+      await subscriber.unsubscribe(topic);
+      expect(subscriber.topics.length).to.equal(0);
+      expect(
+        requestSpy.getCall(1).calledWith(
+          Sinon.match({
+            method: "waku_unsubscribe",
+            params: {
+              topic,
+            },
+          }),
+        ),
+      ).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
Part of:

- #915 

## Key changes
- Tests public interfaces of core controllers
- Avoids dependence on interactions with the relay-server by mocking specific functions where needed.


## Test suites implemented
- [x] core.spec.ts
- [x] keychain.spec.ts (only a `storageKey` check for now since it's a dead simple controller)
- [x] messages.spec.ts
- [x] publisher.spec.ts
- [x] relayer.spec.ts
- [x] store.spec.ts
- [x] subscriber.spec.ts

## Remaining

- [x] crypto.spec.ts (see https://github.com/WalletConnect/walletconnect-monorepo/pull/1033)
