### PR TITLE
Empty variables causing errors - Continuation of #974

### DIFF
--- a/packages/helpers/utils/src/ethereum.ts
+++ b/packages/helpers/utils/src/ethereum.ts
@@ -66,16 +66,16 @@ export function parseTransactionData(txData: Partial<ITxData>): Partial<ITxData>
   const txDataRPC = {
     from: sanitizeHex(txData.from),
     to: typeof txData.to === "undefined" ? null : sanitizeHex(txData.to),
-    gasPrice: typeof txData.gasPrice === "undefined" ? "" : parseHexValues(txData.gasPrice),
+    gasPrice: typeof txData.gasPrice === "undefined" ? undefined : parseHexValues(txData.gasPrice),
     gas:
       typeof txData.gas === "undefined"
         ? typeof txData.gasLimit === "undefined"
-          ? ""
+          ? undefined
           : parseHexValues(txData.gasLimit)
         : parseHexValues(txData.gas),
-    value: typeof txData.value === "undefined" ? "" : parseHexValues(txData.value),
-    nonce: typeof txData.nonce === "undefined" ? "" : parseHexValues(txData.nonce),
-    data: typeof txData.data === "undefined" ? "" : sanitizeHex(txData.data) || "0x",
+    value: typeof txData.value === "undefined" ? undefined : parseHexValues(txData.value),
+    nonce: typeof txData.nonce === "undefined" ? undefined : parseHexValues(txData.nonce),
+    data: typeof txData.data === "undefined" ? undefined : sanitizeHex(txData.data) || "0x",
   };
 
   const prunable = ["gasPrice", "gas", "value", "nonce"];


### PR DESCRIPTION
A continuation of https://github.com/WalletConnect/walletconnect-monorepo/pull/974

`gasPrice`, `gas`, `value`, `nonce`, and `data` are left in blank strings, causing errors when deploying/interacting with smart contracts. This could potentially fix some issues, please mention this PR in those issues to inform users.