### PR TITLE
@walletconnect/iso-crypto add @walletconnect/encoding dependency

### DIFF
--- a/packages/helpers/iso-crypto/package.json
+++ b/packages/helpers/iso-crypto/package.json
@@ -63,7 +63,8 @@
   "dependencies": {
     "@walletconnect/crypto": "^1.0.2",
     "@walletconnect/types": "^1.7.8",
-    "@walletconnect/utils": "^1.7.8"
+    "@walletconnect/utils": "^1.7.8",
+    "@walletconnect/encoding": "^1.0.1"
   },
   "gitHead": "165f7993c2acc907c653c02847fb02721052c6e7"
 }


### PR DESCRIPTION
fixing a closed issue which didn't seem to resolve #844 

`@walletconnect/iso-crypto` is importing `@walletconnect/encoding` here https://github.com/WalletConnect/walletconnect-monorepo/blob/8668dcc5ac9a6ec7b446eb2bc51d477b7545303c/packages/helpers/iso-crypto/src/index.ts

commit fixes pnp error `@walletconnect/iso-crypto tried to access @walletconnect/encoding,`