### PR TITLE
Check if node app is not an electron app

### DIFF
--- a/legacy/modal/src/index.ts
+++ b/legacy/modal/src/index.ts
@@ -6,7 +6,8 @@ import * as browserLib from "./browser";
 const isNode = () =>
   typeof process !== "undefined" &&
   typeof process.versions !== "undefined" &&
-  typeof process.versions.node !== "undefined";
+  typeof process.versions.node !== "undefined" &&
+  typeof process.versions.electron === "undefined";
 
 function open(uri: string, cb: any, qrcodeModalOptions?: IQRCodeModalOptions) {
   // eslint-disable-next-line no-console


### PR DESCRIPTION
WalletConnect modal is checking first if we're running a NodeJS app. The problem is electron apps have Node & Browser available. The current implementation it's showing the QR code as text, even though we could just use the browser version.

This PR fixes this issue.

It closes #1007 