### PR TITLE
Engine validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,3 @@ test.db-journal
 setup
 result*
 ops/grafana/grafana.ini
-
-.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,34 @@
+{
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": false
+  },
+  "editor.formatOnSave": true,
+  "editor.tabSize": 2,
+  "editor.wordWrapColumn": 90,
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "files.autoSave": "onWindowChange",
+  "javascript.updateImportsOnFileMove.enabled": "always",
+  "typescript.suggest.autoImports": false,
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.updateImportsOnFileMove.enabled": "always"
+}

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -25,7 +25,7 @@
     "build:esm": "npx tsc -p tsconfig.esm.json",
     "build": "run-s build:pre build:cjs build:esm build:umd",
     "test:pre": "rm -rf ./test/test.db",
-    "test:run": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 10000 --exit --r ts-node/register ./test/**/*.spec.ts",
+    "test:run": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --parallel --timeout 10000 --exit --r ts-node/register ./test/**/*.spec.ts",
     "test": "run-s test:pre test:run",
     "watch": "tsc -p tsconfig.json --watch",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -25,7 +25,7 @@
     "build:esm": "npx tsc -p tsconfig.esm.json",
     "build": "run-s build:pre build:cjs build:esm build:umd",
     "test:pre": "rm -rf ./test/test.db",
-    "test:run": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 10000 --exit -r ts-node/register ./test/**/*.spec.ts",
+    "test:run": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 10000 --exit --r ts-node/register ./test/**/*.spec.ts",
     "test": "run-s test:pre test:run",
     "watch": "tsc -p tsconfig.json --watch",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -19,7 +19,6 @@ import {
   SessionTypes,
   JsonRpcTypes,
   ExpirerTypes,
-  EngineTypes,
 } from "@walletconnect/types";
 import {
   calcExpiry,
@@ -31,6 +30,7 @@ import {
   engineEvent,
   isValidNamespaces,
   isValidRelays,
+  isValidUrl,
 } from "@walletconnect/utils";
 import { JsonRpcResponse } from "@walletconnect/jsonrpc-types";
 
@@ -93,7 +93,7 @@ export class Engine extends IEngine {
   };
 
   public pair: IEngine["pair"] = async params => {
-    // TODO(ilja) validation
+    this.isValidPair(params);
     const { topic, symKey, relay } = parseUri(params.uri);
     const expiry = calcExpiry(FIVE_MINUTES);
     const pairing = { topic, relay, expiry, active: false };
@@ -773,7 +773,7 @@ export class Engine extends IEngine {
   }
 
   // ---------- Validation ---------------------------------------------- //
-  private isValidConnect(params: EngineTypes.ConnectParams) {
+  private isValidConnect: EnginePrivate["isValidConnect"] = params => {
     const { pairingTopic, namespaces, relays } = params;
 
     if (pairingTopic && (!pairingTopic.length || !this.client.pairing.get(pairingTopic)))
@@ -783,5 +783,11 @@ export class Engine extends IEngine {
       throw ERROR.MISSING_OR_INVALID.format({ name: "namespaces" });
 
     if (!isValidRelays(relays, true)) throw ERROR.MISSING_OR_INVALID.format({ name: "relays" });
-  }
+  };
+
+  private isValidPair: EnginePrivate["isValidPair"] = params => {
+    if (!isValidUrl(params?.uri)) {
+      throw ERROR.MISSING_OR_INVALID.format({ name: "uri" });
+    }
+  };
 }

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -37,6 +37,7 @@ import {
   isValidString,
   isValidErrorReason,
   areAccountsInNamespaces,
+  isValidExpiry,
 } from "@walletconnect/utils";
 import { JsonRpcResponse } from "@walletconnect/jsonrpc-types";
 
@@ -851,5 +852,9 @@ export class Engine extends IEngine {
       throw ERROR.MISSING_OR_INVALID.format({ name: "updateExpiry topic" });
     if (!this.client.session.get(topic))
       throw ERROR.NO_MATCHING_TOPIC.format({ context: "session", topic });
+    if (!isValidExpiry(expiry))
+      throw ERROR.MISSING_OR_INVALID.format({
+        name: "updateExpiry expiry (min 5 min, max 30 days)",
+      });
   };
 }

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -35,6 +35,7 @@ import {
   isValidParams,
   isValidAccounts,
   isValidString,
+  isValidErrorReason,
 } from "@walletconnect/utils";
 import { JsonRpcResponse } from "@walletconnect/jsonrpc-types";
 
@@ -171,7 +172,7 @@ export class Engine extends IEngine {
   };
 
   public reject: IEngine["reject"] = async params => {
-    // TODO(ilja) validation
+    this.isValidReject(params);
     const { id, reason } = params;
     const { pairingTopic } = this.client.proposal.get(id);
     if (pairingTopic && id) {
@@ -805,5 +806,13 @@ export class Engine extends IEngine {
       throw ERROR.MISSING_OR_INVALID.format({ name: "approve accounts" });
     if (!isValidString(relayProtocol, true))
       throw ERROR.MISSING_OR_INVALID.format({ name: "approve relayProtocol" });
+  };
+
+  private isValidReject: EnginePrivate["isValidReject"] = params => {
+    if (!isValidParams(params)) throw ERROR.MISSING_OR_INVALID.format({ name: "reject params" });
+    const { id, reason } = params;
+    if (!isValidId(id)) throw ERROR.MISSING_OR_INVALID.format({ name: "reject id" });
+    if (!isValidErrorReason(reason))
+      throw ERROR.MISSING_OR_INVALID.format({ name: "reject reason" });
   };
 }

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -31,6 +31,8 @@ import {
   isValidNamespaces,
   isValidRelays,
   isValidUrl,
+  isValidId,
+  isValidParams,
 } from "@walletconnect/utils";
 import { JsonRpcResponse } from "@walletconnect/jsonrpc-types";
 
@@ -106,7 +108,7 @@ export class Engine extends IEngine {
   };
 
   public approve: IEngine["approve"] = async params => {
-    // TODO(ilja) validation
+    this.isValidApprove(params);
     const { id, relayProtocol, accounts, namespaces } = params;
     const { pairingTopic, proposer } = this.client.proposal.get(id);
 
@@ -774,20 +776,26 @@ export class Engine extends IEngine {
 
   // ---------- Validation ---------------------------------------------- //
   private isValidConnect: EnginePrivate["isValidConnect"] = params => {
+    if (!isValidParams(params)) throw ERROR.MISSING_OR_INVALID.format({ name: "connect params" });
+
     const { pairingTopic, namespaces, relays } = params;
 
     if (pairingTopic && (!pairingTopic.length || !this.client.pairing.get(pairingTopic)))
       throw ERROR.NO_MATCHING_TOPIC.format({ context: "pairing", topic: pairingTopic });
-
     if (!isValidNamespaces(namespaces, true))
-      throw ERROR.MISSING_OR_INVALID.format({ name: "namespaces" });
-
-    if (!isValidRelays(relays, true)) throw ERROR.MISSING_OR_INVALID.format({ name: "relays" });
+      throw ERROR.MISSING_OR_INVALID.format({ name: "connect namespaces" });
+    if (!isValidRelays(relays, true))
+      throw ERROR.MISSING_OR_INVALID.format({ name: "connect relays" });
   };
 
   private isValidPair: EnginePrivate["isValidPair"] = params => {
-    if (!isValidUrl(params?.uri)) {
-      throw ERROR.MISSING_OR_INVALID.format({ name: "uri" });
-    }
+    if (!isValidParams(params)) throw ERROR.MISSING_OR_INVALID.format({ name: "pair params" });
+    if (!isValidUrl(params.uri)) throw ERROR.MISSING_OR_INVALID.format({ name: "pair uri" });
+  };
+
+  private isValidApprove: EnginePrivate["isValidApprove"] = params => {
+    if (!isValidParams(params)) throw ERROR.MISSING_OR_INVALID.format({ name: "approve params" });
+    const { id } = params;
+    if (!isValidId(id)) throw ERROR.MISSING_OR_INVALID.format({ name: "approve id" });
   };
 }

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -33,6 +33,8 @@ import {
   isValidUrl,
   isValidId,
   isValidParams,
+  isValidAccounts,
+  isValidString,
 } from "@walletconnect/utils";
 import { JsonRpcResponse } from "@walletconnect/jsonrpc-types";
 
@@ -795,7 +797,13 @@ export class Engine extends IEngine {
 
   private isValidApprove: EnginePrivate["isValidApprove"] = params => {
     if (!isValidParams(params)) throw ERROR.MISSING_OR_INVALID.format({ name: "approve params" });
-    const { id } = params;
+    const { id, namespaces, accounts, relayProtocol } = params;
     if (!isValidId(id)) throw ERROR.MISSING_OR_INVALID.format({ name: "approve id" });
+    if (!isValidNamespaces(namespaces, false))
+      throw ERROR.MISSING_OR_INVALID.format({ name: "approve namespaces" });
+    if (!isValidAccounts(accounts, false))
+      throw ERROR.MISSING_OR_INVALID.format({ name: "approve accounts" });
+    if (!isValidString(relayProtocol, true))
+      throw ERROR.MISSING_OR_INVALID.format({ name: "approve relayProtocol" });
   };
 }

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -276,7 +276,7 @@ export class Engine extends IEngine {
   };
 
   public disconnect: IEngine["disconnect"] = async params => {
-    // TODO(ilja) validation
+    this.isValidDisconnect(params);
     const { topic } = params;
     if (this.client.session.keys.includes(topic)) {
       const id = await this.sendRequest(topic, "wc_sessionDelete", ERROR.DELETED.format());
@@ -883,5 +883,17 @@ export class Engine extends IEngine {
 
     if (chainId && !isValidNamespacesEvent(namespaces, chainId, event.name))
       throw ERROR.MISSING_OR_INVALID.format({ name: "emit event" });
+  };
+
+  private isValidDisconnect: EnginePrivate["isValidDisconnect"] = params => {
+    if (!isValidParams(params))
+      throw ERROR.MISSING_OR_INVALID.format({ name: "disconnect params" });
+
+    const { topic } = params;
+
+    if (!isValidString(topic, false))
+      throw ERROR.MISSING_OR_INVALID.format({ name: "disconnect topic" });
+    if (!this.client.session.keys.includes(topic) && !this.client.pairing.keys.includes(topic))
+      throw ERROR.NO_MATCHING_TOPIC.format({ context: "pairing or session", topic });
   };
 }

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -834,7 +834,10 @@ export class Engine extends IEngine {
       throw ERROR.NO_MATCHING_TOPIC.format({ context: "session", topic });
     if (!isValidAccounts(accounts, false))
       throw ERROR.MISSING_OR_INVALID.format({ name: "updateAccounts accounts" });
-    if (!areAccountsInNamespaces(accounts, this.client.session.get(topic).namespaces))
-      throw ERROR.MISMATCHED_ACCOUNTS.format({ name: "updateAccounts topic" });
+    const { valid, mismatched } = areAccountsInNamespaces(
+      accounts,
+      this.client.session.get(topic).namespaces,
+    );
+    if (!valid) throw ERROR.MISMATCHED_ACCOUNTS.format({ mismatched });
   };
 }

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -203,7 +203,7 @@ export class Engine extends IEngine {
   };
 
   public updateNamespaces: IEngine["updateNamespaces"] = async params => {
-    // TODO(ilja) validation
+    this.isValidUpdateNamespaces(params);
     const { topic, namespaces } = params;
     const id = await this.sendRequest(topic, "wc_sessionUpdateNamespaces", { namespaces });
     const { done, resolve, reject } = createDelayedPromise<void>();
@@ -841,6 +841,20 @@ export class Engine extends IEngine {
       this.client.session.get(topic).namespaces,
     );
     if (!valid) throw ERROR.MISMATCHED_ACCOUNTS.format({ mismatched });
+  };
+
+  private isValidUpdateNamespaces: EnginePrivate["isValidUpdateNamespaces"] = params => {
+    if (!isValidParams(params))
+      throw ERROR.MISSING_OR_INVALID.format({ name: "updateNamespaces params" });
+
+    const { topic, namespaces } = params;
+
+    if (!isValidString(topic, false))
+      throw ERROR.MISSING_OR_INVALID.format({ name: "updateNamespaces topic" });
+    if (!this.client.session.keys.includes(topic))
+      throw ERROR.NO_MATCHING_TOPIC.format({ context: "session", topic });
+    if (!isValidNamespaces(namespaces, false))
+      throw ERROR.MISSING_OR_INVALID.format({ name: "updateNamespaces namespaces" });
   };
 
   private isValidUpdateExpiry: EnginePrivate["isValidUpdateExpiry"] = params => {

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -209,7 +209,7 @@ export class Engine extends IEngine {
   };
 
   public updateExpiry: IEngine["updateExpiry"] = async params => {
-    // TODO(ilja) validate
+    this.isValidUpdateExpiry(params);
     const { topic, expiry } = params;
     const id = await this.sendRequest(topic, "wc_sessionUpdateExpiry", { expiry });
     const { done, resolve, reject } = createDelayedPromise<void>();
@@ -839,5 +839,17 @@ export class Engine extends IEngine {
       this.client.session.get(topic).namespaces,
     );
     if (!valid) throw ERROR.MISMATCHED_ACCOUNTS.format({ mismatched });
+  };
+
+  private isValidUpdateExpiry: EnginePrivate["isValidUpdateExpiry"] = params => {
+    if (!isValidParams(params))
+      throw ERROR.MISSING_OR_INVALID.format({ name: "updateExpiry params" });
+
+    const { topic, expiry } = params;
+
+    if (!isValidString(topic, false))
+      throw ERROR.MISSING_OR_INVALID.format({ name: "updateExpiry topic" });
+    if (!this.client.session.get(topic))
+      throw ERROR.NO_MATCHING_TOPIC.format({ context: "session", topic });
   };
 }

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -854,7 +854,7 @@ export class Engine extends IEngine {
       throw ERROR.NO_MATCHING_TOPIC.format({ context: "session", topic });
     if (!isValidExpiry(expiry))
       throw ERROR.MISSING_OR_INVALID.format({
-        name: "updateExpiry expiry (min 5 min, max 30 days)",
+        name: "updateExpiry expiry (min 5 min, max 7 days)",
       });
   };
 }

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -41,6 +41,7 @@ import {
   isValidNamespacesChainId,
   isValidNamespacesRequest,
   isValidNamespacesEvent,
+  isValidRequest,
   isValidEvent,
 } from "@walletconnect/utils";
 import { JsonRpcResponse } from "@walletconnect/jsonrpc-types";
@@ -862,17 +863,20 @@ export class Engine extends IEngine {
 
     const { topic, request, chainId } = params;
 
-    if (!isValidString(topic, false)) throw ERROR.MISSING_OR_INVALID.format({ name: "emit topic" });
+    if (!isValidString(topic, false))
+      throw ERROR.MISSING_OR_INVALID.format({ name: "request topic" });
     if (!this.client.session.keys.includes(topic))
       throw ERROR.NO_MATCHING_TOPIC.format({ context: "session", topic });
 
     const { namespaces } = this.client.session.get(topic);
 
     if (!isValidNamespacesChainId(namespaces, chainId))
-      throw ERROR.MISSING_OR_INVALID.format({ name: "emit chainId" });
+      throw ERROR.MISSING_OR_INVALID.format({ name: "request chainId" });
+
+    if (!isValidRequest(request)) throw ERROR.MISSING_OR_INVALID.format({ name: "request method" });
 
     if (!isValidNamespacesRequest(namespaces, chainId, request.method))
-      throw ERROR.MISSING_OR_INVALID.format({ name: "emit event" });
+      throw ERROR.MISSING_OR_INVALID.format({ name: "request method" });
   };
 
   private isValidPing: EnginePrivate["isValidPing"] = params => {

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -176,7 +176,7 @@ export class Engine extends IEngine {
     this.isValidReject(params);
     const { id, reason } = params;
     const { pairingTopic } = this.client.proposal.get(id);
-    if (pairingTopic && id) {
+    if (pairingTopic) {
       await this.sendError(id, pairingTopic, reason);
       await this.client.proposal.delete(id, ERROR.DELETED.format());
     }

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -358,7 +358,6 @@ export class Engine extends IEngine {
   };
 
   private sendRequest: EnginePrivate["sendRequest"] = async (topic, method, params) => {
-    // TODO(ilja) validation
     const payload = formatJsonRpcRequest(method, params);
     const message = await this.client.core.crypto.encode(topic, payload);
     await this.client.core.relayer.publish(topic, message);
@@ -368,7 +367,6 @@ export class Engine extends IEngine {
   };
 
   private sendResult: EnginePrivate["sendResult"] = async (id, topic, result) => {
-    // TODO(ilja) validation
     const payload = formatJsonRpcResult(id, result);
     const message = this.client.core.crypto.encode(topic, payload);
     await this.client.core.relayer.publish(topic, message);
@@ -376,7 +374,6 @@ export class Engine extends IEngine {
   };
 
   private sendError: EnginePrivate["sendError"] = async (id, topic, error) => {
-    // TODO(ilja) validation
     const payload = formatJsonRpcError(id, error);
     const message = this.client.core.crypto.encode(topic, payload);
     await this.client.core.relayer.publish(topic, message);
@@ -403,7 +400,6 @@ export class Engine extends IEngine {
   }
 
   private onRelayEventRequest: EnginePrivate["onRelayEventRequest"] = event => {
-    // TODO(ilja) validation
     const { topic, payload } = event;
     const reqMethod = payload.method as JsonRpcTypes.WcMethod;
 
@@ -437,7 +433,6 @@ export class Engine extends IEngine {
   };
 
   private onRelayEventResponse: EnginePrivate["onRelayEventResponse"] = async event => {
-    // TODO(ilja) validation
     const { topic, payload } = event;
     const record = await this.client.history.get(topic, payload.id);
     const resMethod = record.request.method as JsonRpcTypes.WcMethod;
@@ -475,7 +470,6 @@ export class Engine extends IEngine {
     topic,
     payload,
   ) => {
-    // TODO(ilja) validation
     const { params, id: id } = payload;
     await this.client.proposal.set(id, {
       id,
@@ -489,7 +483,6 @@ export class Engine extends IEngine {
     topic,
     payload,
   ) => {
-    // TODO(ilja) validation
     const { id: id } = payload;
     if (isJsonRpcResult(payload)) {
       const { result } = payload;
@@ -534,7 +527,6 @@ export class Engine extends IEngine {
     topic,
     payload,
   ) => {
-    // TODO(ilja) validation
     const { relay, controller, expiry, accounts, namespaces } = payload.params;
     const session = {
       topic,
@@ -561,7 +553,6 @@ export class Engine extends IEngine {
     topic,
     payload,
   ) => {
-    // TODO(ilja) validation
     const { id } = payload;
     if (isJsonRpcResult(payload)) {
       await this.client.session.update(topic, { acknowledged: true });
@@ -576,7 +567,6 @@ export class Engine extends IEngine {
     topic,
     payload,
   ) => {
-    // TODO(ilja) validation
     const { params, id } = payload;
     await this.client.session.update(topic, { accounts: params.accounts });
     await this.sendResult<"wc_sessionUpdateAccounts">(id, topic, true);
@@ -587,7 +577,6 @@ export class Engine extends IEngine {
     _topic,
     payload,
   ) => {
-    // TODO(ilja) validation
     const { id } = payload;
     if (isJsonRpcResult(payload)) {
       this.events.emit(engineEvent("update_accounts", id), {});
@@ -600,7 +589,6 @@ export class Engine extends IEngine {
     topic,
     payload,
   ) => {
-    // TODO(ilja) validation
     const { params, id } = payload;
     await this.client.session.update(topic, { namespaces: params.namespaces });
     await this.sendResult<"wc_sessionUpdateNamespaces">(id, topic, true);
@@ -611,7 +599,6 @@ export class Engine extends IEngine {
     _topic,
     payload,
   ) => {
-    // TODO(ilja) validation
     const { id } = payload;
     if (isJsonRpcResult(payload)) {
       this.events.emit(engineEvent("update_namespaces", id), {});
@@ -624,7 +611,6 @@ export class Engine extends IEngine {
     topic,
     payload,
   ) => {
-    // TODO(ilja) validation
     const { params, id } = payload;
     await this.setExpiry(topic, params.expiry);
     await this.sendResult<"wc_sessionUpdateExpiry">(id, topic, true);
@@ -635,7 +621,6 @@ export class Engine extends IEngine {
     _topic,
     payload,
   ) => {
-    // TODO(ilja) validation
     const { id } = payload;
     if (isJsonRpcResult(payload)) {
       this.events.emit(engineEvent("update_expiry", id), {});
@@ -645,14 +630,12 @@ export class Engine extends IEngine {
   };
 
   private onSessionPingRequest: EnginePrivate["onSessionPingRequest"] = async (topic, payload) => {
-    // TODO(ilja) validation
     const { id } = payload;
     await this.sendResult<"wc_sessionPing">(id, topic, true);
     this.client.events.emit("session_ping", { topic });
   };
 
   private onSessionPingResponse: EnginePrivate["onSessionPingResponse"] = (_topic, payload) => {
-    // TODO(ilja) validation
     const { id } = payload;
     if (isJsonRpcResult(payload)) {
       this.events.emit(engineEvent("session_ping", id), {});
@@ -662,14 +645,12 @@ export class Engine extends IEngine {
   };
 
   private onPairingPingRequest: EnginePrivate["onPairingPingRequest"] = async (topic, payload) => {
-    // TODO(ilja) validation
     const { id } = payload;
     await this.sendResult<"wc_pairingPing">(id, topic, true);
     this.client.events.emit("pairing_ping", { topic });
   };
 
   private onPairingPingResponse: EnginePrivate["onPairingPingResponse"] = (_topic, payload) => {
-    // TODO(ilja) validation
     const { id } = payload;
     if (isJsonRpcResult(payload)) {
       this.events.emit(engineEvent("pairing_ping", id), {});
@@ -682,7 +663,6 @@ export class Engine extends IEngine {
     topic,
     payload,
   ) => {
-    // TODO(ilja) validation
     const { id } = payload;
     await this.sendResult<"wc_sessionDelete">(id, topic, true);
     await this.deleteSession(topic);
@@ -693,7 +673,6 @@ export class Engine extends IEngine {
     topic,
     payload,
   ) => {
-    // TODO(ilja) validation
     const { id } = payload;
     if (isJsonRpcResult(payload)) {
       await this.deleteSession(topic);
@@ -707,7 +686,6 @@ export class Engine extends IEngine {
     topic,
     payload,
   ) => {
-    // TODO(ilja) validation
     const { id } = payload;
     await this.sendResult<"wc_pairingDelete">(id, topic, true);
     await this.deletePairing(topic);
@@ -718,7 +696,6 @@ export class Engine extends IEngine {
     topic,
     payload,
   ) => {
-    // TODO(ilja) validation
     const { id } = payload;
     if (isJsonRpcResult(payload)) {
       await this.deletePairing(topic);
@@ -729,7 +706,6 @@ export class Engine extends IEngine {
   };
 
   private onSessionRequest: EnginePrivate["onSessionRequest"] = async (topic, payload) => {
-    // TODO(ilja) validation
     const { namespaces } = this.client.session.get(topic);
     const { id, params } = payload;
     const { chainId, request } = params;
@@ -749,7 +725,6 @@ export class Engine extends IEngine {
     _topic,
     payload,
   ) => {
-    // TODO(ilja) validation
     const { id } = payload;
     if (isJsonRpcResult(payload)) {
       this.events.emit(engineEvent("request", id), { data: payload.result });
@@ -759,7 +734,6 @@ export class Engine extends IEngine {
   };
 
   private onSessionEventRequest: EnginePrivate["onSessionEventRequest"] = (topic, payload) => {
-    // TODO(ilja) validation
     const { event, chainId } = payload.params;
     this.client.events.emit("event", { topic, event, chainId });
   };

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -43,6 +43,7 @@ import {
   isValidNamespacesEvent,
   isValidRequest,
   isValidEvent,
+  isValidResponse,
 } from "@walletconnect/utils";
 import { JsonRpcResponse } from "@walletconnect/jsonrpc-types";
 
@@ -240,7 +241,7 @@ export class Engine extends IEngine {
   };
 
   public respond: IEngine["respond"] = async params => {
-    // TODO(ilja) validation
+    this.isValidRespond(params);
     const { topic, response } = params;
     const { id } = response;
     if (isJsonRpcResult(response)) {
@@ -877,6 +878,20 @@ export class Engine extends IEngine {
 
     if (!isValidNamespacesRequest(namespaces, chainId, request.method))
       throw ERROR.MISSING_OR_INVALID.format({ name: "request method" });
+  };
+
+  private isValidRespond: EnginePrivate["isValidRespond"] = params => {
+    if (!isValidParams(params)) throw ERROR.MISSING_OR_INVALID.format({ name: "respond params" });
+
+    const { topic, response } = params;
+
+    if (!isValidString(topic, false))
+      throw ERROR.MISSING_OR_INVALID.format({ name: "respond topic" });
+    if (!this.client.session.keys.includes(topic))
+      throw ERROR.NO_MATCHING_TOPIC.format({ context: "session", topic });
+
+    if (!isValidResponse(response))
+      throw ERROR.MISSING_OR_INVALID.format({ name: "respond response" });
   };
 
   private isValidPing: EnginePrivate["isValidPing"] = params => {

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -10,7 +10,7 @@ import {
   deleteClients,
 } from "./shared";
 
-describe("Client", () => {
+describe("Client Integration", () => {
   it("init", async () => {
     const client = await Client.init(TEST_CLIENT_OPTIONS);
     expect(client).to.be.exist;
@@ -32,35 +32,6 @@ describe("Client", () => {
         pairingTopic,
       });
       deleteClients(clients);
-    });
-    it("throws when invalid pairingTopic is provided", async () => {
-      const clients = await initTwoClients();
-      const promise = testConnectMethod(clients, { pairingTopic: "123" });
-      await expect(promise).to.eventually.be.rejectedWith("No matching pairing with topic: 123");
-      deleteClients(clients);
-    });
-    it("throws when invalid or empty namespaces are provided", async () => {
-      const clients = await initTwoClients();
-      const promise1 = testConnectMethod(clients, { namespaces: [] });
-      await expect(promise1).to.eventually.be.rejectedWith("Missing or invalid namespaces");
-      // @ts-ignore
-      const promise2 = testConnectMethod(clients, { namespaces: {} });
-      await expect(promise2).to.eventually.be.rejectedWith("Missing or invalid namespaces");
-      deleteClients(clients);
-    });
-  });
-
-  describe("pair", () => {
-    it("throws when no or invalid uri is provided", async () => {
-      const client = await Client.init(TEST_CLIENT_OPTIONS);
-      // @ts-expect-error
-      const promise1 = client.pair();
-      await expect(promise1).to.eventually.be.rejectedWith("Missing or invalid uri");
-      const promise2 = client.pair({ uri: "" });
-      await expect(promise2).to.eventually.be.rejectedWith("Missing or invalid uri");
-      // @ts-expect-error
-      const promise3 = client.pair({ uri: 123 });
-      await expect(promise3).to.eventually.be.rejectedWith("Missing or invalid uri");
     });
   });
 

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -50,6 +50,20 @@ describe("Client", () => {
     });
   });
 
+  describe("pair", () => {
+    it("throws when no or invalid uri is provided", async () => {
+      const client = await Client.init(TEST_CLIENT_OPTIONS);
+      // @ts-expect-error
+      const promise1 = client.pair();
+      await expect(promise1).to.eventually.be.rejectedWith("Missing or invalid uri");
+      const promise2 = client.pair({ uri: "" });
+      await expect(promise2).to.eventually.be.rejectedWith("Missing or invalid uri");
+      // @ts-expect-error
+      const promise3 = client.pair({ uri: 123 });
+      await expect(promise3).to.eventually.be.rejectedWith("Missing or invalid uri");
+    });
+  });
+
   describe("disconnect", () => {
     describe("pairing", () => {
       it("deletes the pairing on disconnect", async () => {

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -1,4 +1,4 @@
-import { ERROR } from "@walletconnect/utils";
+import { ERROR, calcExpiry } from "@walletconnect/utils";
 import "mocha";
 import Client from "../src";
 import {
@@ -9,6 +9,7 @@ import {
   TEST_CLIENT_OPTIONS,
   deleteClients,
 } from "./shared";
+import { FIVE_MINUTES } from "@walletconnect/time";
 
 describe("Client Integration", () => {
   it("init", async () => {
@@ -211,8 +212,7 @@ describe("Client Integration", () => {
       const {
         sessionA: { topic },
       } = await testConnectMethod(clients);
-      const expiryBefore = clients.A.session.get(topic).expiry;
-      const expiryAfter = expiryBefore + 1000;
+      const expiryAfter = calcExpiry(FIVE_MINUTES);
       await clients.A.updateExpiry({
         topic,
         expiry: expiryAfter,

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -7,6 +7,7 @@ import {
   testConnectMethod,
   TEST_CLIENT_DATABASE,
   TEST_CLIENT_OPTIONS,
+  deleteClients,
 } from "./shared";
 
 describe("Client", () => {
@@ -19,6 +20,7 @@ describe("Client", () => {
     it("connect (with new pairing)", async () => {
       const clients = await initTwoClients();
       await testConnectMethod(clients);
+      deleteClients(clients);
     });
     it("connect (with old pairing)", async () => {
       const clients = await initTwoClients();
@@ -29,13 +31,13 @@ describe("Client", () => {
       await testConnectMethod(clients, {
         pairingTopic,
       });
+      deleteClients(clients);
     });
     it("throws when invalid pairingTopic is provided", async () => {
       const clients = await initTwoClients();
-      const promise = testConnectMethod(clients, { pairingTopic: "invalid" });
-      await expect(promise).to.eventually.be.rejectedWith(
-        "No matching pairing with topic: invalid",
-      );
+      const promise = testConnectMethod(clients, { pairingTopic: "123" });
+      await expect(promise).to.eventually.be.rejectedWith("No matching pairing with topic: 123");
+      deleteClients(clients);
     });
     it("throws when invalid or empty namespaces are provided", async () => {
       const clients = await initTwoClients();
@@ -44,6 +46,7 @@ describe("Client", () => {
       // @ts-ignore
       const promise2 = testConnectMethod(clients, { namespaces: {} });
       await expect(promise2).to.eventually.be.rejectedWith("Missing or invalid namespaces");
+      deleteClients(clients);
     });
   });
 
@@ -63,6 +66,7 @@ describe("Client", () => {
         await expect(promise).to.eventually.be.rejectedWith(
           `No matching pairing or session with topic: ${topic}`,
         );
+        deleteClients(clients);
       });
     });
     describe("session", () => {
@@ -80,6 +84,7 @@ describe("Client", () => {
         await expect(promise).to.eventually.be.rejectedWith(
           `No matching pairing or session with topic: ${topic}`,
         );
+        deleteClients(clients);
       });
     });
   });
@@ -91,6 +96,7 @@ describe("Client", () => {
       await expect(clients.A.ping({ topic: fakeTopic })).to.eventually.be.rejectedWith(
         `No matching pairing or session with topic: ${fakeTopic}`,
       );
+      deleteClients(clients);
     });
     describe("pairing", () => {
       it("A pings B with existing pairing", async () => {
@@ -99,6 +105,7 @@ describe("Client", () => {
           pairingA: { topic },
         } = await testConnectMethod(clients);
         await clients.A.ping({ topic });
+        deleteClients(clients);
       });
       it("B pings A with existing pairing", async () => {
         const clients = await initTwoClients();
@@ -106,6 +113,7 @@ describe("Client", () => {
           pairingA: { topic },
         } = await testConnectMethod(clients);
         await clients.B.ping({ topic });
+        deleteClients(clients);
       });
       it("clients can ping each other after restart", async () => {
         const beforeClients = await initTwoClients({
@@ -118,8 +126,7 @@ describe("Client", () => {
         await beforeClients.A.ping({ topic });
         await beforeClients.B.ping({ topic });
         // delete
-        delete beforeClients.A;
-        delete beforeClients.B;
+        deleteClients(beforeClients);
         // restart
         const afterClients = await initTwoClients({
           storageOptions: { database: TEST_CLIENT_DATABASE },
@@ -127,6 +134,7 @@ describe("Client", () => {
         // ping
         await afterClients.A.ping({ topic });
         await afterClients.B.ping({ topic });
+        deleteClients(afterClients);
       });
     });
     describe("session", () => {
@@ -136,6 +144,7 @@ describe("Client", () => {
           sessionA: { topic },
         } = await testConnectMethod(clients);
         await clients.A.ping({ topic });
+        deleteClients(clients);
       });
       it("B pings A with existing session", async () => {
         const clients = await initTwoClients();
@@ -143,6 +152,7 @@ describe("Client", () => {
           sessionA: { topic },
         } = await testConnectMethod(clients);
         await clients.B.ping({ topic });
+        deleteClients(clients);
       });
       it("clients can ping each other after restart", async () => {
         const beforeClients = await initTwoClients({
@@ -155,8 +165,7 @@ describe("Client", () => {
         await beforeClients.A.ping({ topic });
         await beforeClients.B.ping({ topic });
         // delete
-        delete beforeClients.A;
-        delete beforeClients.B;
+        deleteClients(beforeClients);
         // restart
         const afterClients = await initTwoClients({
           storageOptions: { database: TEST_CLIENT_DATABASE },
@@ -164,6 +173,7 @@ describe("Client", () => {
         // ping
         await afterClients.A.ping({ topic });
         await afterClients.B.ping({ topic });
+        deleteClients(afterClients);
       });
     });
   });
@@ -185,6 +195,7 @@ describe("Client", () => {
       });
       const result = clients.A.session.get(topic).accounts;
       expect(result).to.eql(accountsAfter);
+      deleteClients(clients);
     });
   });
 
@@ -205,6 +216,7 @@ describe("Client", () => {
       });
       const result = clients.A.session.get(topic).namespaces;
       expect(result).to.eql(namespacesAfter);
+      deleteClients(clients);
     });
   });
 
@@ -222,6 +234,7 @@ describe("Client", () => {
       });
       const result = clients.A.session.get(topic).expiry;
       expect(result).to.eql(expiryAfter);
+      deleteClients(clients);
     });
   });
 });

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -28,9 +28,22 @@ describe("Client", () => {
       const { topic: pairingTopic } = A.pairing.get(A.pairing.keys[0]);
       await testConnectMethod(clients, {
         pairingTopic,
-        namespaces: [],
-        accounts: [],
       });
+    });
+    it("throws when invalid pairingTopic is provided", async () => {
+      const clients = await initTwoClients();
+      const promise = testConnectMethod(clients, { pairingTopic: "invalid" });
+      await expect(promise).to.eventually.be.rejectedWith(
+        "No matching pairing with topic: invalid",
+      );
+    });
+    it("throws when invalid or empty namespaces are provided", async () => {
+      const clients = await initTwoClients();
+      const promise1 = testConnectMethod(clients, { namespaces: [] });
+      await expect(promise1).to.eventually.be.rejectedWith("Missing or invalid namespaces");
+      // @ts-ignore
+      const promise2 = testConnectMethod(clients, { namespaces: {} });
+      await expect(promise2).to.eventually.be.rejectedWith("Missing or invalid namespaces");
     });
   });
 

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -172,7 +172,7 @@ describe("Client Integration", () => {
       const accountsBefore = clients.A.session.get(topic).accounts;
       const accountsAfter = [
         ...accountsBefore,
-        "eip155:42:0x3c582121909DE92Dc89A36898633C1aE4790382b",
+        "eip155:43114:0x3c582121909DE92Dc89A36898633C1aE4790382b",
       ];
       await clients.A.updateAccounts({
         topic,

--- a/packages/client/test/shared/connect.ts
+++ b/packages/client/test/shared/connect.ts
@@ -52,7 +52,7 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
 
   await Promise.all([
     new Promise<void>((resolve, reject) => {
-      B.on("session_proposal", async proposal => {
+      B.once("session_proposal", async proposal => {
         try {
           expect(proposal.namespaces).to.eql(connectParams.namespaces);
 

--- a/packages/client/test/shared/helpers.ts
+++ b/packages/client/test/shared/helpers.ts
@@ -1,0 +1,6 @@
+import Client from "../../src";
+
+export function deleteClients(clients: { A: Client; B: Client }) {
+  delete clients.A;
+  delete clients.B;
+}

--- a/packages/client/test/shared/index.ts
+++ b/packages/client/test/shared/index.ts
@@ -3,3 +3,4 @@ export * from "./connect";
 export * from "./init";
 export * from "./mock";
 export * from "./values";
+export * from "./helpers";

--- a/packages/client/test/shared/values.ts
+++ b/packages/client/test/shared/values.ts
@@ -93,6 +93,17 @@ export const TEST_SIGN_REQUEST = { method: TEST_SIGN_METHOD, params: TEST_SIGN_P
 
 export const TEST_RANDOM_REQUEST = { method: "random_method", params: [] };
 
+export const TEST_APPROVE_PARAMS = {
+  id: 123,
+  accounts: TEST_ACCOUNTS,
+  namespaces: TEST_NAMESPACES,
+};
+
+export const TEST_CONNECT_PARAMS = {
+  namespaces: TEST_NAMESPACES,
+  relays: [TEST_RELAY_OPTIONS],
+};
+
 // export const TEST_TIMEOUT_SHORT = CLIENT_SHORT_TIMEOUT;
 // export const TEST_TIMEOUT_SAFEGUARD = toMiliseconds(ONE_SECOND);
 // export const TEST_TIMEOUT_DURATION = toMiliseconds(THIRTY_SECONDS);

--- a/packages/client/test/shared/values.ts
+++ b/packages/client/test/shared/values.ts
@@ -56,11 +56,11 @@ export const TEST_CLIENT_OPTIONS_B = {
   metadata: TEST_APP_METADATA_B,
 };
 
-export const TEST_ETHEREUM_CHAIN_ID = 1;
+export const TEST_ETHEREUM_CHAIN = "eip155:1";
+export const TEST_ARBITRUM_CHAIN = "eip155:42161";
+export const TEST_AVALANCHE_CHAIN = "eip155:43114";
 
-export const TEST_ETHEREUM_CHAIN = `eip155:${TEST_ETHEREUM_CHAIN_ID}`;
-
-export const TEST_CHAINS = [TEST_ETHEREUM_CHAIN];
+export const TEST_CHAINS = [TEST_ETHEREUM_CHAIN, TEST_ARBITRUM_CHAIN, TEST_AVALANCHE_CHAIN];
 export const TEST_METHODS = [
   "eth_sendTransaction",
   "eth_signTransaction",
@@ -110,6 +110,10 @@ export const TEST_REJECT_PARAMS = {
     code: 0,
     message: "GENERIC",
   },
+};
+
+export const TEST_UPDATE_ACCOUNTS_PARAMS = {
+  accounts: TEST_ACCOUNTS,
 };
 
 // export const TEST_TIMEOUT_SHORT = CLIENT_SHORT_TIMEOUT;

--- a/packages/client/test/shared/values.ts
+++ b/packages/client/test/shared/values.ts
@@ -122,8 +122,13 @@ export const TEST_UPDATE_EXPIRY_PARAMS = {
   expiry: calcExpiry(FIVE_MINUTES),
 };
 
+export const TEST_REQUEST_PARAMS = {
+  request: { method: TEST_METHODS[0], params: [] },
+  chainId: TEST_CHAINS[0],
+};
+
 export const TEST_EMIT_PARAMS = {
-  event: TEST_EVENTS[0],
+  event: { name: TEST_EVENTS[0], data: "" },
   chainId: TEST_CHAINS[0],
 };
 

--- a/packages/client/test/shared/values.ts
+++ b/packages/client/test/shared/values.ts
@@ -93,15 +93,23 @@ export const TEST_SIGN_REQUEST = { method: TEST_SIGN_METHOD, params: TEST_SIGN_P
 
 export const TEST_RANDOM_REQUEST = { method: "random_method", params: [] };
 
+export const TEST_CONNECT_PARAMS = {
+  namespaces: TEST_NAMESPACES,
+  relays: [TEST_RELAY_OPTIONS],
+};
+
 export const TEST_APPROVE_PARAMS = {
   id: 123,
   accounts: TEST_ACCOUNTS,
   namespaces: TEST_NAMESPACES,
 };
 
-export const TEST_CONNECT_PARAMS = {
-  namespaces: TEST_NAMESPACES,
-  relays: [TEST_RELAY_OPTIONS],
+export const TEST_REJECT_PARAMS = {
+  id: 123,
+  reason: {
+    code: 0,
+    message: "GENERIC",
+  },
 };
 
 // export const TEST_TIMEOUT_SHORT = CLIENT_SHORT_TIMEOUT;

--- a/packages/client/test/shared/values.ts
+++ b/packages/client/test/shared/values.ts
@@ -1,5 +1,7 @@
 import path from "path";
 import { ClientTypes, RelayerTypes } from "@walletconnect/types";
+import { calcExpiry } from "@walletconnect/utils";
+import { FIVE_MINUTES } from "@walletconnect/time";
 
 // @ts-ignore
 import { ROOT_DIR } from "../../../../ops/js/shared";
@@ -114,6 +116,10 @@ export const TEST_REJECT_PARAMS = {
 
 export const TEST_UPDATE_ACCOUNTS_PARAMS = {
   accounts: TEST_ACCOUNTS,
+};
+
+export const TEST_UPDATE_EXPIRY_PARAMS = {
+  expiry: calcExpiry(FIVE_MINUTES),
 };
 
 // export const TEST_TIMEOUT_SHORT = CLIENT_SHORT_TIMEOUT;

--- a/packages/client/test/shared/values.ts
+++ b/packages/client/test/shared/values.ts
@@ -127,6 +127,14 @@ export const TEST_REQUEST_PARAMS = {
   chainId: TEST_CHAINS[0],
 };
 
+export const TEST_RESPOND_PARAMS = {
+  response: {
+    id: 1,
+    jsonrpc: "2.0",
+    result: {},
+  },
+};
+
 export const TEST_EMIT_PARAMS = {
   event: { name: TEST_EVENTS[0], data: "" },
   chainId: TEST_CHAINS[0],

--- a/packages/client/test/shared/values.ts
+++ b/packages/client/test/shared/values.ts
@@ -122,6 +122,10 @@ export const TEST_UPDATE_EXPIRY_PARAMS = {
   expiry: calcExpiry(FIVE_MINUTES),
 };
 
+export const TEST_UPDATE_NAMESPACES_PARAMS = {
+  namespaces: TEST_NAMESPACES,
+};
+
 export const TEST_REQUEST_PARAMS = {
   request: { method: TEST_METHODS[0], params: [] },
   chainId: TEST_CHAINS[0],

--- a/packages/client/test/shared/values.ts
+++ b/packages/client/test/shared/values.ts
@@ -122,6 +122,11 @@ export const TEST_UPDATE_EXPIRY_PARAMS = {
   expiry: calcExpiry(FIVE_MINUTES),
 };
 
+export const TEST_EMIT_PARAMS = {
+  event: TEST_EVENTS[0],
+  chainId: TEST_CHAINS[0],
+};
+
 // export const TEST_TIMEOUT_SHORT = CLIENT_SHORT_TIMEOUT;
 // export const TEST_TIMEOUT_SAFEGUARD = toMiliseconds(ONE_SECOND);
 // export const TEST_TIMEOUT_DURATION = toMiliseconds(THIRTY_SECONDS);

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -6,6 +6,7 @@ import {
   testConnectMethod,
   TEST_APPROVE_PARAMS,
   TEST_CONNECT_PARAMS,
+  TEST_REJECT_PARAMS,
 } from "./shared";
 import Client from "../src";
 
@@ -120,6 +121,74 @@ describe("Client Validation", () => {
       await expect(
         client.approve({ ...TEST_APPROVE_PARAMS, relayProtocol: "" }),
       ).to.eventually.be.rejectedWith("Missing or invalid approve relayProtocol");
+    });
+  });
+
+  describe("reject", () => {
+    it("throws when no params are passed", async () => {
+      await expect(client.reject()).to.eventually.be.rejectedWith(
+        "Missing or invalid reject params",
+      );
+    });
+
+    it("throws when invalid id is provided", async () => {
+      await expect(
+        client.reject({ ...TEST_REJECT_PARAMS, id: "123" }),
+      ).to.eventually.be.rejectedWith("Missing or invalid reject id");
+    });
+
+    it("throws when empty id is provided", async () => {
+      await expect(client.reject({ ...TEST_REJECT_PARAMS, id: "" })).to.eventually.be.rejectedWith(
+        "Missing or invalid reject id",
+      );
+    });
+
+    it("throws when empty reason is provided", async () => {
+      await expect(
+        client.reject({ ...TEST_REJECT_PARAMS, reason: {} }),
+      ).to.eventually.be.rejectedWith("Missing or invalid reject reason");
+    });
+
+    it("throws when invalid reason is provided", async () => {
+      await expect(
+        client.reject({ ...TEST_REJECT_PARAMS, reason: [] }),
+      ).to.eventually.be.rejectedWith("Missing or invalid reject reason");
+    });
+
+    it("throws when invalid reason code is provided", async () => {
+      await expect(
+        client.reject({
+          ...TEST_REJECT_PARAMS,
+          reason: { ...TEST_REJECT_PARAMS.reason, code: "1" },
+        }),
+      ).to.eventually.be.rejectedWith("Missing or invalid reject reason");
+    });
+
+    it("throws when empty reason code is provided", async () => {
+      await expect(
+        client.reject({
+          ...TEST_REJECT_PARAMS,
+          reason: { ...TEST_REJECT_PARAMS.reason, code: "" },
+        }),
+      ).to.eventually.be.rejectedWith("Missing or invalid reject reason");
+    });
+
+    it("throws when invalid reason message is provided", async () => {
+      await expect(
+        client.reject({
+          ...TEST_REJECT_PARAMS,
+          reason: { ...TEST_REJECT_PARAMS.reason, message: 123 },
+        }),
+      ).to.eventually.be.rejectedWith("Missing or invalid reject reason");
+    });
+
+    it("throws when empty reason message is provided", async () => {
+      await expect(
+        client.reject({
+          ...TEST_REJECT_PARAMS,
+          reason: { ...TEST_REJECT_PARAMS.reason, message: "" },
+        }),
+      ).to.eventually.be.rejectedWith("Missing or invalid reject reason");
     });
   });
 });

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -503,4 +503,36 @@ describe("Client Validation", () => {
       ).to.eventually.be.rejectedWith("Missing or invalid emit event");
     });
   });
+
+  describe("disconnect", () => {
+    it("throws when no params are passed", async () => {
+      await expect(client.disconnect()).to.eventually.be.rejectedWith(
+        "Missing or invalid disconnect params",
+      );
+    });
+
+    it("throws when invalid topic is provided", async () => {
+      await expect(client.disconnect({ topic: 123 })).to.eventually.be.rejectedWith(
+        "Missing or invalid disconnect topic",
+      );
+    });
+
+    it("throws when empty topic is provided", async () => {
+      await expect(client.disconnect({ topic: "" })).to.eventually.be.rejectedWith(
+        "Missing or invalid disconnect topic",
+      );
+    });
+
+    it("throws when no topic is provided", async () => {
+      await expect(client.disconnect({ topic: undefined })).to.eventually.be.rejectedWith(
+        "Missing or invalid disconnect topic",
+      );
+    });
+
+    it("throws when non existant topic is provided", async () => {
+      await expect(client.disconnect({ topic: "none" })).to.eventually.be.rejectedWith(
+        "No matching pairing or session with topic: none",
+      );
+    });
+  });
 });

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -388,4 +388,34 @@ describe("Client Validation", () => {
       );
     });
   });
+
+  describe("ping", () => {
+    it("throws when no params are passed", async () => {
+      await expect(client.ping()).to.eventually.be.rejectedWith("Missing or invalid ping params");
+    });
+
+    it("throws when invalid topic is provided", async () => {
+      await expect(client.ping({ topic: 123 })).to.eventually.be.rejectedWith(
+        "Missing or invalid ping topic",
+      );
+    });
+
+    it("throws when empty topic is provided", async () => {
+      await expect(client.ping({ topic: "" })).to.eventually.be.rejectedWith(
+        "Missing or invalid ping topic",
+      );
+    });
+
+    it("throws when no topic is provided", async () => {
+      await expect(client.ping({ topic: undefined })).to.eventually.be.rejectedWith(
+        "Missing or invalid ping topic",
+      );
+    });
+
+    it("throws when non existant topic is provided", async () => {
+      await expect(client.ping({ topic: "none" })).to.eventually.be.rejectedWith(
+        "No matching pairing or session with topic: none",
+      );
+    });
+  });
 });

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -9,15 +9,14 @@ import {
 } from "./shared";
 import Client from "../src";
 
-describe("Client Validation", () => {
-  let client: Client;
-  let pairingTopic: string;
+let client: Client;
+let pairingTopic: string;
 
+describe("Client Validation", () => {
   before(async () => {
     const clients = await initTwoClients();
     await testConnectMethod(clients);
-    const { A } = clients;
-    client = A;
+    client = clients.A;
     pairingTopic = client.pairing.keys[0];
   });
 
@@ -37,43 +36,45 @@ describe("Client Validation", () => {
     it("throws when empty namespaces are provided", async () => {
       await expect(
         client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, namespaces: [] }),
-      ).to.eventually.be.rejectedWith("Missing or invalid namespaces");
+      ).to.eventually.be.rejectedWith("Missing or invalid connect namespaces");
     });
 
     it("throws when invalid namespaces are provided", async () => {
       await expect(
         client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, namespaces: {} }),
-      ).to.eventually.be.rejectedWith("Missing or invalid namespaces");
+      ).to.eventually.be.rejectedWith("Missing or invalid connect namespaces");
     });
   });
 
   describe("pair", () => {
     it("throws when undefined params are passed", async () => {
-      await expect(client.pair()).to.eventually.be.rejectedWith("Missing or invalid uri");
+      await expect(client.pair()).to.eventually.be.rejectedWith("Missing or invalid pair params");
     });
 
     it("throws when empty uri is provided", async () => {
       await expect(client.pair({ uri: "" })).to.eventually.be.rejectedWith(
-        "Missing or invalid uri",
+        "Missing or invalid pair uri",
       );
     });
 
     it("throws when invalid uri is provided", async () => {
       await expect(client.pair({ uri: 123 })).to.eventually.be.rejectedWith(
-        "Missing or invalid uri",
+        "Missing or invalid pair uri",
       );
     });
   });
 
   describe("approve", () => {
     it("throws when undefined params are passed", async () => {
-      await expect(client.approve()).to.eventually.be.rejectedWith("Missing or invalid uri");
+      await expect(client.approve()).to.eventually.be.rejectedWith(
+        "Missing or invalid approve params",
+      );
     });
 
     it("throws when invalid id is provided", async () => {
       await expect(
         client.approve({ ...TEST_APPROVE_PARAMS, id: "123" }),
-      ).to.eventually.be.rejectedWith("balegdeh");
+      ).to.eventually.be.rejectedWith("Missing or invalid approve id");
     });
   });
 });

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -11,6 +11,8 @@ import {
   TEST_UPDATE_EXPIRY_PARAMS,
 } from "./shared";
 import Client from "../src";
+import { calcExpiry } from "@walletconnect/utils";
+import { ONE_MINUTE, THIRTY_DAYS } from "@walletconnect/time";
 
 let client: Client;
 let pairingTopic: string;
@@ -356,6 +358,34 @@ describe("Client Validation", () => {
       await expect(
         client.updateExpiry({ ...TEST_UPDATE_EXPIRY_PARAMS, topic: "none" }),
       ).to.eventually.be.rejectedWith("No matching session with topic: none");
+    });
+
+    it("throws when invalid expiry is provided", async () => {
+      await expect(client.updateExpiry({ topic, expiry: "1" })).to.eventually.be.rejectedWith(
+        "Missing or invalid updateExpiry expiry (min 5 min, max 30 days)",
+      );
+    });
+
+    it("throws when no expiry is provided", async () => {
+      await expect(client.updateExpiry({ topic, expiry: undefined })).to.eventually.be.rejectedWith(
+        "Missing or invalid updateExpiry expiry (min 5 min, max 30 days)",
+      );
+    });
+
+    it("throws when expiry is less than 5 minutes", async () => {
+      await expect(
+        client.updateExpiry({ topic, expiry: calcExpiry(ONE_MINUTE) }),
+      ).to.eventually.be.rejectedWith(
+        "Missing or invalid updateExpiry expiry (min 5 min, max 30 days)",
+      );
+    });
+
+    it("throws when expiry is more than 30 days", async () => {
+      await expect(
+        client.updateExpiry({ topic, expiry: calcExpiry(THIRTY_DAYS + ONE_MINUTE) }),
+      ).to.eventually.be.rejectedWith(
+        "Missing or invalid updateExpiry expiry (min 5 min, max 30 days)",
+      );
     });
   });
 });

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -47,7 +47,7 @@ describe("Client Validation", () => {
   });
 
   describe("pair", () => {
-    it("throws when undefined params are passed", async () => {
+    it("throws when no params are passed", async () => {
       await expect(client.pair()).to.eventually.be.rejectedWith("Missing or invalid pair params");
     });
 
@@ -65,7 +65,7 @@ describe("Client Validation", () => {
   });
 
   describe("approve", () => {
-    it("throws when undefined params are passed", async () => {
+    it("throws when no params are passed", async () => {
       await expect(client.approve()).to.eventually.be.rejectedWith(
         "Missing or invalid approve params",
       );
@@ -75,6 +75,51 @@ describe("Client Validation", () => {
       await expect(
         client.approve({ ...TEST_APPROVE_PARAMS, id: "123" }),
       ).to.eventually.be.rejectedWith("Missing or invalid approve id");
+    });
+
+    it("throws when empty id is provided", async () => {
+      await expect(
+        client.approve({ ...TEST_APPROVE_PARAMS, id: "" }),
+      ).to.eventually.be.rejectedWith("Missing or invalid approve id");
+    });
+
+    it("throws when invalid accounts are provided", async () => {
+      await expect(
+        client.approve({ ...TEST_APPROVE_PARAMS, accounts: [123] }),
+      ).to.eventually.be.rejectedWith("Missing or invalid approve accounts");
+      await expect(
+        client.approve({ ...TEST_APPROVE_PARAMS, accounts: ["123"] }),
+      ).to.eventually.be.rejectedWith("Missing or invalid approve accounts");
+    });
+
+    it("throws when empty accounts are provided", async () => {
+      await expect(
+        client.approve({ ...TEST_APPROVE_PARAMS, accounts: [] }),
+      ).to.eventually.be.rejectedWith("Missing or invalid approve accounts");
+    });
+
+    it("throws when invalid namespaces are provided", async () => {
+      await expect(
+        client.approve({ ...TEST_APPROVE_PARAMS, namespaces: {} }),
+      ).to.eventually.be.rejectedWith("Missing or invalid approve namespaces");
+    });
+
+    it("throws when empty namespaces are provided", async () => {
+      await expect(
+        client.approve({ ...TEST_APPROVE_PARAMS, namespaces: [] }),
+      ).to.eventually.be.rejectedWith("Missing or invalid approve namespaces");
+    });
+
+    it("throws when invalid relayProtocol are provided", async () => {
+      await expect(
+        client.approve({ ...TEST_APPROVE_PARAMS, relayProtocol: 123 }),
+      ).to.eventually.be.rejectedWith("Missing or invalid approve relayProtocol");
+    });
+
+    it("throws when empty relayProtocol is provided", async () => {
+      await expect(
+        client.approve({ ...TEST_APPROVE_PARAMS, relayProtocol: "" }),
+      ).to.eventually.be.rejectedWith("Missing or invalid approve relayProtocol");
     });
   });
 });

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -7,11 +7,13 @@ import {
   TEST_APPROVE_PARAMS,
   TEST_CONNECT_PARAMS,
   TEST_REJECT_PARAMS,
+  TEST_UPDATE_ACCOUNTS_PARAMS,
 } from "./shared";
 import Client from "../src";
 
 let client: Client;
 let pairingTopic: string;
+let topic: string;
 
 describe("Client Validation", () => {
   before(async () => {
@@ -19,6 +21,7 @@ describe("Client Validation", () => {
     await testConnectMethod(clients);
     client = clients.A;
     pairingTopic = client.pairing.keys[0];
+    topic = client.session.keys[0];
   });
 
   describe("connect", () => {
@@ -26,6 +29,18 @@ describe("Client Validation", () => {
       await expect(client.connect()).to.eventually.be.rejectedWith(
         "Missing or invalid connect params",
       );
+    });
+
+    it("throws when invalid pairingTopic is provided", async () => {
+      await expect(
+        client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic: 123 }),
+      ).to.eventually.be.rejectedWith("Missing or invalid connect pairingTopic");
+    });
+
+    it("throws when empty pairingTopic is provided", async () => {
+      await expect(
+        client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic: "" }),
+      ).to.eventually.be.rejectedWith("Missing or invalid connect pairingTopic");
     });
 
     it("throws when non existant pairingTopic is provided", async () => {
@@ -63,6 +78,12 @@ describe("Client Validation", () => {
         "Missing or invalid pair uri",
       );
     });
+
+    it("throws when no uri is provided", async () => {
+      await expect(client.pair({ uri: undefined })).to.eventually.be.rejectedWith(
+        "Missing or invalid pair uri",
+      );
+    });
   });
 
   describe("approve", () => {
@@ -84,6 +105,12 @@ describe("Client Validation", () => {
       ).to.eventually.be.rejectedWith("Missing or invalid approve id");
     });
 
+    it("throws when no id is provided", async () => {
+      await expect(
+        client.approve({ ...TEST_APPROVE_PARAMS, id: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid approve id");
+    });
+
     it("throws when invalid accounts are provided", async () => {
       await expect(
         client.approve({ ...TEST_APPROVE_PARAMS, accounts: [123] }),
@@ -99,6 +126,12 @@ describe("Client Validation", () => {
       ).to.eventually.be.rejectedWith("Missing or invalid approve accounts");
     });
 
+    it("throws when no accounts are provided", async () => {
+      await expect(
+        client.approve({ ...TEST_APPROVE_PARAMS, accounts: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid approve accounts");
+    });
+
     it("throws when invalid namespaces are provided", async () => {
       await expect(
         client.approve({ ...TEST_APPROVE_PARAMS, namespaces: {} }),
@@ -108,6 +141,12 @@ describe("Client Validation", () => {
     it("throws when empty namespaces are provided", async () => {
       await expect(
         client.approve({ ...TEST_APPROVE_PARAMS, namespaces: [] }),
+      ).to.eventually.be.rejectedWith("Missing or invalid approve namespaces");
+    });
+
+    it("throws when no namespaces are provided", async () => {
+      await expect(
+        client.approve({ ...TEST_APPROVE_PARAMS, namespaces: undefined }),
       ).to.eventually.be.rejectedWith("Missing or invalid approve namespaces");
     });
 
@@ -143,6 +182,12 @@ describe("Client Validation", () => {
       );
     });
 
+    it("throws when no id is provided", async () => {
+      await expect(
+        client.reject({ ...TEST_REJECT_PARAMS, id: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid reject id");
+    });
+
     it("throws when empty reason is provided", async () => {
       await expect(
         client.reject({ ...TEST_REJECT_PARAMS, reason: {} }),
@@ -152,6 +197,12 @@ describe("Client Validation", () => {
     it("throws when invalid reason is provided", async () => {
       await expect(
         client.reject({ ...TEST_REJECT_PARAMS, reason: [] }),
+      ).to.eventually.be.rejectedWith("Missing or invalid reject reason");
+    });
+
+    it("throws when no reason is provided", async () => {
+      await expect(
+        client.reject({ ...TEST_REJECT_PARAMS, reason: undefined }),
       ).to.eventually.be.rejectedWith("Missing or invalid reject reason");
     });
 
@@ -173,6 +224,15 @@ describe("Client Validation", () => {
       ).to.eventually.be.rejectedWith("Missing or invalid reject reason");
     });
 
+    it("throws when no reason code is provided", async () => {
+      await expect(
+        client.reject({
+          ...TEST_REJECT_PARAMS,
+          reason: { ...TEST_REJECT_PARAMS.reason, code: undefined },
+        }),
+      ).to.eventually.be.rejectedWith("Missing or invalid reject reason");
+    });
+
     it("throws when invalid reason message is provided", async () => {
       await expect(
         client.reject({
@@ -189,6 +249,62 @@ describe("Client Validation", () => {
           reason: { ...TEST_REJECT_PARAMS.reason, message: "" },
         }),
       ).to.eventually.be.rejectedWith("Missing or invalid reject reason");
+    });
+
+    it("throws when no reason message is provided", async () => {
+      await expect(
+        client.reject({
+          ...TEST_REJECT_PARAMS,
+          reason: { ...TEST_REJECT_PARAMS.reason, message: undefined },
+        }),
+      ).to.eventually.be.rejectedWith("Missing or invalid reject reason");
+    });
+  });
+
+  describe("updateAccounts", () => {
+    it("throws when no params are passed", async () => {
+      await expect(client.updateAccounts()).to.eventually.be.rejectedWith(
+        "Missing or invalid updateAccounts params",
+      );
+    });
+
+    it("throws when invalid topic is provided", async () => {
+      await expect(
+        client.updateAccounts({ ...TEST_UPDATE_ACCOUNTS_PARAMS, topic: 123 }),
+      ).to.eventually.be.rejectedWith("Missing or invalid updateAccounts topic");
+    });
+
+    it("throws when empty topic is provided", async () => {
+      await expect(
+        client.updateAccounts({ ...TEST_UPDATE_ACCOUNTS_PARAMS, topic: "" }),
+      ).to.eventually.be.rejectedWith("Missing or invalid updateAccounts topic");
+    });
+
+    it("throws when no topic is provided", async () => {
+      await expect(
+        client.updateAccounts({ ...TEST_UPDATE_ACCOUNTS_PARAMS, topic: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid updateAccounts topic");
+    });
+
+    it("throws when non existant topic is provided", async () => {
+      await expect(
+        client.updateAccounts({ ...TEST_UPDATE_ACCOUNTS_PARAMS, topic: "none" }),
+      ).to.eventually.be.rejectedWith("No matching session with topic: none");
+    });
+
+    it("throws when invalid accounts are provided", async () => {
+      await expect(
+        client.updateAccounts({ ...TEST_UPDATE_ACCOUNTS_PARAMS, topic, accounts: [123] }),
+      ).to.eventually.be.rejectedWith("Missing or invalid updateAccounts accounts");
+      await expect(
+        client.updateAccounts({ ...TEST_UPDATE_ACCOUNTS_PARAMS, topic, accounts: ["123"] }),
+      ).to.eventually.be.rejectedWith("Missing or invalid updateAccounts accounts");
+    });
+
+    it("throws when no accounts are provided", async () => {
+      await expect(
+        client.updateAccounts({ ...TEST_UPDATE_ACCOUNTS_PARAMS, topic, accounts: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid updateAccounts accounts");
     });
   });
 });

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -9,6 +9,7 @@ import {
   TEST_REJECT_PARAMS,
   TEST_UPDATE_ACCOUNTS_PARAMS,
   TEST_UPDATE_EXPIRY_PARAMS,
+  TEST_REQUEST_PARAMS,
   TEST_EMIT_PARAMS,
 } from "./shared";
 import Client from "../src";
@@ -387,6 +388,92 @@ describe("Client Validation", () => {
       ).to.eventually.be.rejectedWith(
         "Missing or invalid updateExpiry expiry (min 5 min, max 7 days)",
       );
+    });
+  });
+
+  describe("request", () => {
+    it("throws when no params are passed", async () => {
+      await expect(client.request()).to.eventually.be.rejectedWith(
+        "Missing or invalid request params",
+      );
+    });
+
+    it("throws when invalid topic is provided", async () => {
+      await expect(
+        client.request({ ...TEST_REQUEST_PARAMS, topic: 123 }),
+      ).to.eventually.be.rejectedWith("Missing or invalid request topic");
+    });
+
+    it("throws when empty topic is provided", async () => {
+      await expect(
+        client.request({ ...TEST_REQUEST_PARAMS, topic: "" }),
+      ).to.eventually.be.rejectedWith("Missing or invalid request topic");
+    });
+
+    it("throws when no topic is provided", async () => {
+      await expect(
+        client.request({ ...TEST_REQUEST_PARAMS, topic: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid request topic");
+    });
+
+    it("throws when non existant topic is provided", async () => {
+      await expect(
+        client.ping({ ...TEST_REQUEST_PARAMS, topic: "none" }),
+      ).to.eventually.be.rejectedWith("No matching pairing or session with topic: none");
+    });
+
+    it("throws when invalid chainId is provided", async () => {
+      await expect(
+        client.request({ ...TEST_REQUEST_PARAMS, topic, chainId: 123 }),
+      ).to.eventually.be.rejectedWith("Missing or invalid request chainId");
+    });
+
+    it("throws when empty chainId is provided", async () => {
+      await expect(
+        client.request({ ...TEST_REQUEST_PARAMS, topic, chainId: "" }),
+      ).to.eventually.be.rejectedWith("Missing or invalid request chainId");
+    });
+
+    it("throws when invalid request is provided", async () => {
+      await expect(
+        client.request({ ...TEST_REQUEST_PARAMS, topic, request: 123 }),
+      ).to.eventually.be.rejectedWith("Missing or invalid request method");
+    });
+
+    it("throws when empty request is provided", async () => {
+      await expect(
+        client.request({ ...TEST_REQUEST_PARAMS, topic, request: {} }),
+      ).to.eventually.be.rejectedWith("Missing or invalid request method");
+    });
+
+    it("throws when no request is provided", async () => {
+      await expect(
+        client.request({ ...TEST_REQUEST_PARAMS, topic, request: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid request method");
+    });
+
+    it("throws when invalid request method is provided", async () => {
+      await expect(
+        client.request({ ...TEST_REQUEST_PARAMS, topic, request: { method: 123 } }),
+      ).to.eventually.be.rejectedWith("Missing or invalid request method");
+    });
+
+    it("throws when empty request method is provided", async () => {
+      await expect(
+        client.request({ ...TEST_REQUEST_PARAMS, topic, request: { method: "" } }),
+      ).to.eventually.be.rejectedWith("Missing or invalid request method");
+    });
+
+    it("throws when no request method is provided", async () => {
+      await expect(
+        client.request({ ...TEST_REQUEST_PARAMS, topic, request: { method: undefined } }),
+      ).to.eventually.be.rejectedWith("Missing or invalid request method");
+    });
+
+    it("throws when request doesn't exist for given chainId", async () => {
+      await expect(
+        client.request({ ...TEST_REQUEST_PARAMS, topic, request: { method: "unknown" } }),
+      ).to.eventually.be.rejectedWith("Missing or invalid request method");
     });
   });
 

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -6,32 +6,41 @@ import {
   TEST_APPROVE_PARAMS,
   TEST_CONNECT_PARAMS,
 } from "./shared";
+import Client from "../src";
 
 describe("Client Validation", () => {
-  const clients = await initTwoClients();
-  await testConnectMethod(clients);
-  const { A } = clients;
-  const pairingTopic = A.pairing.keys[0];
+  let client: Client;
+  let pairingTopic: string;
+
+  before(async () => {
+    const clients = await initTwoClients();
+    await testConnectMethod(clients);
+    const { A } = clients;
+    client = A;
+    pairingTopic = client.pairing.keys[0];
+  });
 
   describe("connect", () => {
     it("throws when no params are passed", async () => {
       // @ts-expect-error
-      await expect(A.connect()).to.eventually.be.rejectedWith("Missing or invalid connect params");
+      await expect(client.connect()).to.eventually.be.rejectedWith(
+        "Missing or invalid connect params",
+      );
     });
     it("throws when non existant pairingTopic is provided", async () => {
       await expect(
-        A.connect({ ...TEST_CONNECT_PARAMS, pairingTopic: "none" }),
+        client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic: "none" }),
       ).to.eventually.be.rejectedWith("No matching pairing with topic: none");
     });
     it("throws when empty namespaces are provided", async () => {
       await expect(
-        A.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, namespaces: [] }),
+        client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, namespaces: [] }),
       ).to.eventually.be.rejectedWith("Missing or invalid namespaces");
     });
     it("throws when invalid namespaces are provided", async () => {
       await expect(
         // @ts-expect-error
-        A.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, namespaces: {} }),
+        client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, namespaces: {} }),
       ).to.eventually.be.rejectedWith("Missing or invalid namespaces");
     });
   });
@@ -39,26 +48,30 @@ describe("Client Validation", () => {
   describe("pair", () => {
     it("throws when undefined params are passed", async () => {
       // @ts-expect-error
-      await expect(A.pair()).to.eventually.be.rejectedWith("Missing or invalid uri");
+      await expect(client.pair()).to.eventually.be.rejectedWith("Missing or invalid uri");
     });
     it("throws when empty uri is provided", async () => {
-      await expect(A.pair({ uri: "" })).to.eventually.be.rejectedWith("Missing or invalid uri");
+      await expect(client.pair({ uri: "" })).to.eventually.be.rejectedWith(
+        "Missing or invalid uri",
+      );
     });
     it("throws when invalid uri is provided", async () => {
       // @ts-expect-error
-      await expect(A.pair({ uri: 123 })).to.eventually.be.rejectedWith("Missing or invalid uri");
+      await expect(client.pair({ uri: 123 })).to.eventually.be.rejectedWith(
+        "Missing or invalid uri",
+      );
     });
   });
 
   describe("approve", () => {
     it("throws when undefined params are passed", async () => {
       // @ts-expect-error
-      await expect(A.approve()).to.eventually.be.rejectedWith("Missing or invalid uri");
+      await expect(client.approve()).to.eventually.be.rejectedWith("Missing or invalid uri");
     });
     it("throws when invalid id is provided", async () => {
       await expect(
         // @ts-expect-error
-        A.approve({ ...TEST_APPROVE_PARAMS, id: "123" }),
+        client.approve({ ...TEST_APPROVE_PARAMS, id: "123" }),
       ).to.eventually.be.rejectedWith("balegdeh");
     });
   });

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -12,6 +12,7 @@ import {
   TEST_REQUEST_PARAMS,
   TEST_EMIT_PARAMS,
   TEST_RESPOND_PARAMS,
+  TEST_UPDATE_NAMESPACES_PARAMS,
 } from "./shared";
 import Client from "../src";
 import { calcExpiry } from "@walletconnect/utils";
@@ -329,7 +330,53 @@ describe("Client Validation", () => {
   });
 
   describe("updateNamespaces", () => {
-    // TODO
+    it("throws when no params are passed", async () => {
+      await expect(client.updateNamespaces()).to.eventually.be.rejectedWith(
+        "Missing or invalid updateNamespaces params",
+      );
+    });
+
+    it("throws when invalid topic is provided", async () => {
+      await expect(
+        client.updateNamespaces({ ...TEST_UPDATE_NAMESPACES_PARAMS, topic: 123 }),
+      ).to.eventually.be.rejectedWith("Missing or invalid updateNamespaces topic");
+    });
+
+    it("throws when empty topic is provided", async () => {
+      await expect(
+        client.updateNamespaces({ ...TEST_UPDATE_NAMESPACES_PARAMS, topic: "" }),
+      ).to.eventually.be.rejectedWith("Missing or invalid updateNamespaces topic");
+    });
+
+    it("throws when no topic is provided", async () => {
+      await expect(
+        client.updateNamespaces({ ...TEST_UPDATE_NAMESPACES_PARAMS, topic: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid updateNamespaces topic");
+    });
+
+    it("throws when non existant topic is provided", async () => {
+      await expect(
+        client.updateNamespaces({ ...TEST_UPDATE_NAMESPACES_PARAMS, topic: "none" }),
+      ).to.eventually.be.rejectedWith("No matching session with topic: none");
+    });
+
+    it("throws when invalid namespaces are provided", async () => {
+      await expect(
+        client.updateNamespaces({ topic, namespaces: {} }),
+      ).to.eventually.be.rejectedWith("Missing or invalid updateNamespaces namespaces");
+    });
+
+    it("throws when empty namespaces are provided", async () => {
+      await expect(
+        client.updateNamespaces({ topic, namespaces: [] }),
+      ).to.eventually.be.rejectedWith("Missing or invalid updateNamespaces namespaces");
+    });
+
+    it("throws when no namespaces are provided", async () => {
+      await expect(
+        client.updateNamespaces({ topic, namespaces: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid updateNamespaces namespaces");
+    });
   });
 
   describe("updateExpiry", () => {

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -293,18 +293,32 @@ describe("Client Validation", () => {
     });
 
     it("throws when invalid accounts are provided", async () => {
+      await expect(client.updateAccounts({ topic, accounts: [123] })).to.eventually.be.rejectedWith(
+        "Missing or invalid updateAccounts accounts",
+      );
       await expect(
-        client.updateAccounts({ ...TEST_UPDATE_ACCOUNTS_PARAMS, topic, accounts: [123] }),
-      ).to.eventually.be.rejectedWith("Missing or invalid updateAccounts accounts");
-      await expect(
-        client.updateAccounts({ ...TEST_UPDATE_ACCOUNTS_PARAMS, topic, accounts: ["123"] }),
+        client.updateAccounts({ topic, accounts: ["123"] }),
       ).to.eventually.be.rejectedWith("Missing or invalid updateAccounts accounts");
     });
 
     it("throws when no accounts are provided", async () => {
       await expect(
-        client.updateAccounts({ ...TEST_UPDATE_ACCOUNTS_PARAMS, topic, accounts: undefined }),
+        client.updateAccounts({ topic, accounts: undefined }),
       ).to.eventually.be.rejectedWith("Missing or invalid updateAccounts accounts");
+    });
+
+    it("throws when provided accounts are not in session namespace", async () => {
+      await expect(
+        client.updateAccounts({
+          topic,
+          accounts: [
+            "eip155:42:0x3c582121909DE92Dc89A36898633C1aE4790382b",
+            "eip155:10:0x3c582121909DE92Dc89A36898633C1aE4790382b",
+          ],
+        }),
+      ).to.eventually.be.rejectedWith(
+        "Invalid accounts with mismatched chains: eip155:42,eip155:10",
+      );
     });
   });
 });

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import "mocha";
 import {
   expect,
@@ -22,24 +23,25 @@ describe("Client Validation", () => {
 
   describe("connect", () => {
     it("throws when no params are passed", async () => {
-      // @ts-expect-error
       await expect(client.connect()).to.eventually.be.rejectedWith(
         "Missing or invalid connect params",
       );
     });
+
     it("throws when non existant pairingTopic is provided", async () => {
       await expect(
         client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic: "none" }),
       ).to.eventually.be.rejectedWith("No matching pairing with topic: none");
     });
+
     it("throws when empty namespaces are provided", async () => {
       await expect(
         client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, namespaces: [] }),
       ).to.eventually.be.rejectedWith("Missing or invalid namespaces");
     });
+
     it("throws when invalid namespaces are provided", async () => {
       await expect(
-        // @ts-expect-error
         client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, namespaces: {} }),
       ).to.eventually.be.rejectedWith("Missing or invalid namespaces");
     });
@@ -47,16 +49,16 @@ describe("Client Validation", () => {
 
   describe("pair", () => {
     it("throws when undefined params are passed", async () => {
-      // @ts-expect-error
       await expect(client.pair()).to.eventually.be.rejectedWith("Missing or invalid uri");
     });
+
     it("throws when empty uri is provided", async () => {
       await expect(client.pair({ uri: "" })).to.eventually.be.rejectedWith(
         "Missing or invalid uri",
       );
     });
+
     it("throws when invalid uri is provided", async () => {
-      // @ts-expect-error
       await expect(client.pair({ uri: 123 })).to.eventually.be.rejectedWith(
         "Missing or invalid uri",
       );
@@ -65,12 +67,11 @@ describe("Client Validation", () => {
 
   describe("approve", () => {
     it("throws when undefined params are passed", async () => {
-      // @ts-expect-error
       await expect(client.approve()).to.eventually.be.rejectedWith("Missing or invalid uri");
     });
+
     it("throws when invalid id is provided", async () => {
       await expect(
-        // @ts-expect-error
         client.approve({ ...TEST_APPROVE_PARAMS, id: "123" }),
       ).to.eventually.be.rejectedWith("balegdeh");
     });

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -11,6 +11,7 @@ import {
   TEST_UPDATE_EXPIRY_PARAMS,
   TEST_REQUEST_PARAMS,
   TEST_EMIT_PARAMS,
+  TEST_RESPOND_PARAMS,
 } from "./shared";
 import Client from "../src";
 import { calcExpiry } from "@walletconnect/utils";
@@ -418,8 +419,8 @@ describe("Client Validation", () => {
 
     it("throws when non existant topic is provided", async () => {
       await expect(
-        client.ping({ ...TEST_REQUEST_PARAMS, topic: "none" }),
-      ).to.eventually.be.rejectedWith("No matching pairing or session with topic: none");
+        client.request({ ...TEST_REQUEST_PARAMS, topic: "none" }),
+      ).to.eventually.be.rejectedWith("No matching session with topic: none");
     });
 
     it("throws when invalid chainId is provided", async () => {
@@ -474,6 +475,88 @@ describe("Client Validation", () => {
       await expect(
         client.request({ ...TEST_REQUEST_PARAMS, topic, request: { method: "unknown" } }),
       ).to.eventually.be.rejectedWith("Missing or invalid request method");
+    });
+  });
+
+  describe("respond", () => {
+    it("throws when no params are passed", async () => {
+      await expect(client.respond()).to.eventually.be.rejectedWith(
+        "Missing or invalid respond params",
+      );
+    });
+
+    it("throws when invalid topic is provided", async () => {
+      await expect(
+        client.respond({ ...TEST_REQUEST_PARAMS, topic: 123 }),
+      ).to.eventually.be.rejectedWith("Missing or invalid respond topic");
+    });
+
+    it("throws when empty topic is provided", async () => {
+      await expect(
+        client.respond({ ...TEST_RESPOND_PARAMS, topic: "" }),
+      ).to.eventually.be.rejectedWith("Missing or invalid respond topic");
+    });
+
+    it("throws when no topic is provided", async () => {
+      await expect(
+        client.respond({ ...TEST_RESPOND_PARAMS, topic: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid respond topic");
+    });
+
+    it("throws when no response or error is passed", async () => {
+      await expect(
+        client.respond({ ...TEST_RESPOND_PARAMS, topic, response: undefined, error: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid respond response");
+    });
+
+    it("throws when no id is passed", async () => {
+      await expect(
+        client.respond({
+          ...TEST_RESPOND_PARAMS,
+          topic,
+          response: { ...TEST_RESPOND_PARAMS.response, id: undefined },
+        }),
+      ).to.eventually.be.rejectedWith("Missing or invalid respond response");
+    });
+
+    it("throws when invalid id is passed", async () => {
+      await expect(
+        client.respond({
+          ...TEST_RESPOND_PARAMS,
+          topic,
+          response: { ...TEST_RESPOND_PARAMS.response, id: "123" },
+        }),
+      ).to.eventually.be.rejectedWith("Missing or invalid respond response");
+    });
+
+    it("throws when no jsonrpc is passed", async () => {
+      await expect(
+        client.respond({
+          ...TEST_RESPOND_PARAMS,
+          topic,
+          response: { ...TEST_RESPOND_PARAMS.response, jsonrpc: undefined },
+        }),
+      ).to.eventually.be.rejectedWith("Missing or invalid respond response");
+    });
+
+    it("throws when invalid jsonrpc is passed", async () => {
+      await expect(
+        client.respond({
+          ...TEST_RESPOND_PARAMS,
+          topic,
+          response: { ...TEST_RESPOND_PARAMS.response, jsonrpc: 123 },
+        }),
+      ).to.eventually.be.rejectedWith("Missing or invalid respond response");
+    });
+
+    it("throws when empty jsonrpc is passed", async () => {
+      await expect(
+        client.respond({
+          ...TEST_RESPOND_PARAMS,
+          topic,
+          response: { ...TEST_RESPOND_PARAMS.response, jsonrpc: "" },
+        }),
+      ).to.eventually.be.rejectedWith("Missing or invalid respond response");
     });
   });
 
@@ -532,8 +615,8 @@ describe("Client Validation", () => {
 
     it("throws when non existant topic is provided", async () => {
       await expect(
-        client.ping({ ...TEST_EMIT_PARAMS, topic: "none" }),
-      ).to.eventually.be.rejectedWith("No matching pairing or session with topic: none");
+        client.emit({ ...TEST_EMIT_PARAMS, topic: "none" }),
+      ).to.eventually.be.rejectedWith("No matching session with topic: none");
     });
 
     it("throws when invalid chainId is provided", async () => {

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -1,0 +1,65 @@
+import "mocha";
+import {
+  expect,
+  initTwoClients,
+  testConnectMethod,
+  TEST_APPROVE_PARAMS,
+  TEST_CONNECT_PARAMS,
+} from "./shared";
+
+describe("Client Validation", () => {
+  const clients = await initTwoClients();
+  await testConnectMethod(clients);
+  const { A } = clients;
+  const pairingTopic = A.pairing.keys[0];
+
+  describe("connect", () => {
+    it("throws when no params are passed", async () => {
+      // @ts-expect-error
+      await expect(A.connect()).to.eventually.be.rejectedWith("Missing or invalid connect params");
+    });
+    it("throws when non existant pairingTopic is provided", async () => {
+      await expect(
+        A.connect({ ...TEST_CONNECT_PARAMS, pairingTopic: "none" }),
+      ).to.eventually.be.rejectedWith("No matching pairing with topic: none");
+    });
+    it("throws when empty namespaces are provided", async () => {
+      await expect(
+        A.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, namespaces: [] }),
+      ).to.eventually.be.rejectedWith("Missing or invalid namespaces");
+    });
+    it("throws when invalid namespaces are provided", async () => {
+      await expect(
+        // @ts-expect-error
+        A.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, namespaces: {} }),
+      ).to.eventually.be.rejectedWith("Missing or invalid namespaces");
+    });
+  });
+
+  describe("pair", () => {
+    it("throws when undefined params are passed", async () => {
+      // @ts-expect-error
+      await expect(A.pair()).to.eventually.be.rejectedWith("Missing or invalid uri");
+    });
+    it("throws when empty uri is provided", async () => {
+      await expect(A.pair({ uri: "" })).to.eventually.be.rejectedWith("Missing or invalid uri");
+    });
+    it("throws when invalid uri is provided", async () => {
+      // @ts-expect-error
+      await expect(A.pair({ uri: 123 })).to.eventually.be.rejectedWith("Missing or invalid uri");
+    });
+  });
+
+  describe("approve", () => {
+    it("throws when undefined params are passed", async () => {
+      // @ts-expect-error
+      await expect(A.approve()).to.eventually.be.rejectedWith("Missing or invalid uri");
+    });
+    it("throws when invalid id is provided", async () => {
+      await expect(
+        // @ts-expect-error
+        A.approve({ ...TEST_APPROVE_PARAMS, id: "123" }),
+      ).to.eventually.be.rejectedWith("balegdeh");
+    });
+  });
+});

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -12,7 +12,7 @@ import {
 } from "./shared";
 import Client from "../src";
 import { calcExpiry } from "@walletconnect/utils";
-import { ONE_MINUTE, THIRTY_DAYS } from "@walletconnect/time";
+import { ONE_MINUTE, SEVEN_DAYS } from "@walletconnect/time";
 
 let client: Client;
 let pairingTopic: string;
@@ -362,13 +362,13 @@ describe("Client Validation", () => {
 
     it("throws when invalid expiry is provided", async () => {
       await expect(client.updateExpiry({ topic, expiry: "1" })).to.eventually.be.rejectedWith(
-        "Missing or invalid updateExpiry expiry (min 5 min, max 30 days)",
+        "Missing or invalid updateExpiry expiry (min 5 min, max 7 days)",
       );
     });
 
     it("throws when no expiry is provided", async () => {
       await expect(client.updateExpiry({ topic, expiry: undefined })).to.eventually.be.rejectedWith(
-        "Missing or invalid updateExpiry expiry (min 5 min, max 30 days)",
+        "Missing or invalid updateExpiry expiry (min 5 min, max 7 days)",
       );
     });
 
@@ -376,15 +376,15 @@ describe("Client Validation", () => {
       await expect(
         client.updateExpiry({ topic, expiry: calcExpiry(ONE_MINUTE) }),
       ).to.eventually.be.rejectedWith(
-        "Missing or invalid updateExpiry expiry (min 5 min, max 30 days)",
+        "Missing or invalid updateExpiry expiry (min 5 min, max 7 days)",
       );
     });
 
-    it("throws when expiry is more than 30 days", async () => {
+    it("throws when expiry is more than 7 days", async () => {
       await expect(
-        client.updateExpiry({ topic, expiry: calcExpiry(THIRTY_DAYS + ONE_MINUTE) }),
+        client.updateExpiry({ topic, expiry: calcExpiry(SEVEN_DAYS + ONE_MINUTE) }),
       ).to.eventually.be.rejectedWith(
-        "Missing or invalid updateExpiry expiry (min 5 min, max 30 days)",
+        "Missing or invalid updateExpiry expiry (min 5 min, max 7 days)",
       );
     });
   });

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -8,6 +8,7 @@ import {
   TEST_CONNECT_PARAMS,
   TEST_REJECT_PARAMS,
   TEST_UPDATE_ACCOUNTS_PARAMS,
+  TEST_UPDATE_EXPIRY_PARAMS,
 } from "./shared";
 import Client from "../src";
 
@@ -319,6 +320,42 @@ describe("Client Validation", () => {
       ).to.eventually.be.rejectedWith(
         "Invalid accounts with mismatched chains: eip155:42,eip155:10",
       );
+    });
+  });
+
+  describe("updateNamespaces", () => {
+    // TODO
+  });
+
+  describe("updateExpiry", () => {
+    it("throws when no params are passed", async () => {
+      await expect(client.updateExpiry()).to.eventually.be.rejectedWith(
+        "Missing or invalid updateExpiry params",
+      );
+    });
+
+    it("throws when invalid topic is provided", async () => {
+      await expect(
+        client.updateExpiry({ ...TEST_UPDATE_EXPIRY_PARAMS, topic: 123 }),
+      ).to.eventually.be.rejectedWith("Missing or invalid updateExpiry topic");
+    });
+
+    it("throws when empty topic is provided", async () => {
+      await expect(
+        client.updateExpiry({ ...TEST_UPDATE_EXPIRY_PARAMS, topic: "" }),
+      ).to.eventually.be.rejectedWith("Missing or invalid updateExpiry topic");
+    });
+
+    it("throws when no topic is provided", async () => {
+      await expect(
+        client.updateExpiry({ ...TEST_UPDATE_EXPIRY_PARAMS, topic: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid updateExpiry topic");
+    });
+
+    it("throws when non existant topic is provided", async () => {
+      await expect(
+        client.updateExpiry({ ...TEST_UPDATE_EXPIRY_PARAMS, topic: "none" }),
+      ).to.eventually.be.rejectedWith("No matching session with topic: none");
     });
   });
 });

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -9,6 +9,7 @@ import {
   TEST_REJECT_PARAMS,
   TEST_UPDATE_ACCOUNTS_PARAMS,
   TEST_UPDATE_EXPIRY_PARAMS,
+  TEST_EMIT_PARAMS,
 } from "./shared";
 import Client from "../src";
 import { calcExpiry } from "@walletconnect/utils";
@@ -416,6 +417,90 @@ describe("Client Validation", () => {
       await expect(client.ping({ topic: "none" })).to.eventually.be.rejectedWith(
         "No matching pairing or session with topic: none",
       );
+    });
+  });
+
+  describe("emit", () => {
+    it("throws when no params are passed", async () => {
+      await expect(client.emit()).to.eventually.be.rejectedWith("Missing or invalid emit params");
+    });
+
+    it("throws when invalid topic is provided", async () => {
+      await expect(client.emit({ ...TEST_EMIT_PARAMS, topic: 123 })).to.eventually.be.rejectedWith(
+        "Missing or invalid emit topic",
+      );
+    });
+
+    it("throws when empty topic is provided", async () => {
+      await expect(client.emit({ ...TEST_EMIT_PARAMS, topic: "" })).to.eventually.be.rejectedWith(
+        "Missing or invalid emit topic",
+      );
+    });
+
+    it("throws when no topic is provided", async () => {
+      await expect(
+        client.emit({ ...TEST_EMIT_PARAMS, topic: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid emit topic");
+    });
+
+    it("throws when non existant topic is provided", async () => {
+      await expect(
+        client.ping({ ...TEST_EMIT_PARAMS, topic: "none" }),
+      ).to.eventually.be.rejectedWith("No matching pairing or session with topic: none");
+    });
+
+    it("throws when invalid chainId is provided", async () => {
+      await expect(
+        client.emit({ ...TEST_EMIT_PARAMS, topic, chainId: 123 }),
+      ).to.eventually.be.rejectedWith("Missing or invalid emit chainId");
+    });
+
+    it("throws when empty chainId is provided", async () => {
+      await expect(
+        client.emit({ ...TEST_EMIT_PARAMS, topic, chainId: "" }),
+      ).to.eventually.be.rejectedWith("Missing or invalid emit chainId");
+    });
+
+    it("throws when invalid event is provided", async () => {
+      await expect(
+        client.emit({ ...TEST_EMIT_PARAMS, topic, event: 123 }),
+      ).to.eventually.be.rejectedWith("Missing or invalid emit event");
+    });
+
+    it("throws when empty event is provided", async () => {
+      await expect(
+        client.emit({ ...TEST_EMIT_PARAMS, topic, event: {} }),
+      ).to.eventually.be.rejectedWith("Missing or invalid emit event");
+    });
+
+    it("throws when no event is provided", async () => {
+      await expect(
+        client.emit({ ...TEST_EMIT_PARAMS, topic, event: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid emit event");
+    });
+
+    it("throws when invalid event name is provided", async () => {
+      await expect(
+        client.emit({ ...TEST_EMIT_PARAMS, topic, event: { name: 123 } }),
+      ).to.eventually.be.rejectedWith("Missing or invalid emit event");
+    });
+
+    it("throws when empty event name is provided", async () => {
+      await expect(
+        client.emit({ ...TEST_EMIT_PARAMS, topic, event: { name: "" } }),
+      ).to.eventually.be.rejectedWith("Missing or invalid emit event");
+    });
+
+    it("throws when no event name is provided", async () => {
+      await expect(
+        client.emit({ ...TEST_EMIT_PARAMS, topic, event: { name: undefined } }),
+      ).to.eventually.be.rejectedWith("Missing or invalid emit event");
+    });
+
+    it("throws when event doesn't exist for given chainId", async () => {
+      await expect(
+        client.emit({ ...TEST_EMIT_PARAMS, topic, event: { name: "unknown" } }),
+      ).to.eventually.be.rejectedWith("Missing or invalid emit event");
     });
   });
 });

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -270,6 +270,11 @@ export interface EnginePrivate {
     topic: string,
     payload: JsonRpcRequest<JsonRpcTypes.RequestParams["wc_sessionEvent"]>,
   ): void;
+
+  // -- Validators ---------------------------------------------------- //
+  isValidConnect(params: EngineTypes.ConnectParams): void;
+
+  isValidPair(params: EngineTypes.PairParams): void;
 }
 
 // -- class interface ----------------------------------------------- //

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -277,6 +277,8 @@ export interface EnginePrivate {
   isValidPair(params: EngineTypes.PairParams): void;
 
   isValidApprove(params: EngineTypes.ApproveParams): void;
+
+  isValidReject(params: EngineTypes.RejectParams): void;
 }
 
 // -- class interface ----------------------------------------------- //

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -281,6 +281,8 @@ export interface EnginePrivate {
   isValidReject(params: EngineTypes.RejectParams): void;
 
   isValidUpdateAccounts(params: EngineTypes.UpdateAccountsParams): void;
+
+  isValidUpdateExpiry(params: EngineTypes.UpdateExpiryParams): void;
 }
 
 // -- class interface ----------------------------------------------- //

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -284,6 +284,8 @@ export interface EnginePrivate {
 
   isValidUpdateExpiry(params: EngineTypes.UpdateExpiryParams): void;
 
+  isValidUpdateNamespaces(params: EngineTypes.UpdateNamespacesParams): void;
+
   isValidRequest(params: EngineTypes.RequestParams): void;
 
   isValidRespond(params: EngineTypes.RespondParams): void;

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -94,7 +94,7 @@ export declare namespace EngineTypes {
       method: string;
       params: any;
     };
-    chainId?: string;
+    chainId: string;
   }
 
   interface RespondParams {
@@ -108,7 +108,7 @@ export declare namespace EngineTypes {
       name: string;
       data: any;
     };
-    chainId?: string;
+    chainId: string;
   }
 
   interface PingParams {

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -285,6 +285,8 @@ export interface EnginePrivate {
   isValidUpdateExpiry(params: EngineTypes.UpdateExpiryParams): void;
 
   isValidPing(params: EngineTypes.PingParams): void;
+
+  isValidEmit(params: EngineTypes.EmitParams): void;
 }
 
 // -- class interface ----------------------------------------------- //

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -284,6 +284,8 @@ export interface EnginePrivate {
 
   isValidUpdateExpiry(params: EngineTypes.UpdateExpiryParams): void;
 
+  isValidRequest(params: EngineTypes.RequestParams): void;
+
   isValidPing(params: EngineTypes.PingParams): void;
 
   isValidEmit(params: EngineTypes.EmitParams): void;

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -287,6 +287,8 @@ export interface EnginePrivate {
   isValidPing(params: EngineTypes.PingParams): void;
 
   isValidEmit(params: EngineTypes.EmitParams): void;
+
+  isValidDisconnect(params: EngineTypes.DisconnectParams): void;
 }
 
 // -- class interface ----------------------------------------------- //

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -279,6 +279,8 @@ export interface EnginePrivate {
   isValidApprove(params: EngineTypes.ApproveParams): void;
 
   isValidReject(params: EngineTypes.RejectParams): void;
+
+  isValidUpdateAccounts(params: EngineTypes.UpdateAccountsParams): void;
 }
 
 // -- class interface ----------------------------------------------- //

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -283,6 +283,8 @@ export interface EnginePrivate {
   isValidUpdateAccounts(params: EngineTypes.UpdateAccountsParams): void;
 
   isValidUpdateExpiry(params: EngineTypes.UpdateExpiryParams): void;
+
+  isValidPing(params: EngineTypes.PingParams): void;
 }
 
 // -- class interface ----------------------------------------------- //

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -286,6 +286,8 @@ export interface EnginePrivate {
 
   isValidRequest(params: EngineTypes.RequestParams): void;
 
+  isValidRespond(params: EngineTypes.RespondParams): void;
+
   isValidPing(params: EngineTypes.PingParams): void;
 
   isValidEmit(params: EngineTypes.EmitParams): void;

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -275,6 +275,8 @@ export interface EnginePrivate {
   isValidConnect(params: EngineTypes.ConnectParams): void;
 
   isValidPair(params: EngineTypes.PairParams): void;
+
+  isValidApprove(params: EngineTypes.ApproveParams): void;
 }
 
 // -- class interface ----------------------------------------------- //

--- a/packages/types/src/jsonrpc.ts
+++ b/packages/types/src/jsonrpc.ts
@@ -65,14 +65,14 @@ export declare namespace JsonRpcTypes {
         method: string;
         params: any;
       };
-      chainId?: string;
+      chainId: string;
     };
     wc_sessionEvent: {
       event: {
         name: string;
         data: unknown;
       };
-      chainId?: string;
+      chainId: string;
     };
   }
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -5,3 +5,4 @@ export * from "./misc";
 export * from "./relay";
 export * from "./uri";
 export * from "./validators";
+export * from "./namespaces";

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -1,0 +1,8 @@
+import { SessionTypes } from "@walletconnect/types";
+
+export function getNamespacesChains(namespaces: SessionTypes.Namespace[]) {
+  const chains: SessionTypes.Namespace["chains"] = [];
+  namespaces.forEach(namespace => chains.push(...namespace.chains));
+
+  return chains;
+}

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -7,6 +7,18 @@ export function getNamespacesChains(namespaces: SessionTypes.Namespace[]) {
   return chains;
 }
 
+export function getNamespacesMethodsForChainId(
+  namespaces: SessionTypes.Namespace[],
+  chainId: string,
+) {
+  const methods: SessionTypes.Namespace["methods"] = [];
+  namespaces.forEach(namespace => {
+    if (namespace.chains.includes(chainId)) methods.push(...namespace.methods);
+  });
+
+  return methods;
+}
+
 export function getNamespacesEventsForChainId(
   namespaces: SessionTypes.Namespace[],
   chainId: string,

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -6,3 +6,15 @@ export function getNamespacesChains(namespaces: SessionTypes.Namespace[]) {
 
   return chains;
 }
+
+export function getNamespacesEventsForChainId(
+  namespaces: SessionTypes.Namespace[],
+  chainId: string,
+) {
+  const events: SessionTypes.Namespace["events"] = [];
+  namespaces.forEach(namespace => {
+    if (namespace.chains.includes(chainId)) events.push(...namespace.events);
+  });
+
+  return events;
+}

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -4,7 +4,7 @@ import { ErrorResponse } from "@walletconnect/jsonrpc-types";
 import { hasOverlap, isNamespaceEqual, calcExpiry } from "./misc";
 import { getChains } from "./caip";
 import { getNamespacesChains } from "./namespaces";
-import { toMiliseconds, FIVE_MINUTES, THIRTY_DAYS } from "@walletconnect/time";
+import { FIVE_MINUTES, SEVEN_DAYS } from "@walletconnect/time";
 
 export function isSessionCompatible(session: SessionTypes.Struct, filters: SessionTypes.Updatable) {
   const results = [];
@@ -187,7 +187,7 @@ export function isValidExpiry(input: any): input is number {
   if (!isValidNumber(input, false)) return false;
 
   const MIN_FUTURE = calcExpiry(FIVE_MINUTES);
-  const MAX_FUTURE = calcExpiry(THIRTY_DAYS);
+  const MAX_FUTURE = calcExpiry(SEVEN_DAYS);
 
   return input >= MIN_FUTURE && input <= MAX_FUTURE;
 }

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -1,4 +1,4 @@
-import { SessionTypes, ProposalTypes } from "@walletconnect/types";
+import { SessionTypes, ProposalTypes, RelayerTypes } from "@walletconnect/types";
 import { hasOverlap, isNamespaceEqual } from "./misc";
 
 export function isSessionCompatible(session: SessionTypes.Struct, filters: SessionTypes.Updatable) {
@@ -71,4 +71,45 @@ export function isProposalStruct(input: any): input is ProposalTypes.Struct {
 
 export function isSessionStruct(input: any): input is SessionTypes.Struct {
   return input?.topic;
+}
+
+export function isValidNamespace(input: any): input is SessionTypes.Namespace {
+  const { methods, events, chains } = input;
+  return isValidArray(methods) && isValidArray(events) && isValidArray(chains);
+}
+
+export function isValidRelay(input: any): input is RelayerTypes.ProtocolOptions {
+  return input.length && isValidString(input.protocol);
+}
+
+export function isValidNamespaces(
+  input: any,
+  optional: boolean,
+): input is SessionTypes.Namespace[] {
+  let valid = false;
+
+  if (optional && !input) valid = true;
+  else if (input && isValidArray(input) && input.length) {
+    input.forEach((namespace: SessionTypes.Namespace) => {
+      valid = isValidNamespace(namespace);
+    });
+  }
+
+  return valid;
+}
+
+export function isValidRelays(
+  input: any,
+  optional: boolean,
+): input is RelayerTypes.ProtocolOptions[] {
+  let valid = false;
+
+  if (optional && !input) valid = true;
+  else if (input && isValidArray(input) && input.length) {
+    input.forEach((namespace: SessionTypes.Namespace) => {
+      valid = isValidRelay(namespace);
+    });
+  }
+
+  return valid;
 }

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -30,12 +30,18 @@ export function isValidArray(arr: any, itemCondition?: (item: any) => boolean) {
   return false;
 }
 
-export function isValidString(value: any) {
-  return typeof value === "string" && !!value.trim();
+export function isUndefined(input: any): input is undefined {
+  return typeof input === "undefined";
+}
+
+export function isValidString(input: any, optional: boolean) {
+  if (optional && isUndefined(input)) return true;
+
+  return typeof input === "string" && Boolean(input.trim().length);
 }
 
 export function isValidChainId(value: any) {
-  if (isValidString(value) && value.includes(":")) {
+  if (isValidString(value, false) && value.includes(":")) {
     const split = value.split(":");
     return split.length === 2;
   }
@@ -43,7 +49,7 @@ export function isValidChainId(value: any) {
 }
 
 export function isValidAccountId(value: any) {
-  if (isValidString(value) && value.includes(":")) {
+  if (isValidString(value, false) && value.includes(":")) {
     const split = value.split(":");
     if (split.length === 3) {
       const chainId = split[0] + ":" + split[1];
@@ -54,7 +60,7 @@ export function isValidAccountId(value: any) {
 }
 
 export function isValidUrl(value: any) {
-  if (isValidString(value)) {
+  if (isValidString(value, false)) {
     try {
       const url = new URL(value);
       return typeof url !== "undefined";
@@ -79,7 +85,7 @@ export function isValidNamespace(input: any): input is SessionTypes.Namespace {
 }
 
 export function isValidRelay(input: any): input is RelayerTypes.ProtocolOptions {
-  return input.length && isValidString(input.protocol);
+  return isValidString(input.protocol, true);
 }
 
 export function isValidNamespaces(
@@ -120,4 +126,17 @@ export function isValidId(input: any) {
 
 export function isValidParams(input: any) {
   return typeof input !== "undefined" && typeof input !== null;
+}
+
+export function isValidAccounts(input: any, optional: boolean): input is string[] {
+  let valid = false;
+
+  if (optional && !input) valid = true;
+  else if (input && isValidArray(input) && input.length) {
+    input.forEach((account: string) => {
+      valid = isValidAccountId(account);
+    });
+  }
+
+  return valid;
 }

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -2,6 +2,8 @@ import { SessionTypes, ProposalTypes, RelayerTypes } from "@walletconnect/types"
 import { ErrorResponse } from "@walletconnect/jsonrpc-types";
 
 import { hasOverlap, isNamespaceEqual } from "./misc";
+import { getChains } from "./caip";
+import { getNamespacesChains } from "./namespaces";
 
 export function isSessionCompatible(session: SessionTypes.Struct, filters: SessionTypes.Updatable) {
   const results = [];
@@ -92,10 +94,6 @@ export function isValidNamespace(input: any): input is SessionTypes.Namespace {
   return isValidArray(methods) && isValidArray(events) && isValidArray(chains);
 }
 
-export function isValidRelay(input: any): input is RelayerTypes.ProtocolOptions {
-  return isValidString(input.protocol, true);
-}
-
 export function isValidNamespaces(
   input: any,
   optional: boolean,
@@ -110,6 +108,10 @@ export function isValidNamespaces(
   }
 
   return valid;
+}
+
+export function isValidRelay(input: any): input is RelayerTypes.ProtocolOptions {
+  return isValidString(input.protocol, true);
 }
 
 export function isValidRelays(
@@ -156,4 +158,14 @@ export function isValidErrorReason(input: any): input is ErrorResponse {
   if (!input.message || !isValidString(input.message, false)) return false;
 
   return true;
+}
+
+export function areAccountsInNamespaces(
+  accounts: SessionTypes.Accounts,
+  namespaces: SessionTypes.Namespace[],
+) {
+  const accountChains = getChains(accounts);
+  const namespacesChains = getNamespacesChains(namespaces);
+
+  return accountChains.every(chain => namespacesChains.includes(chain));
 }

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -2,7 +2,11 @@ import { SessionTypes, ProposalTypes, RelayerTypes } from "@walletconnect/types"
 import { ErrorResponse } from "@walletconnect/jsonrpc-types";
 import { hasOverlap, isNamespaceEqual, calcExpiry } from "./misc";
 import { getChains } from "./caip";
-import { getNamespacesChains, getNamespacesEventsForChainId } from "./namespaces";
+import {
+  getNamespacesChains,
+  getNamespacesMethodsForChainId,
+  getNamespacesEventsForChainId,
+} from "./namespaces";
 import { FIVE_MINUTES, SEVEN_DAYS } from "@walletconnect/time";
 
 export function isSessionCompatible(session: SessionTypes.Struct, filters: SessionTypes.Updatable) {
@@ -207,6 +211,16 @@ export function isValidNamespacesChainId(namespaces: SessionTypes.Namespace[], c
   }
 
   return true;
+}
+
+export function isValidNamespacesRequest(
+  namespaces: SessionTypes.Namespace[],
+  chainId: string,
+  method: string,
+) {
+  if (!isValidString(method, false)) return false;
+  const methods = getNamespacesMethodsForChainId(namespaces, chainId);
+  return methods.includes(method);
 }
 
 export function isValidNamespacesEvent(

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -1,9 +1,10 @@
 import { SessionTypes, ProposalTypes, RelayerTypes } from "@walletconnect/types";
 import { ErrorResponse } from "@walletconnect/jsonrpc-types";
 
-import { hasOverlap, isNamespaceEqual } from "./misc";
+import { hasOverlap, isNamespaceEqual, calcExpiry } from "./misc";
 import { getChains } from "./caip";
 import { getNamespacesChains } from "./namespaces";
+import { toMiliseconds, FIVE_MINUTES, THIRTY_DAYS } from "@walletconnect/time";
 
 export function isSessionCompatible(session: SessionTypes.Struct, filters: SessionTypes.Updatable) {
   const results = [];
@@ -180,4 +181,13 @@ export function areAccountsInNamespaces(
     valid,
     mismatched,
   };
+}
+
+export function isValidExpiry(input: any): input is number {
+  if (!isValidNumber(input, false)) return false;
+
+  const MIN_FUTURE = calcExpiry(FIVE_MINUTES);
+  const MAX_FUTURE = calcExpiry(THIRTY_DAYS);
+
+  return input >= MIN_FUTURE && input <= MAX_FUTURE;
 }

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -113,3 +113,11 @@ export function isValidRelays(
 
   return valid;
 }
+
+export function isValidId(input: any) {
+  return typeof input === "number";
+}
+
+export function isValidParams(input: any) {
+  return typeof input !== "undefined" && typeof input !== null;
+}

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -202,6 +202,14 @@ export function isValidRequest(request: any) {
   return true;
 }
 
+export function isValidResponse(response: any) {
+  if (isUndefined(response)) return false;
+  if (isUndefined(response.result) && isUndefined(response.error)) return false;
+  if (!isValidNumber(response.id, false)) return false;
+  if (!isValidString(response.jsonrpc, false)) return false;
+  return true;
+}
+
 export function isValidEvent(event: any) {
   if (isUndefined(event)) return false;
   if (!isValidString(event.name, false)) return false;

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -196,6 +196,12 @@ export function isValidExpiry(input: any): input is number {
   return input >= MIN_FUTURE && input <= MAX_FUTURE;
 }
 
+export function isValidRequest(request: any) {
+  if (isUndefined(request)) return false;
+  if (!isValidString(request.method, false)) return false;
+  return true;
+}
+
 export function isValidEvent(event: any) {
   if (isUndefined(event)) return false;
   if (!isValidString(event.name, false)) return false;

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -166,6 +166,18 @@ export function areAccountsInNamespaces(
 ) {
   const accountChains = getChains(accounts);
   const namespacesChains = getNamespacesChains(namespaces);
+  const mismatched: string[] = [];
+  let valid = true;
 
-  return accountChains.every(chain => namespacesChains.includes(chain));
+  accountChains.forEach(chain => {
+    if (!namespacesChains.includes(chain)) {
+      mismatched.push(chain);
+      valid = false;
+    }
+  });
+
+  return {
+    valid,
+    mismatched,
+  };
 }

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -1,4 +1,6 @@
 import { SessionTypes, ProposalTypes, RelayerTypes } from "@walletconnect/types";
+import { ErrorResponse } from "@walletconnect/jsonrpc-types";
+
 import { hasOverlap, isNamespaceEqual } from "./misc";
 
 export function isSessionCompatible(session: SessionTypes.Struct, filters: SessionTypes.Updatable) {
@@ -38,6 +40,12 @@ export function isValidString(input: any, optional: boolean) {
   if (optional && isUndefined(input)) return true;
 
   return typeof input === "string" && Boolean(input.trim().length);
+}
+
+export function isValidNumber(input: any, optional: boolean) {
+  if (optional && isUndefined(input)) return true;
+
+  return typeof input === "number";
 }
 
 export function isValidChainId(value: any) {
@@ -139,4 +147,13 @@ export function isValidAccounts(input: any, optional: boolean): input is string[
   }
 
   return valid;
+}
+
+export function isValidErrorReason(input: any): input is ErrorResponse {
+  if (!input) return false;
+  if (typeof input !== "object") return false;
+  if (!input.code || !isValidNumber(input.code, false)) return false;
+  if (!input.message || !isValidString(input.message, false)) return false;
+
+  return true;
 }


### PR DESCRIPTION
```
    connect
      ✓ throws when no params are passed
      ✓ throws when invalid pairingTopic is provided
      ✓ throws when empty pairingTopic is provided
      ✓ throws when non existant pairingTopic is provided
      ✓ throws when empty namespaces are provided
      ✓ throws when invalid namespaces are provided
    pair
      ✓ throws when no params are passed
      ✓ throws when empty uri is provided
      ✓ throws when invalid uri is provided
      ✓ throws when no uri is provided
    approve
      ✓ throws when no params are passed
      ✓ throws when invalid id is provided
      ✓ throws when empty id is provided
      ✓ throws when no id is provided
      ✓ throws when invalid accounts are provided
      ✓ throws when empty accounts are provided
      ✓ throws when no accounts are provided
      ✓ throws when invalid namespaces are provided
      ✓ throws when empty namespaces are provided
      ✓ throws when no namespaces are provided
      ✓ throws when invalid relayProtocol are provided
      ✓ throws when empty relayProtocol is provided
    reject
      ✓ throws when no params are passed
      ✓ throws when invalid id is provided
      ✓ throws when empty id is provided
      ✓ throws when no id is provided
      ✓ throws when empty reason is provided
      ✓ throws when invalid reason is provided
      ✓ throws when no reason is provided
      ✓ throws when invalid reason code is provided
      ✓ throws when empty reason code is provided
      ✓ throws when no reason code is provided
      ✓ throws when invalid reason message is provided
      ✓ throws when empty reason message is provided
      ✓ throws when no reason message is provided
    updateAccounts
      ✓ throws when no params are passed
      ✓ throws when invalid topic is provided
      ✓ throws when empty topic is provided
      ✓ throws when no topic is provided
      ✓ throws when non existant topic is provided
      ✓ throws when invalid accounts are provided
      ✓ throws when no accounts are provided
      ✓ throws when provided accounts are not in session namespace
    updateNamespaces
      ✓ throws when no params are passed
      ✓ throws when invalid topic is provided
      ✓ throws when empty topic is provided
      ✓ throws when no topic is provided
      ✓ throws when non existant topic is provided
      ✓ throws when invalid namespaces are provided
      ✓ throws when empty namespaces are provided
      ✓ throws when no namespaces are provided
    updateExpiry
      ✓ throws when no params are passed
      ✓ throws when invalid topic is provided
      ✓ throws when empty topic is provided
      ✓ throws when no topic is provided
      ✓ throws when non existant topic is provided
      ✓ throws when invalid expiry is provided
      ✓ throws when no expiry is provided
      ✓ throws when expiry is less than 5 minutes
      ✓ throws when expiry is more than 7 days
    request
      ✓ throws when no params are passed
      ✓ throws when invalid topic is provided
      ✓ throws when empty topic is provided
      ✓ throws when no topic is provided
      ✓ throws when non existant topic is provided
      ✓ throws when invalid chainId is provided
      ✓ throws when empty chainId is provided
      ✓ throws when invalid request is provided
      ✓ throws when empty request is provided
      ✓ throws when no request is provided
      ✓ throws when invalid request method is provided
      ✓ throws when empty request method is provided
      ✓ throws when no request method is provided
      ✓ throws when request doesn't exist for given chainId
    respond
      ✓ throws when no params are passed
      ✓ throws when invalid topic is provided
      ✓ throws when empty topic is provided
      ✓ throws when no topic is provided
      ✓ throws when no response or error is passed
      ✓ throws when no id is passed
      ✓ throws when invalid id is passed
      ✓ throws when no jsonrpc is passed
      ✓ throws when invalid jsonrpc is passed
      ✓ throws when empty jsonrpc is passed
    ping
      ✓ throws when no params are passed
      ✓ throws when invalid topic is provided
      ✓ throws when empty topic is provided
      ✓ throws when no topic is provided
      ✓ throws when non existant topic is provided
    emit
      ✓ throws when no params are passed
      ✓ throws when invalid topic is provided
      ✓ throws when empty topic is provided
      ✓ throws when no topic is provided
      ✓ throws when non existant topic is provided
      ✓ throws when invalid chainId is provided
      ✓ throws when empty chainId is provided
      ✓ throws when invalid event is provided
      ✓ throws when empty event is provided
      ✓ throws when no event is provided
      ✓ throws when invalid event name is provided
      ✓ throws when empty event name is provided
      ✓ throws when no event name is provided
      ✓ throws when event doesn't exist for given chainId
    disconnect
      ✓ throws when no params are passed
      ✓ throws when invalid topic is provided
      ✓ throws when empty topic is provided
      ✓ throws when no topic is provided
      ✓ throws when non existant topic is provided
```