### PR TITLE
Removed socket response for empty message

### DIFF
--- a/servers/relay/src/ws.ts
+++ b/servers/relay/src/ws.ts
@@ -96,7 +96,8 @@ export class WebSocketService {
       this.logger.trace({ type: "message", direction: "incoming", message });
 
       if (!message || !message.trim()) {
-        this.send(socketId, "Missing or invalid socket data");
+        //this.send(socketId, "Missing or invalid socket data");
+        // this gets triggered by web sockets that send ping packets
         return;
       }
       const payload = safeJsonParse(message);


### PR DESCRIPTION
This PR removes the socket response when a blank message is received. This is more performant and since there is no outbound data for bad messages and ping packets can also be handled somewhat gracefully.