### PR TITLE
[v2 rc] namespace refactor

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -117,27 +117,18 @@ export class Client extends IClient {
     }
   };
 
-  public updateAccounts: IClient["updateAccounts"] = async params => {
+  public update: IClient["update"] = async params => {
     try {
-      return await this.engine.updateAccounts(params);
+      return await this.engine.update(params);
     } catch (error) {
       this.logger.error((error as any).message);
       throw error;
     }
   };
 
-  public updateNamespaces: IClient["updateNamespaces"] = async params => {
+  public extend: IClient["extend"] = async params => {
     try {
-      return await this.engine.updateNamespaces(params);
-    } catch (error) {
-      this.logger.error((error as any).message);
-      throw error;
-    }
-  };
-
-  public updateExpiry: IClient["updateExpiry"] = async params => {
-    try {
-      return await this.engine.updateExpiry(params);
+      return await this.engine.extend(params);
     } catch (error) {
       this.logger.error((error as any).message);
       throw error;

--- a/packages/client/src/constants/client.ts
+++ b/packages/client/src/constants/client.ts
@@ -17,9 +17,8 @@ export const CLIENT_SHORT_TIMEOUT = 50;
 
 export const CLIENT_EVENTS: Record<ClientTypes.Event, ClientTypes.Event> = {
   session_proposal: "session_proposal",
-  update_accounts: "update_accounts",
-  update_namespaces: "update_namespaces",
-  update_expiry: "update_expiry",
+  update: "update",
+  extend: "extend",
   session_ping: "session_ping",
   pairing_ping: "pairing_ping",
   session_delete: "session_delete",

--- a/packages/client/src/constants/client.ts
+++ b/packages/client/src/constants/client.ts
@@ -17,8 +17,8 @@ export const CLIENT_SHORT_TIMEOUT = 50;
 
 export const CLIENT_EVENTS: Record<ClientTypes.Event, ClientTypes.Event> = {
   session_proposal: "session_proposal",
-  update: "update",
-  extend: "extend",
+  session_update: "session_update",
+  session_extend: "session_extend",
   session_ping: "session_ping",
   pairing_ping: "pairing_ping",
   session_delete: "session_delete",

--- a/packages/client/src/constants/proposal.ts
+++ b/packages/client/src/constants/proposal.ts
@@ -1,1 +1,6 @@
+import { calcExpiry } from "@walletconnect/utils";
+import { THIRTY_DAYS } from "@walletconnect/time";
+
 export const PROPOSAL_CONTEXT = "proposal";
+
+export const PROPOSAL_EXPIRY = calcExpiry(THIRTY_DAYS);

--- a/packages/client/src/constants/session.ts
+++ b/packages/client/src/constants/session.ts
@@ -1,5 +1,8 @@
 import { SEVEN_DAYS } from "@walletconnect/time";
+import { calcExpiry } from "@walletconnect/utils";
 
 export const SESSION_CONTEXT = "session";
 
 export const SESSION_DEFAULT_TTL = SEVEN_DAYS;
+
+export const SESSION_EXPIRY = calcExpiry(SEVEN_DAYS);

--- a/packages/client/src/constants/session.ts
+++ b/packages/client/src/constants/session.ts
@@ -5,4 +5,4 @@ export const SESSION_CONTEXT = "session";
 
 export const SESSION_DEFAULT_TTL = SEVEN_DAYS;
 
-export const SESSION_EXPIRY = calcExpiry(SEVEN_DAYS);
+export const SESSION_EXPIRY = calcExpiry(SESSION_DEFAULT_TTL);

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -712,8 +712,8 @@ export class Engine extends IEngine {
       throw ERROR.MISSING_OR_INVALID.format({ name: "connect pairingTopic" });
     if (pairingTopic && !this.client.pairing.keys.includes(pairingTopic))
       throw ERROR.NO_MATCHING_TOPIC.format({ context: "pairing", topic: pairingTopic });
-    if (!isValidProposedNamespaces(proposedNamespaces, true))
-      throw ERROR.MISSING_OR_INVALID.format({ name: "connect namespaces" });
+    if (!isValidProposedNamespaces(proposedNamespaces, false))
+      throw ERROR.MISSING_OR_INVALID.format({ name: "connect proposedNamespaces" });
     if (!isValidRelays(relays, true))
       throw ERROR.MISSING_OR_INVALID.format({ name: "connect relays" });
   };

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -1,6 +1,6 @@
 import EventEmmiter from "events";
 import { RELAYER_EVENTS, RELAYER_DEFAULT_PROTOCOL } from "@walletconnect/core";
-import { EXPIRER_EVENTS, SESSION_EXPIRY } from "../constants";
+import { EXPIRER_EVENTS, SESSION_EXPIRY, PROPOSAL_EXPIRY } from "../constants";
 import {
   formatJsonRpcRequest,
   formatJsonRpcResult,
@@ -307,8 +307,8 @@ export class Engine extends IEngine {
   }
 
   private activatePairing: EnginePrivate["activatePairing"] = async topic => {
-    await this.client.pairing.update(topic, { active: true });
-    await this.setExpiry(topic, calcExpiry(THIRTY_DAYS));
+    await this.client.pairing.update(topic, { active: true, expiry: PROPOSAL_EXPIRY });
+    await this.setExpiry(topic, PROPOSAL_EXPIRY);
   };
 
   private deleteSession: EnginePrivate["deleteSession"] = async topic => {

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -41,7 +41,7 @@ import {
   isValidRequest,
   isValidEvent,
   isValidResponse,
-  isValidProposedNamespaces,
+  isValidRequiredNamespaces,
 } from "@walletconnect/utils";
 import { JsonRpcResponse } from "@walletconnect/jsonrpc-types";
 
@@ -58,7 +58,7 @@ export class Engine extends IEngine {
 
   public connect: IEngine["connect"] = async params => {
     this.isValidConnect(params);
-    const { pairingTopic, proposedNamespaces, relays } = params;
+    const { pairingTopic, requiredNamespaces, relays } = params;
     let topic = pairingTopic;
     let uri: string | undefined = undefined;
     let active = false;
@@ -76,7 +76,7 @@ export class Engine extends IEngine {
 
     const publicKey = await this.client.core.crypto.generateKeyPair();
     const proposal = {
-      proposedNamespaces: proposedNamespaces ?? [],
+      requiredNamespaces,
       relays: relays ?? [{ protocol: RELAYER_DEFAULT_PROTOCOL }],
       proposer: {
         publicKey,
@@ -746,13 +746,13 @@ export class Engine extends IEngine {
   // ---------- Validation ---------------------------------------------- //
   private isValidConnect: EnginePrivate["isValidConnect"] = params => {
     if (!isValidParams(params)) throw ERROR.MISSING_OR_INVALID.format({ name: "connect params" });
-    const { pairingTopic, proposedNamespaces, relays } = params;
+    const { pairingTopic, requiredNamespaces, relays } = params;
     if (!isValidString(pairingTopic, true))
       throw ERROR.MISSING_OR_INVALID.format({ name: "connect pairingTopic" });
     if (pairingTopic && !this.client.pairing.keys.includes(pairingTopic))
       throw ERROR.NO_MATCHING_TOPIC.format({ context: "pairing", topic: pairingTopic });
-    if (!isValidProposedNamespaces(proposedNamespaces, false))
-      throw ERROR.MISSING_OR_INVALID.format({ name: "connect proposedNamespaces" });
+    if (!isValidRequiredNamespaces(requiredNamespaces, false))
+      throw ERROR.MISSING_OR_INVALID.format({ name: "connect requiredNamespaces" });
     if (!isValidRelays(relays, true))
       throw ERROR.MISSING_OR_INVALID.format({ name: "connect relays" });
   };

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -41,6 +41,7 @@ import {
   isValidRequest,
   isValidEvent,
   isValidResponse,
+  isValidProposedNamespaces,
 } from "@walletconnect/utils";
 import { JsonRpcResponse } from "@walletconnect/jsonrpc-types";
 
@@ -659,9 +660,8 @@ export class Engine extends IEngine {
     const { id, params } = payload;
     const { chainId, request } = params;
 
-    // Move this to validation
-    const isChain = chainId && namespaces.some(n => n.chains.includes(chainId));
-    const isMethod = namespaces.some(n => n.methods.includes(request.method));
+    const isChain = isValidNamespacesChainId(namespaces, chainId);
+    const isMethod = isValidNamespacesRequest(namespaces, chainId, request.method);
 
     if (!isChain) {
       await this.sendError(id, topic, ERROR.UNSUPPORTED_CHAINS.format());

--- a/packages/client/src/controllers/session.ts
+++ b/packages/client/src/controllers/session.ts
@@ -10,7 +10,7 @@ export class Session extends Store<string, SessionTypes.Struct> {
     super(core, logger, SESSION_CONTEXT, CLIENT_STORAGE_PREFIX);
   }
 
-  public find(filters: SessionTypes.Updatable): SessionTypes.Struct[] {
+  public find(filters: SessionTypes.Filters): SessionTypes.Struct[] {
     return this.values.filter((session: SessionTypes.Struct) =>
       isSessionCompatible(session, filters),
     );

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -195,7 +195,8 @@ describe("Client Integration", () => {
       const {
         sessionA: { topic },
       } = await testConnectMethod(clients);
-      const newExpiry = calcExpiry(SEVEN_DAYS);
+      // Adjusted due to tests sometimes being ahead by 1s
+      const newExpiry = calcExpiry(SEVEN_DAYS) - 10;
       await clients.A.extend({
         topic,
       });

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -164,28 +164,7 @@ describe("Client Integration", () => {
     });
   });
 
-  describe("updateAccounts", () => {
-    it("updates session account state with provided accounts", async () => {
-      const clients = await initTwoClients();
-      const {
-        sessionA: { topic },
-      } = await testConnectMethod(clients);
-      const accountsBefore = clients.A.session.get(topic).accounts;
-      const accountsAfter = [
-        ...accountsBefore,
-        "eip155:43114:0x3c582121909DE92Dc89A36898633C1aE4790382b",
-      ];
-      await clients.A.updateAccounts({
-        topic,
-        accounts: accountsAfter,
-      });
-      const result = clients.A.session.get(topic).accounts;
-      expect(result).to.eql(accountsAfter);
-      deleteClients(clients);
-    });
-  });
-
-  describe("updateNamespaces", () => {
+  describe("update", () => {
     it("updates session namespaces state with provided namespaces", async () => {
       const clients = await initTwoClients();
       const {
@@ -196,7 +175,7 @@ describe("Client Integration", () => {
         ...namespacesBefore,
         { chains: ["eip155:12"], methods: ["eth_sendTransaction"], events: ["accountsChanged"] },
       ];
-      await clients.A.updateNamespaces({
+      await clients.A.update({
         topic,
         namespaces: namespacesAfter,
       });
@@ -206,16 +185,15 @@ describe("Client Integration", () => {
     });
   });
 
-  describe("updateExpiry", () => {
+  describe("extend", () => {
     it("updates session expiry state with provided expiry", async () => {
       const clients = await initTwoClients();
       const {
         sessionA: { topic },
       } = await testConnectMethod(clients);
       const expiryAfter = calcExpiry(FIVE_MINUTES);
-      await clients.A.updateExpiry({
+      await clients.A.extend({
         topic,
-        expiry: expiryAfter,
       });
       const result = clients.A.session.get(topic).expiry;
       expect(result).to.eql(expiryAfter);

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -171,14 +171,14 @@ describe("Client Integration", () => {
         sessionA: { topic },
       } = await testConnectMethod(clients);
       const namespacesBefore = clients.A.session.get(topic).namespaces;
-      const namespacesAfter = [
+      const namespacesAfter = {
         ...namespacesBefore,
-        {
+        eip000: {
           accounts: ["eip155:1:0x000000000000000000000000000000000000dead"],
           methods: ["eth_sendTransaction"],
           events: ["accountsChanged"],
         },
-      ];
+      };
       await clients.A.update({
         topic,
         namespaces: namespacesAfter,

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -173,8 +173,8 @@ describe("Client Integration", () => {
       const namespacesBefore = clients.A.session.get(topic).namespaces;
       const namespacesAfter = {
         ...namespacesBefore,
-        eip000: {
-          accounts: ["eip155:1:0x000000000000000000000000000000000000dead"],
+        eip9001: {
+          accounts: ["eip9001:1:0x000000000000000000000000000000000000dead"],
           methods: ["eth_sendTransaction"],
           events: ["accountsChanged"],
         },

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -9,7 +9,7 @@ import {
   TEST_CLIENT_OPTIONS,
   deleteClients,
 } from "./shared";
-import { FIVE_MINUTES } from "@walletconnect/time";
+import { SEVEN_DAYS } from "@walletconnect/time";
 
 describe("Client Integration", () => {
   it("init", async () => {
@@ -173,7 +173,11 @@ describe("Client Integration", () => {
       const namespacesBefore = clients.A.session.get(topic).namespaces;
       const namespacesAfter = [
         ...namespacesBefore,
-        { chains: ["eip155:12"], methods: ["eth_sendTransaction"], events: ["accountsChanged"] },
+        {
+          accounts: ["eip155:1:0x000000000000000000000000000000000000dead"],
+          methods: ["eth_sendTransaction"],
+          events: ["accountsChanged"],
+        },
       ];
       await clients.A.update({
         topic,
@@ -186,17 +190,17 @@ describe("Client Integration", () => {
   });
 
   describe("extend", () => {
-    it("updates session expiry state with provided expiry", async () => {
+    it("updates session expiry state", async () => {
       const clients = await initTwoClients();
       const {
         sessionA: { topic },
       } = await testConnectMethod(clients);
-      const expiryAfter = calcExpiry(FIVE_MINUTES);
+      const newExpiry = calcExpiry(SEVEN_DAYS);
       await clients.A.extend({
         topic,
       });
-      const result = clients.A.session.get(topic).expiry;
-      expect(result).to.eql(expiryAfter);
+      const expiry = clients.A.session.get(topic).expiry;
+      expect(expiry).to.be.greaterThanOrEqual(newExpiry);
       deleteClients(clients);
     });
   });

--- a/packages/client/test/shared/connect.ts
+++ b/packages/client/test/shared/connect.ts
@@ -12,8 +12,8 @@ import { TEST_RELAY_OPTIONS, TEST_NAMESPACES, TEST_PROPOSED_NAMESPACES } from ".
 import { Clients } from "./init";
 
 export interface TestConnectParams {
-  proposedNamespaces?: ProposalTypes.ProposedNamespace[];
-  namespaces?: SessionTypes.Namespace[];
+  requiredNamespaces?: ProposalTypes.RequiredNamespaces;
+  namespaces?: SessionTypes.Namespaces;
   relays?: RelayerTypes.ProtocolOptions[];
   pairingTopic?: string;
 }
@@ -22,7 +22,7 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
   const { A, B } = clients;
 
   const connectParams: EngineTypes.ConnectParams = {
-    proposedNamespaces: params?.proposedNamespaces || TEST_PROPOSED_NAMESPACES,
+    requiredNamespaces: params?.requiredNamespaces || TEST_PROPOSED_NAMESPACES,
     relays: params?.relays || undefined,
     pairingTopic: params?.pairingTopic || undefined,
   };
@@ -57,7 +57,7 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
     new Promise<void>((resolve, reject) => {
       B.once("session_proposal", async proposal => {
         try {
-          expect(proposal.proposedNamespaces).to.eql(connectParams.proposedNamespaces);
+          expect(proposal.requiredNamespaces).to.eql(connectParams.requiredNamespaces);
 
           const { acknowledged } = await B.approve({
             id: proposal.id,

--- a/packages/client/test/shared/connect.ts
+++ b/packages/client/test/shared/connect.ts
@@ -1,30 +1,27 @@
 import "mocha";
-// import { expect } from "chai";
-
 import { parseUri } from "@walletconnect/utils";
 import { EngineTypes, PairingTypes, RelayerTypes, SessionTypes } from "@walletconnect/types";
-
 import { expect } from "./chai";
-import { TEST_ACCOUNTS, TEST_RELAY_OPTIONS, TEST_NAMESPACES } from "./values";
-
+import { TEST_RELAY_OPTIONS, TEST_NAMESPACES, TEST_PROPOSED_NAMESPACES } from "./values";
 import { Clients } from "./init";
 
-export interface TestConnectParams extends EngineTypes.ConnectParams {
-  accounts?: string[];
+export interface TestConnectParams {
+  proposedNamespaces?: SessionTypes.ProposedNamespace[];
+  namespaces?: SessionTypes.Namespace[];
   relays?: RelayerTypes.ProtocolOptions[];
+  pairingTopic?: string;
 }
 
 export async function testConnectMethod(clients: Clients, params?: TestConnectParams) {
   const { A, B } = clients;
 
   const connectParams: EngineTypes.ConnectParams = {
-    namespaces: params?.namespaces || TEST_NAMESPACES,
+    proposedNamespaces: params?.proposedNamespaces || TEST_PROPOSED_NAMESPACES,
     relays: params?.relays || undefined,
     pairingTopic: params?.pairingTopic || undefined,
   };
 
   const approveParams: Omit<EngineTypes.ApproveParams, "id"> = {
-    accounts: params?.accounts || TEST_ACCOUNTS,
     namespaces: params?.namespaces || TEST_NAMESPACES,
   };
 
@@ -54,7 +51,7 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
     new Promise<void>((resolve, reject) => {
       B.once("session_proposal", async proposal => {
         try {
-          expect(proposal.namespaces).to.eql(connectParams.namespaces);
+          expect(proposal.proposedNamespaces).to.eql(connectParams.proposedNamespaces);
 
           const { acknowledged } = await B.approve({
             id: proposal.id,
@@ -106,9 +103,6 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
   // relay
   expect(sessionA.relay).to.eql(TEST_RELAY_OPTIONS);
   expect(sessionA.relay).to.eql(sessionB.relay);
-  // accounts
-  expect(sessionA.accounts).to.eql(approveParams.accounts);
-  expect(sessionA.accounts).to.eql(sessionB.accounts);
   // namespaces
   expect(sessionA.namespaces).to.eql(approveParams.namespaces);
   expect(sessionA.namespaces).to.eql(sessionB.namespaces);

--- a/packages/client/test/shared/connect.ts
+++ b/packages/client/test/shared/connect.ts
@@ -1,12 +1,18 @@
 import "mocha";
 import { parseUri } from "@walletconnect/utils";
-import { EngineTypes, PairingTypes, RelayerTypes, SessionTypes } from "@walletconnect/types";
+import {
+  EngineTypes,
+  PairingTypes,
+  RelayerTypes,
+  ProposalTypes,
+  SessionTypes,
+} from "@walletconnect/types";
 import { expect } from "./chai";
 import { TEST_RELAY_OPTIONS, TEST_NAMESPACES, TEST_PROPOSED_NAMESPACES } from "./values";
 import { Clients } from "./init";
 
 export interface TestConnectParams {
-  proposedNamespaces?: SessionTypes.ProposedNamespace[];
+  proposedNamespaces?: ProposalTypes.ProposedNamespace[];
   namespaces?: SessionTypes.Namespace[];
   relays?: RelayerTypes.ProtocolOptions[];
   pairingTopic?: string;

--- a/packages/client/test/shared/connect.ts
+++ b/packages/client/test/shared/connect.ts
@@ -8,7 +8,7 @@ import {
   SessionTypes,
 } from "@walletconnect/types";
 import { expect } from "./chai";
-import { TEST_RELAY_OPTIONS, TEST_NAMESPACES, TEST_PROPOSED_NAMESPACES } from "./values";
+import { TEST_RELAY_OPTIONS, TEST_NAMESPACES, TEST_REQUIRED_NAMESPACES } from "./values";
 import { Clients } from "./init";
 
 export interface TestConnectParams {
@@ -22,7 +22,7 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
   const { A, B } = clients;
 
   const connectParams: EngineTypes.ConnectParams = {
-    requiredNamespaces: params?.requiredNamespaces || TEST_PROPOSED_NAMESPACES,
+    requiredNamespaces: params?.requiredNamespaces || TEST_REQUIRED_NAMESPACES,
     relays: params?.relays || undefined,
     pairingTopic: params?.pairingTopic || undefined,
   };

--- a/packages/client/test/shared/values.ts
+++ b/packages/client/test/shared/values.ts
@@ -75,7 +75,7 @@ export const TEST_ETHEREUM_ACCOUNT = `${TEST_ETHEREUM_CHAIN}:${TEST_ETHEREUM_ADD
 
 export const TEST_ACCOUNTS = [TEST_ETHEREUM_ACCOUNT];
 
-export const TEST_PROPOSED_NAMESPACES = {
+export const TEST_REQUIRED_NAMESPACES = {
   eip155: {
     methods: TEST_METHODS,
     chains: TEST_CHAINS,
@@ -102,7 +102,7 @@ export const TEST_SIGN_REQUEST = { method: TEST_SIGN_METHOD, params: TEST_SIGN_P
 export const TEST_RANDOM_REQUEST = { method: "random_method", params: [] };
 
 export const TEST_CONNECT_PARAMS = {
-  proposedNamespaces: TEST_PROPOSED_NAMESPACES,
+  requiredNamespaces: TEST_REQUIRED_NAMESPACES,
   relays: [TEST_RELAY_OPTIONS],
 };
 

--- a/packages/client/test/shared/values.ts
+++ b/packages/client/test/shared/values.ts
@@ -71,7 +71,13 @@ export const TEST_METHODS = [
 ];
 export const TEST_EVENTS = ["chainChanged", "accountsChanged"];
 
-export const TEST_NAMESPACES = [
+export const TEST_ETHEREUM_ADDRESS = "0x3c582121909DE92Dc89A36898633C1aE4790382b";
+
+export const TEST_ETHEREUM_ACCOUNT = `${TEST_ETHEREUM_CHAIN}:${TEST_ETHEREUM_ADDRESS}`;
+
+export const TEST_ACCOUNTS = [TEST_ETHEREUM_ACCOUNT];
+
+export const TEST_PROPOSED_NAMESPACES = [
   {
     methods: TEST_METHODS,
     chains: TEST_CHAINS,
@@ -79,11 +85,13 @@ export const TEST_NAMESPACES = [
   },
 ];
 
-export const TEST_ETHEREUM_ADDRESS = "0x3c582121909DE92Dc89A36898633C1aE4790382b";
-
-export const TEST_ETHEREUM_ACCOUNT = `${TEST_ETHEREUM_CHAIN}:${TEST_ETHEREUM_ADDRESS}`;
-
-export const TEST_ACCOUNTS = [TEST_ETHEREUM_ACCOUNT];
+export const TEST_NAMESPACES = [
+  {
+    methods: TEST_METHODS,
+    accounts: TEST_ACCOUNTS,
+    events: TEST_EVENTS,
+  },
+];
 
 export const TEST_MESSAGE = "My name is John Doe";
 export const TEST_SIGNATURE =

--- a/packages/client/test/shared/values.ts
+++ b/packages/client/test/shared/values.ts
@@ -75,21 +75,21 @@ export const TEST_ETHEREUM_ACCOUNT = `${TEST_ETHEREUM_CHAIN}:${TEST_ETHEREUM_ADD
 
 export const TEST_ACCOUNTS = [TEST_ETHEREUM_ACCOUNT];
 
-export const TEST_PROPOSED_NAMESPACES = [
-  {
+export const TEST_PROPOSED_NAMESPACES = {
+  eip155: {
     methods: TEST_METHODS,
     chains: TEST_CHAINS,
     events: TEST_EVENTS,
   },
-];
+};
 
-export const TEST_NAMESPACES = [
-  {
+export const TEST_NAMESPACES = {
+  eip155: {
     methods: TEST_METHODS,
     accounts: TEST_ACCOUNTS,
     events: TEST_EVENTS,
   },
-];
+};
 
 export const TEST_MESSAGE = "My name is John Doe";
 export const TEST_SIGNATURE =

--- a/packages/client/test/shared/values.ts
+++ b/packages/client/test/shared/values.ts
@@ -1,7 +1,5 @@
 import path from "path";
 import { ClientTypes, RelayerTypes } from "@walletconnect/types";
-import { calcExpiry } from "@walletconnect/utils";
-import { FIVE_MINUTES } from "@walletconnect/time";
 
 // @ts-ignore
 import { ROOT_DIR } from "../../../../ops/js/shared";
@@ -104,13 +102,12 @@ export const TEST_SIGN_REQUEST = { method: TEST_SIGN_METHOD, params: TEST_SIGN_P
 export const TEST_RANDOM_REQUEST = { method: "random_method", params: [] };
 
 export const TEST_CONNECT_PARAMS = {
-  namespaces: TEST_NAMESPACES,
+  proposedNamespaces: TEST_PROPOSED_NAMESPACES,
   relays: [TEST_RELAY_OPTIONS],
 };
 
 export const TEST_APPROVE_PARAMS = {
   id: 123,
-  accounts: TEST_ACCOUNTS,
   namespaces: TEST_NAMESPACES,
 };
 
@@ -122,15 +119,7 @@ export const TEST_REJECT_PARAMS = {
   },
 };
 
-export const TEST_UPDATE_ACCOUNTS_PARAMS = {
-  accounts: TEST_ACCOUNTS,
-};
-
-export const TEST_UPDATE_EXPIRY_PARAMS = {
-  expiry: calcExpiry(FIVE_MINUTES),
-};
-
-export const TEST_UPDATE_NAMESPACES_PARAMS = {
+export const TEST_UPDATE_PARAMS = {
   namespaces: TEST_NAMESPACES,
 };
 
@@ -151,9 +140,3 @@ export const TEST_EMIT_PARAMS = {
   event: { name: TEST_EVENTS[0], data: "" },
   chainId: TEST_CHAINS[0],
 };
-
-// export const TEST_TIMEOUT_SHORT = CLIENT_SHORT_TIMEOUT;
-// export const TEST_TIMEOUT_SAFEGUARD = toMiliseconds(ONE_SECOND);
-// export const TEST_TIMEOUT_DURATION = toMiliseconds(THIRTY_SECONDS);
-// export const TEST_PAIRING_TTL = toMiliseconds(PAIRING_DEFAULT_TTL);
-// export const TEST_SESSION_TTL = toMiliseconds(SESSION_DEFAULT_TTL);

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -122,13 +122,13 @@ describe("Client Validation", () => {
 
     it("throws when invalid namespaces are provided", async () => {
       await expect(
-        client.approve({ ...TEST_APPROVE_PARAMS, namespaces: {} }),
+        client.approve({ ...TEST_APPROVE_PARAMS, namespaces: [] }),
       ).to.eventually.be.rejectedWith("Missing or invalid approve namespaces");
     });
 
     it("throws when empty namespaces are provided", async () => {
       await expect(
-        client.approve({ ...TEST_APPROVE_PARAMS, namespaces: [] }),
+        client.approve({ ...TEST_APPROVE_PARAMS, namespaces: {} }),
       ).to.eventually.be.rejectedWith("Missing or invalid approve namespaces");
     });
 

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -7,7 +7,6 @@ import {
   TEST_APPROVE_PARAMS,
   TEST_CONNECT_PARAMS,
   TEST_REJECT_PARAMS,
-  TEST_UPDATE_ACCOUNTS_PARAMS,
   TEST_UPDATE_EXPIRY_PARAMS,
   TEST_REQUEST_PARAMS,
   TEST_EMIT_PARAMS,
@@ -15,8 +14,6 @@ import {
   TEST_UPDATE_NAMESPACES_PARAMS,
 } from "./shared";
 import Client from "../src";
-import { calcExpiry } from "@walletconnect/utils";
-import { ONE_MINUTE, SEVEN_DAYS } from "@walletconnect/time";
 
 let client: Client;
 let pairingTopic: string;
@@ -268,174 +265,85 @@ describe("Client Validation", () => {
     });
   });
 
-  describe("updateAccounts", () => {
+  describe("update", () => {
     it("throws when no params are passed", async () => {
-      await expect(client.updateAccounts()).to.eventually.be.rejectedWith(
-        "Missing or invalid updateAccounts params",
+      await expect(client.update()).to.eventually.be.rejectedWith(
+        "Missing or invalid update params",
       );
     });
 
     it("throws when invalid topic is provided", async () => {
       await expect(
-        client.updateAccounts({ ...TEST_UPDATE_ACCOUNTS_PARAMS, topic: 123 }),
-      ).to.eventually.be.rejectedWith("Missing or invalid updateAccounts topic");
+        client.update({ ...TEST_UPDATE_NAMESPACES_PARAMS, topic: 123 }),
+      ).to.eventually.be.rejectedWith("Missing or invalid update topic");
     });
 
     it("throws when empty topic is provided", async () => {
       await expect(
-        client.updateAccounts({ ...TEST_UPDATE_ACCOUNTS_PARAMS, topic: "" }),
-      ).to.eventually.be.rejectedWith("Missing or invalid updateAccounts topic");
+        client.update({ ...TEST_UPDATE_NAMESPACES_PARAMS, topic: "" }),
+      ).to.eventually.be.rejectedWith("Missing or invalid update topic");
     });
 
     it("throws when no topic is provided", async () => {
       await expect(
-        client.updateAccounts({ ...TEST_UPDATE_ACCOUNTS_PARAMS, topic: undefined }),
-      ).to.eventually.be.rejectedWith("Missing or invalid updateAccounts topic");
+        client.update({ ...TEST_UPDATE_NAMESPACES_PARAMS, topic: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid update topic");
     });
 
     it("throws when non existant topic is provided", async () => {
       await expect(
-        client.updateAccounts({ ...TEST_UPDATE_ACCOUNTS_PARAMS, topic: "none" }),
-      ).to.eventually.be.rejectedWith("No matching session with topic: none");
-    });
-
-    it("throws when invalid accounts are provided", async () => {
-      await expect(client.updateAccounts({ topic, accounts: [123] })).to.eventually.be.rejectedWith(
-        "Missing or invalid updateAccounts accounts",
-      );
-      await expect(
-        client.updateAccounts({ topic, accounts: ["123"] }),
-      ).to.eventually.be.rejectedWith("Missing or invalid updateAccounts accounts");
-    });
-
-    it("throws when no accounts are provided", async () => {
-      await expect(
-        client.updateAccounts({ topic, accounts: undefined }),
-      ).to.eventually.be.rejectedWith("Missing or invalid updateAccounts accounts");
-    });
-
-    it("throws when provided accounts are not in session namespace", async () => {
-      await expect(
-        client.updateAccounts({
-          topic,
-          accounts: [
-            "eip155:42:0x3c582121909DE92Dc89A36898633C1aE4790382b",
-            "eip155:10:0x3c582121909DE92Dc89A36898633C1aE4790382b",
-          ],
-        }),
-      ).to.eventually.be.rejectedWith(
-        "Invalid accounts with mismatched chains: eip155:42,eip155:10",
-      );
-    });
-  });
-
-  describe("updateNamespaces", () => {
-    it("throws when no params are passed", async () => {
-      await expect(client.updateNamespaces()).to.eventually.be.rejectedWith(
-        "Missing or invalid updateNamespaces params",
-      );
-    });
-
-    it("throws when invalid topic is provided", async () => {
-      await expect(
-        client.updateNamespaces({ ...TEST_UPDATE_NAMESPACES_PARAMS, topic: 123 }),
-      ).to.eventually.be.rejectedWith("Missing or invalid updateNamespaces topic");
-    });
-
-    it("throws when empty topic is provided", async () => {
-      await expect(
-        client.updateNamespaces({ ...TEST_UPDATE_NAMESPACES_PARAMS, topic: "" }),
-      ).to.eventually.be.rejectedWith("Missing or invalid updateNamespaces topic");
-    });
-
-    it("throws when no topic is provided", async () => {
-      await expect(
-        client.updateNamespaces({ ...TEST_UPDATE_NAMESPACES_PARAMS, topic: undefined }),
-      ).to.eventually.be.rejectedWith("Missing or invalid updateNamespaces topic");
-    });
-
-    it("throws when non existant topic is provided", async () => {
-      await expect(
-        client.updateNamespaces({ ...TEST_UPDATE_NAMESPACES_PARAMS, topic: "none" }),
+        client.update({ ...TEST_UPDATE_NAMESPACES_PARAMS, topic: "none" }),
       ).to.eventually.be.rejectedWith("No matching session with topic: none");
     });
 
     it("throws when invalid namespaces are provided", async () => {
-      await expect(
-        client.updateNamespaces({ topic, namespaces: {} }),
-      ).to.eventually.be.rejectedWith("Missing or invalid updateNamespaces namespaces");
+      await expect(client.update({ topic, namespaces: {} })).to.eventually.be.rejectedWith(
+        "Missing or invalid update namespaces",
+      );
     });
 
     it("throws when empty namespaces are provided", async () => {
-      await expect(
-        client.updateNamespaces({ topic, namespaces: [] }),
-      ).to.eventually.be.rejectedWith("Missing or invalid updateNamespaces namespaces");
+      await expect(client.update({ topic, namespaces: [] })).to.eventually.be.rejectedWith(
+        "Missing or invalid update namespaces",
+      );
     });
 
     it("throws when no namespaces are provided", async () => {
-      await expect(
-        client.updateNamespaces({ topic, namespaces: undefined }),
-      ).to.eventually.be.rejectedWith("Missing or invalid updateNamespaces namespaces");
+      await expect(client.update({ topic, namespaces: undefined })).to.eventually.be.rejectedWith(
+        "Missing or invalid update namespaces",
+      );
     });
   });
 
-  describe("updateExpiry", () => {
+  describe("extend", () => {
     it("throws when no params are passed", async () => {
-      await expect(client.updateExpiry()).to.eventually.be.rejectedWith(
-        "Missing or invalid updateExpiry params",
+      await expect(client.extend()).to.eventually.be.rejectedWith(
+        "Missing or invalid extend params",
       );
     });
 
     it("throws when invalid topic is provided", async () => {
       await expect(
-        client.updateExpiry({ ...TEST_UPDATE_EXPIRY_PARAMS, topic: 123 }),
-      ).to.eventually.be.rejectedWith("Missing or invalid updateExpiry topic");
+        client.extend({ ...TEST_UPDATE_EXPIRY_PARAMS, topic: 123 }),
+      ).to.eventually.be.rejectedWith("Missing or invalid extend topic");
     });
 
     it("throws when empty topic is provided", async () => {
       await expect(
-        client.updateExpiry({ ...TEST_UPDATE_EXPIRY_PARAMS, topic: "" }),
-      ).to.eventually.be.rejectedWith("Missing or invalid updateExpiry topic");
+        client.extend({ ...TEST_UPDATE_EXPIRY_PARAMS, topic: "" }),
+      ).to.eventually.be.rejectedWith("Missing or invalid extend topic");
     });
 
     it("throws when no topic is provided", async () => {
       await expect(
-        client.updateExpiry({ ...TEST_UPDATE_EXPIRY_PARAMS, topic: undefined }),
-      ).to.eventually.be.rejectedWith("Missing or invalid updateExpiry topic");
+        client.extend({ ...TEST_UPDATE_EXPIRY_PARAMS, topic: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid extend topic");
     });
 
     it("throws when non existant topic is provided", async () => {
       await expect(
-        client.updateExpiry({ ...TEST_UPDATE_EXPIRY_PARAMS, topic: "none" }),
+        client.extend({ ...TEST_UPDATE_EXPIRY_PARAMS, topic: "none" }),
       ).to.eventually.be.rejectedWith("No matching session with topic: none");
-    });
-
-    it("throws when invalid expiry is provided", async () => {
-      await expect(client.updateExpiry({ topic, expiry: "1" })).to.eventually.be.rejectedWith(
-        "Missing or invalid updateExpiry expiry (min 5 min, max 7 days)",
-      );
-    });
-
-    it("throws when no expiry is provided", async () => {
-      await expect(client.updateExpiry({ topic, expiry: undefined })).to.eventually.be.rejectedWith(
-        "Missing or invalid updateExpiry expiry (min 5 min, max 7 days)",
-      );
-    });
-
-    it("throws when expiry is less than 5 minutes", async () => {
-      await expect(
-        client.updateExpiry({ topic, expiry: calcExpiry(ONE_MINUTE) }),
-      ).to.eventually.be.rejectedWith(
-        "Missing or invalid updateExpiry expiry (min 5 min, max 7 days)",
-      );
-    });
-
-    it("throws when expiry is more than 7 days", async () => {
-      await expect(
-        client.updateExpiry({ topic, expiry: calcExpiry(SEVEN_DAYS + ONE_MINUTE) }),
-      ).to.eventually.be.rejectedWith(
-        "Missing or invalid updateExpiry expiry (min 5 min, max 7 days)",
-      );
     });
   });
 

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -52,22 +52,22 @@ describe("Client Validation", () => {
       ).to.eventually.be.rejectedWith("No matching pairing with topic: none");
     });
 
-    it("throws when empty proposedNamespaces are provided", async () => {
+    it("throws when empty requiredNamespaces are provided", async () => {
       await expect(
-        client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, proposedNamespaces: [] }),
-      ).to.eventually.be.rejectedWith("Missing or invalid connect proposedNamespaces");
+        client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, requiredNamespaces: {} }),
+      ).to.eventually.be.rejectedWith("Missing or invalid connect requiredNamespaces");
     });
 
-    it("throws when invalid proposedNamespaces are provided", async () => {
+    it("throws when invalid requiredNamespaces are provided", async () => {
       await expect(
-        client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, proposedNamespaces: {} }),
-      ).to.eventually.be.rejectedWith("Missing or invalid connect proposedNamespaces");
+        client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, requiredNamespaces: [] }),
+      ).to.eventually.be.rejectedWith("Missing or invalid connect requiredNamespaces");
     });
 
-    it("throws when no proposedNamespaces are provided", async () => {
+    it("throws when no requiredNamespaces are provided", async () => {
       await expect(
-        client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, proposedNamespaces: undefined }),
-      ).to.eventually.be.rejectedWith("Missing or invalid connect proposedNamespaces");
+        client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, requiredNamespaces: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid connect requiredNamespaces");
     });
   });
 

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -7,11 +7,10 @@ import {
   TEST_APPROVE_PARAMS,
   TEST_CONNECT_PARAMS,
   TEST_REJECT_PARAMS,
-  TEST_UPDATE_EXPIRY_PARAMS,
+  TEST_UPDATE_PARAMS,
   TEST_REQUEST_PARAMS,
   TEST_EMIT_PARAMS,
   TEST_RESPOND_PARAMS,
-  TEST_UPDATE_NAMESPACES_PARAMS,
 } from "./shared";
 import Client from "../src";
 
@@ -53,16 +52,22 @@ describe("Client Validation", () => {
       ).to.eventually.be.rejectedWith("No matching pairing with topic: none");
     });
 
-    it("throws when empty namespaces are provided", async () => {
+    it("throws when empty proposedNamespaces are provided", async () => {
       await expect(
-        client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, namespaces: [] }),
-      ).to.eventually.be.rejectedWith("Missing or invalid connect namespaces");
+        client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, proposedNamespaces: [] }),
+      ).to.eventually.be.rejectedWith("Missing or invalid connect proposedNamespaces");
     });
 
-    it("throws when invalid namespaces are provided", async () => {
+    it("throws when invalid proposedNamespaces are provided", async () => {
       await expect(
-        client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, namespaces: {} }),
-      ).to.eventually.be.rejectedWith("Missing or invalid connect namespaces");
+        client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, proposedNamespaces: {} }),
+      ).to.eventually.be.rejectedWith("Missing or invalid connect proposedNamespaces");
+    });
+
+    it("throws when no proposedNamespaces are provided", async () => {
+      await expect(
+        client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, proposedNamespaces: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid connect proposedNamespaces");
     });
   });
 
@@ -113,27 +118,6 @@ describe("Client Validation", () => {
       await expect(
         client.approve({ ...TEST_APPROVE_PARAMS, id: undefined }),
       ).to.eventually.be.rejectedWith("Missing or invalid approve id");
-    });
-
-    it("throws when invalid accounts are provided", async () => {
-      await expect(
-        client.approve({ ...TEST_APPROVE_PARAMS, accounts: [123] }),
-      ).to.eventually.be.rejectedWith("Missing or invalid approve accounts");
-      await expect(
-        client.approve({ ...TEST_APPROVE_PARAMS, accounts: ["123"] }),
-      ).to.eventually.be.rejectedWith("Missing or invalid approve accounts");
-    });
-
-    it("throws when empty accounts are provided", async () => {
-      await expect(
-        client.approve({ ...TEST_APPROVE_PARAMS, accounts: [] }),
-      ).to.eventually.be.rejectedWith("Missing or invalid approve accounts");
-    });
-
-    it("throws when no accounts are provided", async () => {
-      await expect(
-        client.approve({ ...TEST_APPROVE_PARAMS, accounts: undefined }),
-      ).to.eventually.be.rejectedWith("Missing or invalid approve accounts");
     });
 
     it("throws when invalid namespaces are provided", async () => {
@@ -274,25 +258,25 @@ describe("Client Validation", () => {
 
     it("throws when invalid topic is provided", async () => {
       await expect(
-        client.update({ ...TEST_UPDATE_NAMESPACES_PARAMS, topic: 123 }),
+        client.update({ ...TEST_UPDATE_PARAMS, topic: 123 }),
       ).to.eventually.be.rejectedWith("Missing or invalid update topic");
     });
 
     it("throws when empty topic is provided", async () => {
       await expect(
-        client.update({ ...TEST_UPDATE_NAMESPACES_PARAMS, topic: "" }),
+        client.update({ ...TEST_UPDATE_PARAMS, topic: "" }),
       ).to.eventually.be.rejectedWith("Missing or invalid update topic");
     });
 
     it("throws when no topic is provided", async () => {
       await expect(
-        client.update({ ...TEST_UPDATE_NAMESPACES_PARAMS, topic: undefined }),
+        client.update({ ...TEST_UPDATE_PARAMS, topic: undefined }),
       ).to.eventually.be.rejectedWith("Missing or invalid update topic");
     });
 
     it("throws when non existant topic is provided", async () => {
       await expect(
-        client.update({ ...TEST_UPDATE_NAMESPACES_PARAMS, topic: "none" }),
+        client.update({ ...TEST_UPDATE_PARAMS, topic: "none" }),
       ).to.eventually.be.rejectedWith("No matching session with topic: none");
     });
 
@@ -323,27 +307,27 @@ describe("Client Validation", () => {
     });
 
     it("throws when invalid topic is provided", async () => {
-      await expect(
-        client.extend({ ...TEST_UPDATE_EXPIRY_PARAMS, topic: 123 }),
-      ).to.eventually.be.rejectedWith("Missing or invalid extend topic");
+      await expect(client.extend({ topic: 123 })).to.eventually.be.rejectedWith(
+        "Missing or invalid extend topic",
+      );
     });
 
     it("throws when empty topic is provided", async () => {
-      await expect(
-        client.extend({ ...TEST_UPDATE_EXPIRY_PARAMS, topic: "" }),
-      ).to.eventually.be.rejectedWith("Missing or invalid extend topic");
+      await expect(client.extend({ topic: "" })).to.eventually.be.rejectedWith(
+        "Missing or invalid extend topic",
+      );
     });
 
     it("throws when no topic is provided", async () => {
-      await expect(
-        client.extend({ ...TEST_UPDATE_EXPIRY_PARAMS, topic: undefined }),
-      ).to.eventually.be.rejectedWith("Missing or invalid extend topic");
+      await expect(client.extend({ topic: undefined })).to.eventually.be.rejectedWith(
+        "Missing or invalid extend topic",
+      );
     });
 
     it("throws when non existant topic is provided", async () => {
-      await expect(
-        client.extend({ ...TEST_UPDATE_EXPIRY_PARAMS, topic: "none" }),
-      ).to.eventually.be.rejectedWith("No matching session with topic: none");
+      await expect(client.extend({ topic: "none" })).to.eventually.be.rejectedWith(
+        "No matching session with topic: none",
+      );
     });
   });
 

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -11,6 +11,8 @@ import {
   TEST_REQUEST_PARAMS,
   TEST_EMIT_PARAMS,
   TEST_RESPOND_PARAMS,
+  TEST_NAMESPACES,
+  TEST_REQUIRED_NAMESPACES,
 } from "./shared";
 import Client from "../src";
 
@@ -67,6 +69,43 @@ describe("Client Validation", () => {
     it("throws when no requiredNamespaces are provided", async () => {
       await expect(
         client.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, requiredNamespaces: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid connect requiredNamespaces");
+    });
+
+    it("throws when empty extension is provided", async () => {
+      await expect(
+        client.connect({
+          ...TEST_CONNECT_PARAMS,
+          pairingTopic,
+          requiredNamespaces: { ...TEST_REQUIRED_NAMESPACES, extension: [] },
+        }),
+      ).to.eventually.be.rejectedWith("Missing or invalid connect requiredNamespaces");
+      await expect(
+        client.connect({
+          ...TEST_CONNECT_PARAMS,
+          pairingTopic,
+          requiredNamespaces: { ...TEST_REQUIRED_NAMESPACES, extension: [{}] },
+        }),
+      ).to.eventually.be.rejectedWith("Missing or invalid connect requiredNamespaces");
+    });
+
+    it("throws when invalid extension is provided", async () => {
+      await expect(
+        client.connect({
+          ...TEST_CONNECT_PARAMS,
+          pairingTopic,
+          requiredNamespaces: { ...TEST_REQUIRED_NAMESPACES, extension: {} },
+        }),
+      ).to.eventually.be.rejectedWith("Missing or invalid connect requiredNamespaces");
+    });
+
+    it("throws when invalid extension values are provided", async () => {
+      await expect(
+        client.connect({
+          ...TEST_CONNECT_PARAMS,
+          pairingTopic,
+          requiredNamespaces: { ...TEST_REQUIRED_NAMESPACES, extension: { invalid: [""] } },
+        }),
       ).to.eventually.be.rejectedWith("Missing or invalid connect requiredNamespaces");
     });
   });
@@ -135,6 +174,39 @@ describe("Client Validation", () => {
     it("throws when no namespaces are provided", async () => {
       await expect(
         client.approve({ ...TEST_APPROVE_PARAMS, namespaces: undefined }),
+      ).to.eventually.be.rejectedWith("Missing or invalid approve namespaces");
+    });
+
+    it("throws when empty extension is provided", async () => {
+      await expect(
+        client.approve({
+          ...TEST_APPROVE_PARAMS,
+          namespaces: { ...TEST_NAMESPACES, extension: [] },
+        }),
+      ).to.eventually.be.rejectedWith("Missing or invalid approve namespaces");
+      await expect(
+        client.approve({
+          ...TEST_APPROVE_PARAMS,
+          namespaces: { ...TEST_NAMESPACES, extension: [{}] },
+        }),
+      ).to.eventually.be.rejectedWith("Missing or invalid approve namespaces");
+    });
+
+    it("throws when invalid extension is provided", async () => {
+      await expect(
+        client.approve({
+          ...TEST_APPROVE_PARAMS,
+          namespaces: { ...TEST_NAMESPACES, extension: {} },
+        }),
+      ).to.eventually.be.rejectedWith("Missing or invalid approve namespaces");
+    });
+
+    it("throws when invalid extension values are provided", async () => {
+      await expect(
+        client.approve({
+          ...TEST_APPROVE_PARAMS,
+          namespaces: { ...TEST_NAMESPACES, extension: { invalid: [""] } },
+        }),
       ).to.eventually.be.rejectedWith("Missing or invalid approve namespaces");
     });
 

--- a/packages/client/test/validation.spec.ts
+++ b/packages/client/test/validation.spec.ts
@@ -374,6 +374,12 @@ describe("Client Validation", () => {
       ).to.eventually.be.rejectedWith("Missing or invalid request chainId");
     });
 
+    it("throws when chain id is not in session namespace", async () => {
+      await expect(
+        client.request({ ...TEST_REQUEST_PARAMS, topic, chainId: "eip000:0" }),
+      ).to.eventually.be.rejectedWith("Missing or invalid request chainId");
+    });
+
     it("throws when invalid request is provided", async () => {
       await expect(
         client.request({ ...TEST_REQUEST_PARAMS, topic, request: 123 }),

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -11,8 +11,8 @@ import { IExpirer } from "./expirer";
 export declare namespace ClientTypes {
   type Event =
     | "session_proposal"
-    | "update"
-    | "extend"
+    | "session_update"
+    | "session_extend"
     | "session_ping"
     | "pairing_ping"
     | "session_delete"
@@ -22,8 +22,8 @@ export declare namespace ClientTypes {
 
   interface EventArguments {
     session_proposal: ProposalTypes.Struct;
-    update: { topic: string; namespaces: SessionTypes.Namespaces };
-    extend: { topic: string };
+    session_update: { topic: string; namespaces: SessionTypes.Namespaces };
+    session_extend: { topic: string };
     session_ping: { topic: string };
     pairing_ping: { topic: string };
     session_delete: { topic: string };

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -11,9 +11,8 @@ import { IExpirer } from "./expirer";
 export declare namespace ClientTypes {
   type Event =
     | "session_proposal"
-    | "update_accounts"
-    | "update_namespaces"
-    | "update_expiry"
+    | "update"
+    | "extend"
     | "session_ping"
     | "pairing_ping"
     | "session_delete"
@@ -23,9 +22,8 @@ export declare namespace ClientTypes {
 
   interface EventArguments {
     session_proposal: ProposalTypes.Struct;
-    update_accounts: { topic: string; accounts: SessionTypes.Accounts };
-    update_namespaces: { topic: string; namespaces: SessionTypes.Namespace[] };
-    update_expiry: { topic: string; expiry: number };
+    update: { topic: string; namespaces: SessionTypes.Namespace[] };
+    extend: { topic: string };
     session_ping: { topic: string };
     pairing_ping: { topic: string };
     session_delete: { topic: string };
@@ -116,9 +114,8 @@ export abstract class IClient {
   public abstract pair: IEngine["pair"];
   public abstract approve: IEngine["approve"];
   public abstract reject: IEngine["reject"];
-  public abstract updateAccounts: IEngine["updateAccounts"];
-  public abstract updateNamespaces: IEngine["updateNamespaces"];
-  public abstract updateExpiry: IEngine["updateExpiry"];
+  public abstract update: IEngine["update"];
+  public abstract extend: IEngine["extend"];
   public abstract request: IEngine["request"];
   public abstract respond: IEngine["respond"];
   public abstract ping: IEngine["ping"];

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -22,7 +22,7 @@ export declare namespace ClientTypes {
 
   interface EventArguments {
     session_proposal: ProposalTypes.Struct;
-    update: { topic: string; namespaces: SessionTypes.Namespace[] };
+    update: { topic: string; namespaces: SessionTypes.Namespaces };
     extend: { topic: string };
     session_ping: { topic: string };
     pairing_ping: { topic: string };

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -51,7 +51,7 @@ export declare namespace EngineTypes {
   }
 
   interface ConnectParams {
-    proposedNamespaces: ProposalTypes.ProposedNamespace[];
+    requiredNamespaces: ProposalTypes.RequiredNamespaces;
     pairingTopic?: string;
     relays?: RelayerTypes.ProtocolOptions[];
   }
@@ -62,7 +62,7 @@ export declare namespace EngineTypes {
 
   interface ApproveParams {
     id: number;
-    namespaces: SessionTypes.Namespace[];
+    namespaces: SessionTypes.Namespaces;
     relayProtocol?: string;
   }
 
@@ -73,7 +73,7 @@ export declare namespace EngineTypes {
 
   interface UpdateParams {
     topic: string;
-    namespaces: SessionTypes.Namespace[];
+    namespaces: SessionTypes.Namespaces;
   }
 
   interface ExtendParams {

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -50,7 +50,7 @@ export declare namespace EngineTypes {
   }
 
   interface ConnectParams {
-    proposedNamespaces: SessionTypes.ProposedNamespaces[];
+    proposedNamespaces: SessionTypes.ProposedNamespace[];
     pairingTopic?: string;
     relays?: RelayerTypes.ProtocolOptions[];
   }

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -15,10 +15,10 @@ import { EventEmitter } from "events";
 
 export declare namespace EngineTypes {
   type Event =
-    | "connect"
-    | "approve"
-    | "update"
-    | "extend"
+    | "session_connect"
+    | "session_approve"
+    | "session_update"
+    | "session_extend"
     | "session_ping"
     | "pairing_ping"
     | "session_delete"
@@ -26,10 +26,10 @@ export declare namespace EngineTypes {
     | "request";
 
   interface EventArguments {
-    connect: { error?: ErrorResponse; data?: SessionTypes.Struct };
-    approve: { error?: ErrorResponse };
-    update: { error?: ErrorResponse };
-    extend: { error?: ErrorResponse };
+    session_connect: { error?: ErrorResponse; data?: SessionTypes.Struct };
+    session_approve: { error?: ErrorResponse };
+    session_update: { error?: ErrorResponse };
+    session_extend: { error?: ErrorResponse };
     session_ping: { error?: ErrorResponse };
     pairing_ping: { error?: ErrorResponse };
     session_delete: { error?: ErrorResponse };

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -8,6 +8,7 @@ import {
 import { IClient } from "./client";
 import { RelayerTypes } from "./relayer";
 import { SessionTypes } from "./session";
+import { ProposalTypes } from "./proposal";
 import { PairingTypes } from "./pairing";
 import { JsonRpcTypes } from "./jsonrpc";
 import { EventEmitter } from "events";
@@ -50,7 +51,7 @@ export declare namespace EngineTypes {
   }
 
   interface ConnectParams {
-    proposedNamespaces: SessionTypes.ProposedNamespace[];
+    proposedNamespaces: ProposalTypes.ProposedNamespace[];
     pairingTopic?: string;
     relays?: RelayerTypes.ProtocolOptions[];
   }

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -16,9 +16,8 @@ export declare namespace EngineTypes {
   type Event =
     | "connect"
     | "approve"
-    | "update_accounts"
-    | "update_namespaces"
-    | "update_expiry"
+    | "update"
+    | "extend"
     | "session_ping"
     | "pairing_ping"
     | "session_delete"
@@ -28,9 +27,8 @@ export declare namespace EngineTypes {
   interface EventArguments {
     connect: { error?: ErrorResponse; data?: SessionTypes.Struct };
     approve: { error?: ErrorResponse };
-    update_accounts: { error?: ErrorResponse };
-    update_namespaces: { error?: ErrorResponse };
-    update_expiry: { error?: ErrorResponse };
+    update: { error?: ErrorResponse };
+    extend: { error?: ErrorResponse };
     session_ping: { error?: ErrorResponse };
     pairing_ping: { error?: ErrorResponse };
     session_delete: { error?: ErrorResponse };
@@ -52,8 +50,8 @@ export declare namespace EngineTypes {
   }
 
   interface ConnectParams {
+    proposedNamespaces: SessionTypes.ProposedNamespaces[];
     pairingTopic?: string;
-    namespaces?: SessionTypes.Namespace[];
     relays?: RelayerTypes.ProtocolOptions[];
   }
 
@@ -63,7 +61,6 @@ export declare namespace EngineTypes {
 
   interface ApproveParams {
     id: number;
-    accounts: SessionTypes.Accounts;
     namespaces: SessionTypes.Namespace[];
     relayProtocol?: string;
   }
@@ -73,19 +70,13 @@ export declare namespace EngineTypes {
     reason: ErrorResponse;
   }
 
-  interface UpdateAccountsParams {
-    topic: string;
-    accounts: SessionTypes.Accounts;
-  }
-
-  interface UpdateNamespacesParams {
+  interface UpdateParams {
     topic: string;
     namespaces: SessionTypes.Namespace[];
   }
 
-  interface UpdateExpiryParams {
+  interface ExtendParams {
     topic: string;
-    expiry: SessionTypes.Expiry;
   }
 
   interface RequestParams {
@@ -186,34 +177,24 @@ export interface EnginePrivate {
     payload: JsonRpcResult<JsonRpcTypes.Results["wc_sessionSettle"]> | JsonRpcError,
   ): Promise<void>;
 
-  onSessionUpdateAccountsRequest(
+  onSessionUpdateRequest(
     topic: string,
-    payload: JsonRpcRequest<JsonRpcTypes.RequestParams["wc_sessionUpdateAccounts"]>,
+    payload: JsonRpcRequest<JsonRpcTypes.RequestParams["wc_sessionUpdate"]>,
   ): Promise<void>;
 
-  onSessionUpdateAccountsResponse(
+  onSessionUpdateResponse(
     topic: string,
-    payload: JsonRpcResult<JsonRpcTypes.Results["wc_sessionUpdateAccounts"]> | JsonRpcError,
+    payload: JsonRpcResult<JsonRpcTypes.Results["wc_sessionUpdate"]> | JsonRpcError,
   ): void;
 
-  onSessionUpdateNamespacesRequest(
+  onSessionExtendRequest(
     topic: string,
-    payload: JsonRpcRequest<JsonRpcTypes.RequestParams["wc_sessionUpdateNamespaces"]>,
+    payload: JsonRpcRequest<JsonRpcTypes.RequestParams["wc_sessionExtend"]>,
   ): Promise<void>;
 
-  onSessionUpdateNamespacesResponse(
+  onSessionExtendResponse(
     topic: string,
-    payload: JsonRpcResult<JsonRpcTypes.Results["wc_sessionUpdateNamespaces"]> | JsonRpcError,
-  ): void;
-
-  onSessionUpdateExpiryRequest(
-    topic: string,
-    payload: JsonRpcRequest<JsonRpcTypes.RequestParams["wc_sessionUpdateExpiry"]>,
-  ): Promise<void>;
-
-  onSessionUpdateExpiryResponse(
-    topic: string,
-    payload: JsonRpcResult<JsonRpcTypes.Results["wc_sessionUpdateExpiry"]> | JsonRpcError,
+    payload: JsonRpcResult<JsonRpcTypes.Results["wc_sessionExtend"]> | JsonRpcError,
   ): void;
 
   onSessionPingRequest(
@@ -280,11 +261,9 @@ export interface EnginePrivate {
 
   isValidReject(params: EngineTypes.RejectParams): void;
 
-  isValidUpdateAccounts(params: EngineTypes.UpdateAccountsParams): void;
+  isValidUpdate(params: EngineTypes.UpdateParams): void;
 
-  isValidUpdateExpiry(params: EngineTypes.UpdateExpiryParams): void;
-
-  isValidUpdateNamespaces(params: EngineTypes.UpdateNamespacesParams): void;
+  isValidExtend(params: EngineTypes.ExtendParams): void;
 
   isValidRequest(params: EngineTypes.RequestParams): void;
 
@@ -314,11 +293,9 @@ export abstract class IEngine {
 
   public abstract reject(params: EngineTypes.RejectParams): Promise<void>;
 
-  public abstract updateAccounts(params: EngineTypes.UpdateAccountsParams): Promise<void>;
+  public abstract update(params: EngineTypes.UpdateParams): Promise<void>;
 
-  public abstract updateNamespaces(params: EngineTypes.UpdateNamespacesParams): Promise<void>;
-
-  public abstract updateExpiry(params: EngineTypes.UpdateExpiryParams): Promise<void>;
+  public abstract extend(params: EngineTypes.ExtendParams): Promise<void>;
 
   public abstract request(params: EngineTypes.RequestParams): Promise<JsonRpcResponse>;
 

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -241,7 +241,7 @@ export interface EnginePrivate {
   onSessionRequest(
     topic: string,
     payload: JsonRpcRequest<JsonRpcTypes.RequestParams["wc_sessionRequest"]>,
-  ): Promise<void>;
+  ): void;
 
   onSessionRequestResponse(
     topic: string,

--- a/packages/types/src/jsonrpc.ts
+++ b/packages/types/src/jsonrpc.ts
@@ -12,9 +12,8 @@ export declare namespace JsonRpcTypes {
     | "wc_pairingPing"
     | "wc_sessionPropose"
     | "wc_sessionSettle"
-    | "wc_sessionUpdateAccounts"
-    | "wc_sessionUpdateNamespaces"
-    | "wc_sessionUpdateExpiry"
+    | "wc_sessionUpdate"
+    | "wc_sessionExtend"
     | "wc_sessionDelete"
     | "wc_sessionPing"
     | "wc_sessionRequest"
@@ -30,7 +29,7 @@ export declare namespace JsonRpcTypes {
     wc_pairingPing: {};
     wc_sessionPropose: {
       relays: RelayerTypes.ProtocolOptions[];
-      namespaces: SessionTypes.Namespace[];
+      proposedNamespaces: SessionTypes.ProposedNamespaces[];
       proposer: {
         publicKey: string;
         metadata: ClientTypes.Metadata;
@@ -38,7 +37,6 @@ export declare namespace JsonRpcTypes {
     };
     wc_sessionSettle: {
       relay: RelayerTypes.ProtocolOptions;
-      accounts: SessionTypes.Accounts;
       namespaces: SessionTypes.Namespace[];
       expiry: number;
       controller: {
@@ -46,15 +44,10 @@ export declare namespace JsonRpcTypes {
         metadata: ClientTypes.Metadata;
       };
     };
-    wc_sessionUpdateAccounts: {
-      accounts: SessionTypes.Accounts;
-    };
-    wc_sessionUpdateNamespaces: {
+    wc_sessionUpdate: {
       namespaces: SessionTypes.Namespace[];
     };
-    wc_sessionUpdateExpiry: {
-      expiry: number;
-    };
+    wc_sessionExtend: {};
     wc_sessionDelete: {
       code: number;
       message: string;
@@ -85,9 +78,8 @@ export declare namespace JsonRpcTypes {
       responderPublicKey: string;
     };
     wc_sessionSettle: true;
-    wc_sessionUpdateAccounts: true;
-    wc_sessionUpdateNamespaces: true;
-    wc_sessionUpdateExpiry: true;
+    wc_sessionUpdate: true;
+    wc_sessionExtend: true;
     wc_sessionDelete: true;
     wc_sessionPing: true;
     wc_sessionRequest: JsonRpcResult;

--- a/packages/types/src/jsonrpc.ts
+++ b/packages/types/src/jsonrpc.ts
@@ -30,7 +30,7 @@ export declare namespace JsonRpcTypes {
     wc_pairingPing: {};
     wc_sessionPropose: {
       relays: RelayerTypes.ProtocolOptions[];
-      proposedNamespaces: ProposalTypes.ProposedNamespace[];
+      requiredNamespaces: ProposalTypes.RequiredNamespaces;
       proposer: {
         publicKey: string;
         metadata: ClientTypes.Metadata;
@@ -38,7 +38,7 @@ export declare namespace JsonRpcTypes {
     };
     wc_sessionSettle: {
       relay: RelayerTypes.ProtocolOptions;
-      namespaces: SessionTypes.Namespace[];
+      namespaces: SessionTypes.Namespaces;
       expiry: number;
       controller: {
         publicKey: string;
@@ -46,7 +46,7 @@ export declare namespace JsonRpcTypes {
       };
     };
     wc_sessionUpdate: {
-      namespaces: SessionTypes.Namespace[];
+      namespaces: SessionTypes.Namespaces;
     };
     wc_sessionExtend: {};
     wc_sessionDelete: {

--- a/packages/types/src/jsonrpc.ts
+++ b/packages/types/src/jsonrpc.ts
@@ -29,7 +29,7 @@ export declare namespace JsonRpcTypes {
     wc_pairingPing: {};
     wc_sessionPropose: {
       relays: RelayerTypes.ProtocolOptions[];
-      proposedNamespaces: SessionTypes.ProposedNamespaces[];
+      proposedNamespaces: SessionTypes.ProposedNamespace[];
       proposer: {
         publicKey: string;
         metadata: ClientTypes.Metadata;

--- a/packages/types/src/jsonrpc.ts
+++ b/packages/types/src/jsonrpc.ts
@@ -2,6 +2,7 @@ import { ErrorResponse, JsonRpcResult } from "@walletconnect/jsonrpc-types";
 import { ClientTypes } from "./client";
 import { RelayerTypes } from "./relayer";
 import { SessionTypes } from "./session";
+import { ProposalTypes } from "./proposal";
 
 export declare namespace JsonRpcTypes {
   // -- core ------------------------------------------------------- //
@@ -29,7 +30,7 @@ export declare namespace JsonRpcTypes {
     wc_pairingPing: {};
     wc_sessionPropose: {
       relays: RelayerTypes.ProtocolOptions[];
-      proposedNamespaces: SessionTypes.ProposedNamespace[];
+      proposedNamespaces: ProposalTypes.ProposedNamespace[];
       proposer: {
         publicKey: string;
         metadata: ClientTypes.Metadata;

--- a/packages/types/src/proposal.ts
+++ b/packages/types/src/proposal.ts
@@ -11,7 +11,7 @@ export declare namespace ProposalTypes {
       publicKey: string;
       metadata: ClientTypes.Metadata;
     };
-    proposedNamespaces: SessionTypes.ProposedNamespaces[];
+    proposedNamespaces: SessionTypes.ProposedNamespace[];
     pairingTopic?: string;
   }
 }

--- a/packages/types/src/proposal.ts
+++ b/packages/types/src/proposal.ts
@@ -3,14 +3,17 @@ import { RelayerTypes } from "./relayer";
 import { IStore } from "./store";
 
 export declare namespace ProposalTypes {
-  interface RequiredNamespaceBody {
+  interface BaseRequiredNamespace {
     chains: string[];
     methods: string[];
     events: string[];
-    extension?: Omit<RequiredNamespaceBody, "extension">[];
   }
 
-  type RequiredNamespaces = Record<string, RequiredNamespaceBody>;
+  interface RequiredNamespace extends BaseRequiredNamespace {
+    extension?: BaseRequiredNamespace[];
+  }
+
+  type RequiredNamespaces = Record<string, RequiredNamespace>;
 
   export interface Struct {
     id: number;

--- a/packages/types/src/proposal.ts
+++ b/packages/types/src/proposal.ts
@@ -11,7 +11,7 @@ export declare namespace ProposalTypes {
       chains: string[];
       methods?: string[];
       events?: string[];
-    };
+    }[];
   }
 
   type RequiredNamespaces = Record<string, RequiredNamespaceBody>;

--- a/packages/types/src/proposal.ts
+++ b/packages/types/src/proposal.ts
@@ -11,7 +11,7 @@ export declare namespace ProposalTypes {
       publicKey: string;
       metadata: ClientTypes.Metadata;
     };
-    namespaces: SessionTypes.Namespace[];
+    proposedNamespaces: SessionTypes.ProposedNamespaces[];
     pairingTopic?: string;
   }
 }

--- a/packages/types/src/proposal.ts
+++ b/packages/types/src/proposal.ts
@@ -23,7 +23,7 @@ export declare namespace ProposalTypes {
       publicKey: string;
       metadata: ClientTypes.Metadata;
     };
-    requiredNamespaces: RequiredNamespaces[];
+    requiredNamespaces: RequiredNamespaces;
     pairingTopic?: string;
   }
 }

--- a/packages/types/src/proposal.ts
+++ b/packages/types/src/proposal.ts
@@ -3,11 +3,18 @@ import { RelayerTypes } from "./relayer";
 import { IStore } from "./store";
 
 export declare namespace ProposalTypes {
-  interface ProposedNamespace {
+  interface RequiredNamespaceBody {
+    chains: string[];
     methods: string[];
     events: string[];
-    chains: string[];
+    extension?: {
+      chains: string[];
+      methods?: string[];
+      events?: string[];
+    };
   }
+
+  type RequiredNamespaces = Record<string, RequiredNamespaceBody>;
 
   export interface Struct {
     id: number;
@@ -16,7 +23,7 @@ export declare namespace ProposalTypes {
       publicKey: string;
       metadata: ClientTypes.Metadata;
     };
-    proposedNamespaces: ProposedNamespace[];
+    requiredNamespaces: RequiredNamespaces[];
     pairingTopic?: string;
   }
 }

--- a/packages/types/src/proposal.ts
+++ b/packages/types/src/proposal.ts
@@ -1,9 +1,14 @@
 import { ClientTypes } from "./client";
 import { RelayerTypes } from "./relayer";
-import { SessionTypes } from "./session";
 import { IStore } from "./store";
 
 export declare namespace ProposalTypes {
+  interface ProposedNamespace {
+    methods: string[];
+    events: string[];
+    chains: string[];
+  }
+
   export interface Struct {
     id: number;
     relays: RelayerTypes.ProtocolOptions[];
@@ -11,7 +16,7 @@ export declare namespace ProposalTypes {
       publicKey: string;
       metadata: ClientTypes.Metadata;
     };
-    proposedNamespaces: SessionTypes.ProposedNamespace[];
+    proposedNamespaces: ProposedNamespace[];
     pairingTopic?: string;
   }
 }

--- a/packages/types/src/proposal.ts
+++ b/packages/types/src/proposal.ts
@@ -7,11 +7,7 @@ export declare namespace ProposalTypes {
     chains: string[];
     methods: string[];
     events: string[];
-    extension?: {
-      chains: string[];
-      methods?: string[];
-      events?: string[];
-    }[];
+    extension?: Omit<RequiredNamespaceBody, "extension">[];
   }
 
   type RequiredNamespaces = Record<string, RequiredNamespaceBody>;

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -11,12 +11,6 @@ export declare namespace SessionTypes {
     accounts: string[];
   }
 
-  interface ProposedNamespace {
-    methods: string[];
-    events: string[];
-    chains: string[];
-  }
-
   interface Struct {
     topic: string;
     relay: RelayerTypes.ProtocolOptions;

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -9,11 +9,7 @@ export declare namespace SessionTypes {
     accounts: string[];
     methods: string[];
     events: string[];
-    extension?: {
-      accounts: string[];
-      methods?: string[];
-      events?: string[];
-    }[];
+    extension?: Omit<NamespaceBody, "extension">[];
   }
 
   type Namespaces = Record<string, NamespaceBody>;

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -13,7 +13,7 @@ export declare namespace SessionTypes {
       accounts: string[];
       methods?: string[];
       events?: string[];
-    };
+    }[];
   }
 
   type Namespaces = Record<string, NamespaceBody>;

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -5,11 +5,18 @@ import { IStore } from "./store";
 export declare namespace SessionTypes {
   type Expiry = number;
 
-  interface Namespace {
+  interface NamespaceBody {
+    accounts: string[];
     methods: string[];
     events: string[];
-    accounts: string[];
+    extension?: {
+      accounts: string[];
+      methods?: string[];
+      events?: string[];
+    };
   }
+
+  type Namespaces = Record<string, NamespaceBody>;
 
   interface Struct {
     topic: string;
@@ -17,7 +24,7 @@ export declare namespace SessionTypes {
     expiry: Expiry;
     acknowledged: boolean;
     controller: string;
-    namespaces: Namespace[];
+    namespaces: Namespaces;
     self: {
       publicKey: string;
       metadata: ClientTypes.Metadata;
@@ -29,7 +36,10 @@ export declare namespace SessionTypes {
   }
 
   interface Updatable {
-    namespace?: Namespace;
+    namespace?: {
+      key: string;
+      body: NamespaceBody;
+    };
     expiry?: Expiry;
   }
 }

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -5,14 +5,17 @@ import { IStore } from "./store";
 export declare namespace SessionTypes {
   type Expiry = number;
 
-  interface NamespaceBody {
+  interface BaseNamespace {
     accounts: string[];
     methods: string[];
     events: string[];
-    extension?: Omit<NamespaceBody, "extension">[];
   }
 
-  type Namespaces = Record<string, NamespaceBody>;
+  interface Namespace extends BaseNamespace {
+    extension?: BaseNamespace[];
+  }
+
+  type Namespaces = Record<string, Namespace>;
 
   interface Struct {
     topic: string;
@@ -31,15 +34,15 @@ export declare namespace SessionTypes {
     };
   }
 
-  interface Updatable {
+  interface Filters {
     namespace?: {
       key: string;
-      body: NamespaceBody;
+      body: BaseNamespace;
     };
     expiry?: Expiry;
   }
 }
 
 export interface ISession extends IStore<string, SessionTypes.Struct> {
-  find: (filters: SessionTypes.Updatable) => SessionTypes.Struct[];
+  find: (filters: SessionTypes.Filters) => SessionTypes.Struct[];
 }

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -3,11 +3,15 @@ import { RelayerTypes } from "./relayer";
 import { IStore } from "./store";
 
 export declare namespace SessionTypes {
-  type Accounts = string[];
-
   type Expiry = number;
 
   interface Namespace {
+    methods: string[];
+    events: string[];
+    accounts: string[];
+  }
+
+  interface ProposedNamespaces {
     methods: string[];
     events: string[];
     chains: string[];
@@ -19,7 +23,6 @@ export declare namespace SessionTypes {
     expiry: Expiry;
     acknowledged: boolean;
     controller: string;
-    accounts: Accounts;
     namespaces: Namespace[];
     self: {
       publicKey: string;
@@ -32,7 +35,6 @@ export declare namespace SessionTypes {
   }
 
   interface Updatable {
-    accounts?: Accounts;
     namespace?: Namespace;
     expiry?: Expiry;
   }

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -11,7 +11,7 @@ export declare namespace SessionTypes {
     accounts: string[];
   }
 
-  interface ProposedNamespaces {
+  interface ProposedNamespace {
     methods: string[];
     events: string[];
     chains: string[];

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -1,15 +1,9 @@
 import { FIVE_MINUTES, fromMiliseconds, toMiliseconds } from "@walletconnect/time";
-import {
-  ClientTypes,
-  RelayerClientMetadata,
-  EngineTypes,
-  SessionTypes,
-} from "@walletconnect/types";
+import { ClientTypes, RelayerClientMetadata, EngineTypes } from "@walletconnect/types";
 import { getDocument, getLocation, getNavigator } from "@walletconnect/window-getters";
 import { getWindowMetadata } from "@walletconnect/window-metadata";
 import { ErrorResponse } from "@walletconnect/jsonrpc-utils";
 import * as qs from "query-string";
-import isEqual from "lodash.isequal";
 
 // -- constants -----------------------------------------//
 
@@ -123,11 +117,6 @@ export function parseContextNames(context: string, depth = DEFAULT_DEPTH) {
 
 export function formatMessageContext(context: string): string {
   return parseContextNames(context).join(EMPTY_SPACE);
-}
-
-// -- object ------------------------------------------------ //
-export function isNamespaceEqual(a: SessionTypes.Namespace, b: SessionTypes.Namespace) {
-  return isEqual(a, b);
 }
 
 // -- array ------------------------------------------------- //

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -1,8 +1,20 @@
 import { SessionTypes } from "@walletconnect/types";
 
+export function getAccountsChains(accounts: SessionTypes.Namespace["accounts"]) {
+  const chains: string[] = [];
+  accounts.forEach(account => {
+    const [chain] = account.split(":");
+    chains.push(chain);
+  });
+
+  return chains;
+}
+
 export function getNamespacesChains(namespaces: SessionTypes.Namespace[]) {
-  const chains: SessionTypes.Namespace["chains"] = [];
-  namespaces.forEach(namespace => chains.push(...namespace.chains));
+  const chains: string[] = [];
+  namespaces.forEach(namespace => {
+    chains.push(...getAccountsChains(namespace.accounts));
+  });
 
   return chains;
 }
@@ -13,7 +25,8 @@ export function getNamespacesMethodsForChainId(
 ) {
   const methods: SessionTypes.Namespace["methods"] = [];
   namespaces.forEach(namespace => {
-    if (namespace.chains.includes(chainId)) methods.push(...namespace.methods);
+    const chains = getAccountsChains(namespace.accounts);
+    if (chains.includes(chainId)) methods.push(...namespace.methods);
   });
 
   return methods;
@@ -25,7 +38,8 @@ export function getNamespacesEventsForChainId(
 ) {
   const events: SessionTypes.Namespace["events"] = [];
   namespaces.forEach(namespace => {
-    if (namespace.chains.includes(chainId)) events.push(...namespace.events);
+    const chains = getAccountsChains(namespace.accounts);
+    if (chains.includes(chainId)) events.push(...namespace.events);
   });
 
   return events;

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -1,6 +1,6 @@
 import { SessionTypes } from "@walletconnect/types";
 
-export function getAccountsChains(accounts: SessionTypes.NamespaceBody["accounts"]) {
+export function getAccountsChains(accounts: SessionTypes.Namespace["accounts"]) {
   const chains: string[] = [];
   accounts.forEach(account => {
     const [chain, chainId] = account.split(":");
@@ -28,7 +28,7 @@ export function getNamespacesMethodsForChainId(
   namespaces: SessionTypes.Namespaces,
   chainId: string,
 ) {
-  const methods: SessionTypes.NamespaceBody["methods"] = [];
+  const methods: SessionTypes.Namespace["methods"] = [];
   Object.values(namespaces).forEach(namespace => {
     const chains = getAccountsChains(namespace.accounts);
     if (chains.includes(chainId)) methods.push(...namespace.methods);
@@ -47,7 +47,7 @@ export function getNamespacesEventsForChainId(
   namespaces: SessionTypes.Namespaces,
   chainId: string,
 ) {
-  const events: SessionTypes.NamespaceBody["events"] = [];
+  const events: SessionTypes.Namespace["events"] = [];
   Object.values(namespaces).forEach(namespace => {
     const chains = getAccountsChains(namespace.accounts);
     if (chains.includes(chainId)) events.push(...namespace.events);

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -14,6 +14,11 @@ export function getNamespacesChains(namespaces: SessionTypes.Namespaces) {
   const chains: string[] = [];
   Object.values(namespaces).forEach(namespace => {
     chains.push(...getAccountsChains(namespace.accounts));
+    if (namespace.extension) {
+      namespace.extension.forEach(extension => {
+        chains.push(...getAccountsChains(extension.accounts));
+      });
+    }
   });
 
   return chains;
@@ -27,6 +32,12 @@ export function getNamespacesMethodsForChainId(
   Object.values(namespaces).forEach(namespace => {
     const chains = getAccountsChains(namespace.accounts);
     if (chains.includes(chainId)) methods.push(...namespace.methods);
+    if (namespace.extension) {
+      namespace.extension.forEach(extension => {
+        const extensionChains = getAccountsChains(extension.accounts);
+        if (extensionChains.includes(chainId)) methods.push(...extension.methods);
+      });
+    }
   });
 
   return methods;
@@ -40,6 +51,12 @@ export function getNamespacesEventsForChainId(
   Object.values(namespaces).forEach(namespace => {
     const chains = getAccountsChains(namespace.accounts);
     if (chains.includes(chainId)) events.push(...namespace.events);
+    if (namespace.extension) {
+      namespace.extension.forEach(extension => {
+        const extensionChains = getAccountsChains(extension.accounts);
+        if (extensionChains.includes(chainId)) events.push(...extension.events);
+      });
+    }
   });
 
   return events;

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -3,8 +3,8 @@ import { SessionTypes } from "@walletconnect/types";
 export function getAccountsChains(accounts: SessionTypes.Namespace["accounts"]) {
   const chains: string[] = [];
   accounts.forEach(account => {
-    const [chain] = account.split(":");
-    chains.push(chain);
+    const [chain, chainId] = account.split(":");
+    chains.push(`${chain}:${chainId}`);
   });
 
   return chains;

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -1,6 +1,6 @@
 import { SessionTypes } from "@walletconnect/types";
 
-export function getAccountsChains(accounts: SessionTypes.Namespace["accounts"]) {
+export function getAccountsChains(accounts: SessionTypes.NamespaceBody["accounts"]) {
   const chains: string[] = [];
   accounts.forEach(account => {
     const [chain, chainId] = account.split(":");
@@ -10,9 +10,9 @@ export function getAccountsChains(accounts: SessionTypes.Namespace["accounts"]) 
   return chains;
 }
 
-export function getNamespacesChains(namespaces: SessionTypes.Namespace[]) {
+export function getNamespacesChains(namespaces: SessionTypes.Namespaces) {
   const chains: string[] = [];
-  namespaces.forEach(namespace => {
+  Object.values(namespaces).forEach(namespace => {
     chains.push(...getAccountsChains(namespace.accounts));
   });
 
@@ -20,11 +20,11 @@ export function getNamespacesChains(namespaces: SessionTypes.Namespace[]) {
 }
 
 export function getNamespacesMethodsForChainId(
-  namespaces: SessionTypes.Namespace[],
+  namespaces: SessionTypes.Namespaces,
   chainId: string,
 ) {
-  const methods: SessionTypes.Namespace["methods"] = [];
-  namespaces.forEach(namespace => {
+  const methods: SessionTypes.NamespaceBody["methods"] = [];
+  Object.values(namespaces).forEach(namespace => {
     const chains = getAccountsChains(namespace.accounts);
     if (chains.includes(chainId)) methods.push(...namespace.methods);
   });
@@ -33,11 +33,11 @@ export function getNamespacesMethodsForChainId(
 }
 
 export function getNamespacesEventsForChainId(
-  namespaces: SessionTypes.Namespace[],
+  namespaces: SessionTypes.Namespaces,
   chainId: string,
 ) {
-  const events: SessionTypes.Namespace["events"] = [];
-  namespaces.forEach(namespace => {
+  const events: SessionTypes.NamespaceBody["events"] = [];
+  Object.values(namespaces).forEach(namespace => {
     const chains = getAccountsChains(namespace.accounts);
     if (chains.includes(chainId)) events.push(...namespace.events);
   });

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -91,35 +91,37 @@ export function isSessionStruct(input: any): input is SessionTypes.Struct {
   return input?.topic;
 }
 
-export function isValidProposedNamespace(input: any): input is ProposalTypes.ProposedNamespace {
+export function isValidRequiredNamespaceBody(
+  input: any,
+): input is ProposalTypes.RequiredNamespaceBody {
   const { methods, events, chains } = input;
   let validChains = true;
-  const validProposedNamespace =
+  const validRequiredNamespace =
     isValidArray(methods) && isValidArray(events) && isValidArray(chains);
   chains.forEach((chain: string) => {
     if (!isValidChainId(chain, false)) validChains = false;
   });
-  return validProposedNamespace && validChains;
+
+  return validRequiredNamespace && validChains;
 }
 
-export function isValidProposedNamespaces(
+export function isValidRequiredNamespaces(
   input: any,
   optional: boolean,
-): input is ProposalTypes.ProposedNamespace[] {
+): input is ProposalTypes.RequiredNamespaces {
   let valid = false;
-
   if (optional && !input) valid = true;
   else if (input && isValidArray(input) && input.length) {
     valid = true;
-    input.forEach((namespace: ProposalTypes.ProposedNamespace) => {
-      if (!isValidProposedNamespace(namespace)) valid = false;
+    Object.values(input).forEach(namespace => {
+      if (!isValidRequiredNamespaceBody(namespace)) valid = false;
     });
   }
 
   return valid;
 }
 
-export function isValidNamespace(input: any): input is SessionTypes.Namespace[] {
+export function isValidNamespaceBody(input: any): input is SessionTypes.NamespaceBody {
   const { methods, events, accounts } = input;
   let validAccounts = true;
   const validNamespace = isValidArray(methods) && isValidArray(events) && isValidArray(accounts);
@@ -129,17 +131,14 @@ export function isValidNamespace(input: any): input is SessionTypes.Namespace[] 
   return validNamespace && validAccounts;
 }
 
-export function isValidNamespaces(
-  input: any,
-  optional: boolean,
-): input is SessionTypes.Namespace[] {
+export function isValidNamespaces(input: any, optional: boolean): input is SessionTypes.Namespaces {
   let valid = false;
 
   if (optional && !input) valid = true;
   else if (input && isValidArray(input) && input.length) {
     valid = true;
-    input.forEach((namespace: SessionTypes.Namespace) => {
-      if (!isValidNamespace(namespace)) valid = false;
+    Object.values(input).forEach(namespace => {
+      if (!isValidNamespaceBody(namespace)) valid = false;
     });
   }
 
@@ -158,8 +157,8 @@ export function isValidRelays(
 
   if (optional && !input) valid = true;
   else if (input && isValidArray(input) && input.length) {
-    input.forEach((namespace: SessionTypes.Namespace) => {
-      valid = isValidRelay(namespace);
+    input.forEach((relay: RelayerTypes.ProtocolOptions) => {
+      valid = isValidRelay(relay);
     });
   }
 
@@ -216,7 +215,7 @@ export function isValidEvent(event: any) {
   return true;
 }
 
-export function isValidNamespacesChainId(namespaces: SessionTypes.Namespace[], chainId: string) {
+export function isValidNamespacesChainId(namespaces: SessionTypes.Namespaces, chainId: string) {
   if (!isValidChainId(chainId, false)) return false;
   const chains = getNamespacesChains(namespaces);
   if (!chains.includes(chainId)) return false;
@@ -225,7 +224,7 @@ export function isValidNamespacesChainId(namespaces: SessionTypes.Namespace[], c
 }
 
 export function isValidNamespacesRequest(
-  namespaces: SessionTypes.Namespace[],
+  namespaces: SessionTypes.Namespaces,
   chainId: string,
   method: string,
 ) {
@@ -235,7 +234,7 @@ export function isValidNamespacesRequest(
 }
 
 export function isValidNamespacesEvent(
-  namespaces: SessionTypes.Namespace[],
+  namespaces: SessionTypes.Namespaces,
   chainId: string,
   eventName: string,
 ) {

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -216,13 +216,10 @@ export function isValidEvent(event: any) {
   return true;
 }
 
-export function isValidNamespacesChainId(namespaces: SessionTypes.Namespace[], chainId?: string) {
-  if (!isValidChainId(chainId, true)) return false;
-
-  if (chainId) {
-    const chains = getNamespacesChains(namespaces);
-    if (!chains.includes(chainId)) return false;
-  }
+export function isValidNamespacesChainId(namespaces: SessionTypes.Namespace[], chainId: string) {
+  if (!isValidChainId(chainId, false)) return false;
+  const chains = getNamespacesChains(namespaces);
+  if (!chains.includes(chainId)) return false;
 
   return true;
 }

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -1,13 +1,11 @@
 import { SessionTypes, ProposalTypes, RelayerTypes } from "@walletconnect/types";
 import { ErrorResponse } from "@walletconnect/jsonrpc-types";
-import { isNamespaceEqual, calcExpiry } from "./misc";
-import { getChains } from "./caip";
+import { isNamespaceEqual } from "./misc";
 import {
   getNamespacesChains,
   getNamespacesMethodsForChainId,
   getNamespacesEventsForChainId,
 } from "./namespaces";
-import { FIVE_MINUTES, SEVEN_DAYS } from "@walletconnect/time";
 
 export function isSessionCompatible(session: SessionTypes.Struct, filters: SessionTypes.Updatable) {
   const results = [];

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -102,9 +102,11 @@ export function isValidRequiredNamespaceBody(
   let validChains = true;
   const validRequiredNamespace =
     isValidArray(methods) && isValidArray(events) && isValidArray(chains);
-  chains.forEach((chain: string) => {
-    if (!isValidChainId(chain, false)) validChains = false;
-  });
+  if (validRequiredNamespace) {
+    chains.forEach((chain: string) => {
+      if (!isValidChainId(chain, false)) validChains = false;
+    });
+  }
 
   return validRequiredNamespace && validChains;
 }
@@ -114,11 +116,17 @@ export function isValidRequiredNamespaces(
   optional: boolean,
 ): input is ProposalTypes.RequiredNamespaces {
   let valid = false;
-  if (optional && !input) valid = true;
+  if (optional && !input) return true;
   else if (input && isValidObject(input)) {
     valid = true;
-    Object.values(input).forEach(namespace => {
+    Object.values(input).forEach((namespace: any) => {
       if (!isValidRequiredNamespaceBody(namespace)) valid = false;
+      if (valid && namespace?.extension) {
+        if (!isValidArray(namespace.extension)) valid = false;
+        namespace.extension.forEach((extension: any) => {
+          if (!isValidRequiredNamespaceBody(extension)) valid = false;
+        });
+      }
     });
   }
 
@@ -129,20 +137,28 @@ export function isValidNamespaceBody(input: any): input is SessionTypes.Namespac
   const { methods, events, accounts } = input;
   let validAccounts = true;
   const validNamespace = isValidArray(methods) && isValidArray(events) && isValidArray(accounts);
-  accounts.forEach((account: string) => {
-    if (!isValidAccountId(account)) validAccounts = false;
-  });
+  if (validNamespace) {
+    accounts.forEach((account: string) => {
+      if (!isValidAccountId(account)) validAccounts = false;
+    });
+  }
+
   return validNamespace && validAccounts;
 }
 
 export function isValidNamespaces(input: any, optional: boolean): input is SessionTypes.Namespaces {
   let valid = false;
-
-  if (optional && !input) valid = true;
+  if (optional && !input) return true;
   else if (input && isValidObject(input)) {
     valid = true;
-    Object.values(input).forEach(namespace => {
+    Object.values(input).forEach((namespace: any) => {
       if (!isValidNamespaceBody(namespace)) valid = false;
+      if (valid && namespace?.extension) {
+        if (!isValidArray(namespace.extension)) valid = false;
+        namespace.extension.forEach((extension: any) => {
+          if (!isValidNamespaceBody(extension)) valid = false;
+        });
+      }
     });
   }
 

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -106,12 +106,12 @@ export function isValidProposedNamespaces(
   input: any,
   optional: boolean,
 ): input is SessionTypes.ProposedNamespace[] {
-  let valid = false;
+  let valid = true;
 
   if (optional && !input) valid = true;
   else if (input && isValidArray(input) && input.length) {
     input.forEach((namespace: SessionTypes.ProposedNamespace) => {
-      valid = isValidProposedNamespace(namespace);
+      if (!isValidProposedNamespace(namespace)) valid = false;
     });
   }
 
@@ -132,12 +132,12 @@ export function isValidNamespaces(
   input: any,
   optional: boolean,
 ): input is SessionTypes.Namespace[] {
-  let valid = false;
+  let valid = true;
 
   if (optional && !input) valid = true;
   else if (input && isValidArray(input) && input.length) {
     input.forEach((namespace: SessionTypes.Namespace) => {
-      valid = isValidNamespace(namespace);
+      if (!isValidNamespace(namespace)) valid = false;
     });
   }
 

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -35,6 +35,10 @@ export function isValidArray(arr: any, itemCondition?: (item: any) => boolean) {
   return false;
 }
 
+export function isValidObject(obj: any) {
+  return Object.getPrototypeOf(obj) === Object.prototype && Object.keys(obj).length;
+}
+
 export function isUndefined(input: any): input is undefined {
   return typeof input === "undefined";
 }
@@ -111,7 +115,7 @@ export function isValidRequiredNamespaces(
 ): input is ProposalTypes.RequiredNamespaces {
   let valid = false;
   if (optional && !input) valid = true;
-  else if (input && isValidArray(input) && input.length) {
+  else if (input && isValidObject(input)) {
     valid = true;
     Object.values(input).forEach(namespace => {
       if (!isValidRequiredNamespaceBody(namespace)) valid = false;
@@ -135,7 +139,7 @@ export function isValidNamespaces(input: any, optional: boolean): input is Sessi
   let valid = false;
 
   if (optional && !input) valid = true;
-  else if (input && isValidArray(input) && input.length) {
+  else if (input && isValidObject(input)) {
     valid = true;
     Object.values(input).forEach(namespace => {
       if (!isValidNamespaceBody(namespace)) valid = false;

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -91,7 +91,7 @@ export function isSessionStruct(input: any): input is SessionTypes.Struct {
   return input?.topic;
 }
 
-export function isValidProposedNamespace(input: any): input is SessionTypes.ProposedNamespace {
+export function isValidProposedNamespace(input: any): input is ProposalTypes.ProposedNamespace {
   const { methods, events, chains } = input;
   let validChains = true;
   const validProposedNamespace =
@@ -105,12 +105,12 @@ export function isValidProposedNamespace(input: any): input is SessionTypes.Prop
 export function isValidProposedNamespaces(
   input: any,
   optional: boolean,
-): input is SessionTypes.ProposedNamespace[] {
+): input is ProposalTypes.ProposedNamespace[] {
   let valid = true;
 
   if (optional && !input) valid = true;
   else if (input && isValidArray(input) && input.length) {
-    input.forEach((namespace: SessionTypes.ProposedNamespace) => {
+    input.forEach((namespace: ProposalTypes.ProposedNamespace) => {
       if (!isValidProposedNamespace(namespace)) valid = false;
     });
   }

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -1,6 +1,6 @@
 import { SessionTypes, ProposalTypes, RelayerTypes } from "@walletconnect/types";
 import { ErrorResponse } from "@walletconnect/jsonrpc-types";
-import { isNamespaceEqual } from "./misc";
+import isEqual from "lodash.isequal";
 import {
   getNamespacesChains,
   getNamespacesMethodsForChainId,
@@ -11,8 +11,10 @@ export function isSessionCompatible(session: SessionTypes.Struct, filters: Sessi
   const results = [];
   const { namespace, expiry } = filters;
   if (session.namespaces && namespace) {
-    session.namespaces.forEach(n => {
-      results.push(isNamespaceEqual(namespace, n));
+    Object.keys(session.namespaces).forEach(key => {
+      if (key === namespace.key) {
+        results.push(isEqual(session.namespaces[key], namespace.body));
+      }
     });
   }
   if (session.expiry && expiry) {

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -7,7 +7,7 @@ import {
   getNamespacesEventsForChainId,
 } from "./namespaces";
 
-export function isSessionCompatible(session: SessionTypes.Struct, filters: SessionTypes.Updatable) {
+export function isSessionCompatible(session: SessionTypes.Struct, filters: SessionTypes.Filters) {
   const results = [];
   const { namespace, expiry } = filters;
   if (session.namespaces && namespace) {
@@ -97,7 +97,7 @@ export function isSessionStruct(input: any): input is SessionTypes.Struct {
 
 export function isValidRequiredNamespaceBody(
   input: any,
-): input is ProposalTypes.RequiredNamespaceBody {
+): input is ProposalTypes.BaseRequiredNamespace {
   const { methods, events, chains } = input;
   let validChains = true;
   const validRequiredNamespace =
@@ -133,7 +133,7 @@ export function isValidRequiredNamespaces(
   return valid;
 }
 
-export function isValidNamespaceBody(input: any): input is SessionTypes.NamespaceBody {
+export function isValidNamespaceBody(input: any): input is SessionTypes.BaseNamespace {
   const { methods, events, accounts } = input;
   let validAccounts = true;
   const validNamespace = isValidArray(methods) && isValidArray(events) && isValidArray(accounts);

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -106,10 +106,11 @@ export function isValidProposedNamespaces(
   input: any,
   optional: boolean,
 ): input is ProposalTypes.ProposedNamespace[] {
-  let valid = true;
+  let valid = false;
 
   if (optional && !input) valid = true;
   else if (input && isValidArray(input) && input.length) {
+    valid = true;
     input.forEach((namespace: ProposalTypes.ProposedNamespace) => {
       if (!isValidProposedNamespace(namespace)) valid = false;
     });
@@ -132,10 +133,11 @@ export function isValidNamespaces(
   input: any,
   optional: boolean,
 ): input is SessionTypes.Namespace[] {
-  let valid = true;
+  let valid = false;
 
   if (optional && !input) valid = true;
   else if (input && isValidArray(input) && input.length) {
+    valid = true;
     input.forEach((namespace: SessionTypes.Namespace) => {
       if (!isValidNamespace(namespace)) valid = false;
     });


### PR DESCRIPTION
## Description
Implements new `requiredNamespaces` and `namespaces` structure. Note, currently validation doesn't account for `extension` content, that will come in follow up PRs.

## Tests
```
  Client Validation
    connect
      ✓ throws when no params are passed
      ✓ throws when invalid pairingTopic is provided
      ✓ throws when empty pairingTopic is provided
      ✓ throws when non existant pairingTopic is provided
      ✓ throws when empty requiredNamespaces are provided
      ✓ throws when invalid requiredNamespaces are provided
      ✓ throws when no requiredNamespaces are provided
    pair
      ✓ throws when no params are passed
      ✓ throws when empty uri is provided
      ✓ throws when invalid uri is provided
      ✓ throws when no uri is provided
    approve
      ✓ throws when no params are passed
      ✓ throws when invalid id is provided
      ✓ throws when empty id is provided
      ✓ throws when no id is provided
      ✓ throws when invalid namespaces are provided
      ✓ throws when empty namespaces are provided
      ✓ throws when no namespaces are provided
      ✓ throws when invalid relayProtocol are provided
      ✓ throws when empty relayProtocol is provided
    reject
      ✓ throws when no params are passed
      ✓ throws when invalid id is provided
      ✓ throws when empty id is provided
      ✓ throws when no id is provided
      ✓ throws when empty reason is provided
      ✓ throws when invalid reason is provided
      ✓ throws when no reason is provided
      ✓ throws when invalid reason code is provided
      ✓ throws when empty reason code is provided
      ✓ throws when no reason code is provided
      ✓ throws when invalid reason message is provided
      ✓ throws when empty reason message is provided
      ✓ throws when no reason message is provided
    update
      ✓ throws when no params are passed
      ✓ throws when invalid topic is provided
      ✓ throws when empty topic is provided
      ✓ throws when no topic is provided
      ✓ throws when non existant topic is provided
      ✓ throws when invalid namespaces are provided
      ✓ throws when empty namespaces are provided
      ✓ throws when no namespaces are provided
    extend
      ✓ throws when no params are passed
      ✓ throws when invalid topic is provided
      ✓ throws when empty topic is provided
      ✓ throws when no topic is provided
      ✓ throws when non existant topic is provided
    request
      ✓ throws when no params are passed
      ✓ throws when invalid topic is provided
      ✓ throws when empty topic is provided
      ✓ throws when no topic is provided
      ✓ throws when non existant topic is provided
      ✓ throws when invalid chainId is provided
      ✓ throws when empty chainId is provided
      ✓ throws when chain id is not in session namespace
      ✓ throws when invalid request is provided
      ✓ throws when empty request is provided
      ✓ throws when no request is provided
      ✓ throws when invalid request method is provided
      ✓ throws when empty request method is provided
      ✓ throws when no request method is provided
      ✓ throws when request doesn't exist for given chainId
    respond
      ✓ throws when no params are passed
      ✓ throws when invalid topic is provided
      ✓ throws when empty topic is provided
      ✓ throws when no topic is provided
      ✓ throws when no response or error is passed
      ✓ throws when no id is passed
      ✓ throws when invalid id is passed
      ✓ throws when no jsonrpc is passed
      ✓ throws when invalid jsonrpc is passed
      ✓ throws when empty jsonrpc is passed
    ping
      ✓ throws when no params are passed
      ✓ throws when invalid topic is provided
      ✓ throws when empty topic is provided
      ✓ throws when no topic is provided
      ✓ throws when non existant topic is provided
    emit
      ✓ throws when no params are passed
      ✓ throws when invalid topic is provided
      ✓ throws when empty topic is provided
      ✓ throws when no topic is provided
      ✓ throws when non existant topic is provided
      ✓ throws when invalid chainId is provided
      ✓ throws when empty chainId is provided
      ✓ throws when invalid event is provided
      ✓ throws when empty event is provided
      ✓ throws when no event is provided
      ✓ throws when invalid event name is provided
      ✓ throws when empty event name is provided
      ✓ throws when no event name is provided
      ✓ throws when event doesn't exist for given chainId
    disconnect
      ✓ throws when no params are passed
      ✓ throws when invalid topic is provided
      ✓ throws when empty topic is provided
      ✓ throws when no topic is provided
      ✓ throws when non existant topic is provided


  Client Integration
    ✓ init
    connect
      ✓ connect (with new pairing) (44ms)
      ✓ connect (with old pairing)
    disconnect
      pairing
        ✓ deletes the pairing on disconnect
      session
        ✓ deletes the session on disconnect
    ping
      ✓ throws if the topic is not a known pairing or session topic
      pairing
        ✓ A pings B with existing pairing
        ✓ B pings A with existing pairing
        ✓ clients can ping each other after restart (60ms)
      session
        ✓ A pings B with existing session
        ✓ B pings A with existing session
        ✓ clients can ping each other after restart (65ms)
    update
      ✓ updates session namespaces state with provided namespaces
    extend
      ✓ updates session expiry state
```