### PR TITLE
tweak engine events

### DIFF
--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -22,7 +22,7 @@ export declare namespace ClientTypes {
     | "session_request"
     | "session_event";
 
-  interface BaseEventArgs<T> {
+  interface BaseEventArgs<T = unknown> {
     id: number;
     topic: string;
     params: T;
@@ -31,20 +31,20 @@ export declare namespace ClientTypes {
   interface EventArguments {
     session_proposal: Omit<BaseEventArgs<ProposalTypes.Struct>, "topic">;
     session_update: BaseEventArgs<{ namespaces: SessionTypes.Namespaces }>;
-    session_extend: Omit<BaseEventArgs<unknown>, "params">;
-    session_ping: Omit<BaseEventArgs<unknown>, "params">;
-    pairing_ping: Omit<BaseEventArgs<unknown>, "params">;
-    session_delete: Omit<BaseEventArgs<unknown>, "params">;
-    pairing_delete: Omit<BaseEventArgs<unknown>, "params">;
+    session_extend: Omit<BaseEventArgs, "params">;
+    session_ping: Omit<BaseEventArgs, "params">;
+    pairing_ping: Omit<BaseEventArgs, "params">;
+    session_delete: Omit<BaseEventArgs, "params">;
+    pairing_delete: Omit<BaseEventArgs, "params">;
     session_expire: { topic: string };
     pairing_expire: { topic: string };
     session_request: BaseEventArgs<{
       request: { method: string; params: any };
-      chainId?: string;
+      chainId: string;
     }>;
     session_event: BaseEventArgs<{
       event: { name: string; data: any };
-      chainId?: string;
+      chainId: string;
     }>;
   }
 

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -26,7 +26,7 @@ export declare namespace EngineTypes {
     | "session_request";
 
   interface EventArguments {
-    session_connect: { error?: ErrorResponse; data?: SessionTypes.Struct };
+    session_connect: { error?: ErrorResponse; session?: SessionTypes.Struct };
     session_approve: { error?: ErrorResponse };
     session_update: { error?: ErrorResponse };
     session_extend: { error?: ErrorResponse };
@@ -34,7 +34,7 @@ export declare namespace EngineTypes {
     pairing_ping: { error?: ErrorResponse };
     session_delete: { error?: ErrorResponse };
     pairing_delete: { error?: ErrorResponse };
-    session_request: { error?: ErrorResponse; data?: JsonRpcResponse };
+    session_request: { error?: ErrorResponse; response?: JsonRpcResponse };
   }
 
   interface UriParameters {

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -215,5 +215,5 @@ export function createDelayedPromise<T>() {
 // -- events ---------------------------------------------- //
 
 export function engineEvent(event: EngineTypes.Event, id?: number | string | undefined) {
-  return `${event}:${id ?? ""}`;
+  return `${event}${id ? `:${id}` : ""}`;
 }

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -215,5 +215,5 @@ export function createDelayedPromise<T>() {
 // -- events ---------------------------------------------- //
 
 export function engineEvent(event: EngineTypes.Event, id?: number | string | undefined) {
-  return `${event}${id ?? ""}`;
+  return `${event}:${id ?? ""}`;
 }


### PR DESCRIPTION
Maybe it's nitpicky but I really think these are important changes for stuff I noticed on beta.54 pull request

* separate engineEvent id with `:` 
* rename `data` params with context specific names 
(data should be reserved to encoded strings)
* change chainId typing to required on session_request and session_event
* change generic to default to unknown for BaseEventArgs