### PR TITLE
[v2] Pass full jsonrpc payloads on events, add separate session and pairing expiry events

### DIFF
--- a/packages/client/src/constants/client.ts
+++ b/packages/client/src/constants/client.ts
@@ -22,7 +22,9 @@ export const CLIENT_EVENTS: Record<ClientTypes.Event, ClientTypes.Event> = {
   session_ping: "session_ping",
   pairing_ping: "pairing_ping",
   session_delete: "session_delete",
+  session_expired: "session_expired",
   pairing_delete: "pairing_delete",
+  pairing_expired: "pairing_expired",
   request: "request",
   event: "event",
 };

--- a/packages/client/src/constants/client.ts
+++ b/packages/client/src/constants/client.ts
@@ -22,9 +22,9 @@ export const CLIENT_EVENTS: Record<ClientTypes.Event, ClientTypes.Event> = {
   session_ping: "session_ping",
   pairing_ping: "pairing_ping",
   session_delete: "session_delete",
-  session_expired: "session_expired",
+  session_expire: "session_expire",
   pairing_delete: "pairing_delete",
-  pairing_expired: "pairing_expired",
+  pairing_expire: "pairing_expire",
   request: "request",
   event: "event",
 };

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -734,10 +734,10 @@ export class Engine extends IEngine {
       const { topic } = event;
       if (this.client.session.keys.includes(topic)) {
         await this.deleteSession(topic);
-        this.client.events.emit("session_expired", { topic });
+        this.client.events.emit("session_expire", { topic });
       } else if (this.client.pairing.keys.includes(topic)) {
         await this.deletePairing(topic);
-        this.client.events.emit("pairing_expired", { topic });
+        this.client.events.emit("pairing_expire", { topic });
       }
     });
   }

--- a/packages/client/src/controllers/engine.ts
+++ b/packages/client/src/controllers/engine.ts
@@ -347,7 +347,7 @@ export class Engine extends IEngine {
 
   private sendRequest: EnginePrivate["sendRequest"] = async (topic, method, params) => {
     const payload = formatJsonRpcRequest(method, params);
-    const message = await this.client.core.crypto.encode(topic, payload);
+    const message = this.client.core.crypto.encode(topic, payload);
     await this.client.core.relayer.publish(topic, message);
     this.client.history.set(topic, payload);
 
@@ -456,13 +456,10 @@ export class Engine extends IEngine {
   ) => {
     try {
       this.isValidConnect({ ...payload.params });
-      const { params, id: id } = payload;
-      await this.client.proposal.set(id, {
-        id,
-        pairingTopic: topic,
-        ...params,
-      });
-      this.client.events.emit("session_proposal", { id, ...params });
+      const { params, id } = payload;
+      const proposal = { id, pairingTopic: topic, ...params };
+      await this.client.proposal.set(id, proposal);
+      this.client.events.emit("session_proposal", { ...payload, params: proposal });
     } catch (err) {
       this.client.logger.error(err);
     }
@@ -565,7 +562,7 @@ export class Engine extends IEngine {
       const { params, id } = payload;
       await this.client.session.update(topic, { namespaces: params.namespaces });
       await this.sendResult<"wc_sessionUpdate">(id, topic, true);
-      this.client.events.emit("session_update", { topic, namespaces: params.namespaces });
+      this.client.events.emit("session_update", payload);
     } catch (err) {
       this.client.logger.error(err);
     }
@@ -589,7 +586,7 @@ export class Engine extends IEngine {
       const { id } = payload;
       await this.setExpiry(topic, SESSION_EXPIRY);
       await this.sendResult<"wc_sessionExtend">(id, topic, true);
-      this.client.events.emit("session_extend", { topic });
+      this.client.events.emit("session_extend", { ...payload, params: { topic } });
     } catch (err) {
       this.client.logger.error(err);
     }
@@ -609,7 +606,7 @@ export class Engine extends IEngine {
       this.isValidPing({ topic });
       const { id } = payload;
       await this.sendResult<"wc_sessionPing">(id, topic, true);
-      this.client.events.emit("session_ping", { topic });
+      this.client.events.emit("session_ping", { ...payload, params: { topic } });
     } catch (err) {
       this.client.logger.error(err);
     }
@@ -629,7 +626,7 @@ export class Engine extends IEngine {
       this.isValidPing({ topic });
       const { id } = payload;
       await this.sendResult<"wc_pairingPing">(id, topic, true);
-      this.client.events.emit("pairing_ping", { topic });
+      this.client.events.emit("pairing_ping", { ...payload, params: { topic } });
     } catch (err) {
       this.client.logger.error(err);
     }
@@ -653,7 +650,7 @@ export class Engine extends IEngine {
       const { id } = payload;
       await this.sendResult<"wc_sessionDelete">(id, topic, true);
       await this.deleteSession(topic);
-      this.client.events.emit("session_delete", { topic });
+      this.client.events.emit("session_delete", { ...payload, params: { topic } });
     } catch (err) {
       this.client.logger.error(err);
     }
@@ -681,7 +678,7 @@ export class Engine extends IEngine {
       const { id } = payload;
       await this.sendResult<"wc_pairingDelete">(id, topic, true);
       await this.deletePairing(topic);
-      this.client.events.emit("pairing_delete", { topic });
+      this.client.events.emit("pairing_delete", { ...payload, params: { topic } });
     } catch (err) {
       this.client.logger.error(err);
     }
@@ -703,9 +700,7 @@ export class Engine extends IEngine {
   private onSessionRequest: EnginePrivate["onSessionRequest"] = (topic, payload) => {
     try {
       this.isValidRequest({ topic, ...payload.params });
-      const { params } = payload;
-      const { chainId, request } = params;
-      this.client.events.emit("request", { topic, request, chainId });
+      this.client.events.emit("request", { ...payload, params: { ...payload.params, topic } });
     } catch (err) {
       this.client.logger.error(err);
     }
@@ -726,8 +721,7 @@ export class Engine extends IEngine {
   private onSessionEventRequest: EnginePrivate["onSessionEventRequest"] = (topic, payload) => {
     try {
       this.isValidEmit({ topic, ...payload.params });
-      const { event, chainId } = payload.params;
-      this.client.events.emit("event", { topic, event, chainId });
+      this.client.events.emit("event", { ...payload, params: { ...payload.params, topic } });
     } catch (err) {
       this.client.logger.error(err);
     }
@@ -740,10 +734,10 @@ export class Engine extends IEngine {
       const { topic } = event;
       if (this.client.session.keys.includes(topic)) {
         await this.deleteSession(topic);
-        this.client.events.emit("session_delete", { topic });
+        this.client.events.emit("session_expired", { topic });
       } else if (this.client.pairing.keys.includes(topic)) {
         await this.deletePairing(topic);
-        this.client.events.emit("pairing_delete", { topic });
+        this.client.events.emit("pairing_expired", { topic });
       }
     });
   }

--- a/packages/client/test/shared/connect.ts
+++ b/packages/client/test/shared/connect.ts
@@ -57,7 +57,7 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
     new Promise<void>((resolve, reject) => {
       B.once("session_proposal", async proposal => {
         try {
-          expect(proposal.requiredNamespaces).to.eql(connectParams.requiredNamespaces);
+          expect(proposal.params.requiredNamespaces).to.eql(connectParams.requiredNamespaces);
 
           const { acknowledged } = await B.approve({
             id: proposal.id,

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -7,6 +7,7 @@ import { ISession, SessionTypes } from "./session";
 import { IJsonRpcHistory } from "./history";
 import { CoreTypes, ICore } from "./core";
 import { IExpirer } from "./expirer";
+import { JsonRpcRequest } from "@walletconnect/jsonrpc-types";
 
 export declare namespace ClientTypes {
   type Event =
@@ -17,33 +18,37 @@ export declare namespace ClientTypes {
     | "pairing_ping"
     | "session_delete"
     | "pairing_delete"
+    | "session_expired"
+    | "pairing_expired"
     | "request"
     | "event";
 
   interface EventArguments {
-    session_proposal: ProposalTypes.Struct;
-    session_update: { topic: string; namespaces: SessionTypes.Namespaces };
-    session_extend: { topic: string };
-    session_ping: { topic: string };
-    pairing_ping: { topic: string };
-    session_delete: { topic: string };
-    pairing_delete: { topic: string };
-    request: {
+    session_proposal: JsonRpcRequest<ProposalTypes.Struct>;
+    session_update: JsonRpcRequest<{ namespaces: SessionTypes.Namespaces }>;
+    session_extend: JsonRpcRequest<{ topic: string }>;
+    session_ping: JsonRpcRequest<{ topic: string }>;
+    pairing_ping: JsonRpcRequest<{ topic: string }>;
+    session_delete: JsonRpcRequest<{ topic: string }>;
+    pairing_delete: JsonRpcRequest<{ topic: string }>;
+    session_expired: { topic: string };
+    pairing_expired: { topic: string };
+    request: JsonRpcRequest<{
       topic: string;
       request: {
         method: string;
         params: any;
       };
       chainId?: string;
-    };
-    event: {
+    }>;
+    event: JsonRpcRequest<{
       topic: string;
       event: {
         name: string;
         data: any;
       };
       chainId?: string;
-    };
+    }>;
   }
 
   type Metadata = {

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -18,8 +18,8 @@ export declare namespace ClientTypes {
     | "pairing_ping"
     | "session_delete"
     | "pairing_delete"
-    | "session_expired"
-    | "pairing_expired"
+    | "session_expire"
+    | "pairing_expire"
     | "request"
     | "event";
 
@@ -31,8 +31,8 @@ export declare namespace ClientTypes {
     pairing_ping: JsonRpcRequest<{ topic: string }>;
     session_delete: JsonRpcRequest<{ topic: string }>;
     pairing_delete: JsonRpcRequest<{ topic: string }>;
-    session_expired: { topic: string };
-    pairing_expired: { topic: string };
+    session_expire: { topic: string };
+    pairing_expire: { topic: string };
     request: JsonRpcRequest<{
       topic: string;
       request: {


### PR DESCRIPTION
* Passing full jsonrpc payloads in events (i.e. including id / jsonrpc etc...) this was how it worked before, ids are needed for responses as well
* Added 2 new events for session expiry to differentiate them from delete requests