### PR TITLE
iso-crypto: Add @walletconnect/encoding as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
 				"react-native-svg": "9.6.4",
 				"style-loader": "1.2.0",
 				"svg-url-loader": "5.0.0",
-				"ts-loader": "6.2.2",
+				"ts-loader": "8.4.0",
 				"use-deep-compare-effect": "1.6.1",
 				"web3": "1.3.5",
 				"web3-provider-engine": "16.0.1",
@@ -141,9 +141,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.18.8",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
-			"integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.13.tgz",
+			"integrity": "sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -199,11 +199,11 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-			"integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.13.tgz",
+			"integrity": "sha512-CkPg8ySSPuHTYPJYo7IRALdqyjM9HCbt/3uOBEFbzyGVP6Mn8bwFPB0jX6982JVNBlYzM1nnPkfjuXSOPtQeEQ==",
 			"dependencies": {
-				"@babel/types": "^7.18.10",
+				"@babel/types": "^7.18.13",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"jsesc": "^2.5.1"
 			},
@@ -260,9 +260,9 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.9.tgz",
-			"integrity": "sha512-WvypNAYaVh23QcjpMR24CwZY2Nz6hqdOcFdPbNpV56hL5H6KiFheO7Xm1aPdlLQ7d5emYZX7VZwPp9x3z+2opw==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.13.tgz",
+			"integrity": "sha512-hDvXp+QYxSRL+23mpAlSGxHMDyIGChm0/AwTfTAAK5Ufe40nCsyNdaYCGuK91phn/fVu9kqayImRDkvNAgdrsA==",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
 				"@babel/helper-environment-visitor": "^7.18.9",
@@ -530,13 +530,13 @@
 			}
 		},
 		"node_modules/@babel/helper-wrap-function": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.18.10.tgz",
-			"integrity": "sha512-95NLBP59VWdfK2lyLKe6eTMq9xg+yWKzxzxbJ1wcYNi1Auz200+83fMDADjRxBvc2QQor5zja2yTQzXGhk2GtQ==",
+			"version": "7.18.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.18.11.tgz",
+			"integrity": "sha512-oBUlbv+rjZLh2Ks9SKi4aL7eKaAXBWleHzU89mP0G6BMUlRxSckk9tSIkgDGydhgFxHuGSlBQZfnaD47oBEB7w==",
 			"dependencies": {
 				"@babel/helper-function-name": "^7.18.9",
 				"@babel/template": "^7.18.10",
-				"@babel/traverse": "^7.18.10",
+				"@babel/traverse": "^7.18.11",
 				"@babel/types": "^7.18.10"
 			},
 			"engines": {
@@ -599,9 +599,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.10.tgz",
-			"integrity": "sha512-TYk3OA0HKL6qNryUayb5UUEhM/rkOQozIBEA5ITXh5DWrSp0TlUQXMyZmnWxG/DizSWBeeQ0Zbc5z8UGaaqoeg==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.13.tgz",
+			"integrity": "sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -1028,9 +1028,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.9.tgz",
-			"integrity": "sha512-p5VCYNddPLkZTq4XymQIaIfZNJwT9YsjkPOhkVEqt6QIpQFZVM9IltqqYpOEkJoN1DPznmxUDyZ5CTZs/ZCuHA==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.13.tgz",
+			"integrity": "sha512-TodpQ29XekIsex2A+YJPj5ax2plkGa8YYY6mFjCohk/IG9IY42Rtuj1FuDeemfg2ipxIFLzPeA83SIBnlhSIow==",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.18.9"
 			},
@@ -1498,9 +1498,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typescript": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.10.tgz",
-			"integrity": "sha512-j2HQCJuMbi88QftIb5zlRu3c7PU+sXNnscqsrjqegoGiCgXR569pEdben9vly5QHKL2ilYkfnSwu64zsZo/VYQ==",
+			"version": "7.18.12",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.12.tgz",
+			"integrity": "sha512-2vjjam0cum0miPkenUbQswKowuxs/NjMwIKEq0zwegRxXk12C9YOF9STXnaUptITOtOJHKHpzvvWYOjbm6tc0w==",
 			"dependencies": {
 				"@babel/helper-create-class-features-plugin": "^7.18.9",
 				"@babel/helper-plugin-utils": "^7.18.9",
@@ -1676,18 +1676,18 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.10.tgz",
-			"integrity": "sha512-J7ycxg0/K9XCtLyHf0cz2DqDihonJeIo+z+HEdRe9YuT8TY4A66i+Ab2/xZCEW7Ro60bPCBBfqqboHSamoV3+g==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.13.tgz",
+			"integrity": "sha512-N6kt9X1jRMLPxxxPYWi7tgvJRH/rtoU+dbKAPDM44RFHiMH8igdsaSBgFeskhSl/kLWLDUvIh1RXCrTmg0/zvA==",
 			"dependencies": {
 				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.18.10",
+				"@babel/generator": "^7.18.13",
 				"@babel/helper-environment-visitor": "^7.18.9",
 				"@babel/helper-function-name": "^7.18.9",
 				"@babel/helper-hoist-variables": "^7.18.6",
 				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.18.10",
-				"@babel/types": "^7.18.10",
+				"@babel/parser": "^7.18.13",
+				"@babel/types": "^7.18.13",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -1717,9 +1717,9 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/@babel/types": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.10.tgz",
-			"integrity": "sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.13.tgz",
+			"integrity": "sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.18.10",
 				"@babel/helper-validator-identifier": "^7.18.6",
@@ -1759,16 +1759,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
 		"node_modules/@discordjs/collection": {
@@ -1818,9 +1808,9 @@
 			}
 		},
 		"node_modules/@ethersproject/abi/node_modules/@ethersproject/address": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-			"integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+			"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
 			"funding": [
 				{
 					"type": "individual",
@@ -1832,11 +1822,11 @@
 				}
 			],
 			"dependencies": {
-				"@ethersproject/bignumber": "^5.6.2",
-				"@ethersproject/bytes": "^5.6.1",
-				"@ethersproject/keccak256": "^5.6.1",
-				"@ethersproject/logger": "^5.6.0",
-				"@ethersproject/rlp": "^5.6.1"
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/keccak256": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/rlp": "^5.7.0"
 			}
 		},
 		"node_modules/@ethersproject/abstract-provider": {
@@ -1936,9 +1926,9 @@
 			}
 		},
 		"node_modules/@ethersproject/bignumber": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.2.tgz",
-			"integrity": "sha512-v7+EEUbhGqT3XJ9LMPsKvXYHFc8eHxTowFCG/HgJErmq4XHJ2WR7aeyICg3uTOAQ7Icn0GFHAohXEhxQHq4Ubw==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+			"integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
 			"funding": [
 				{
 					"type": "individual",
@@ -1950,8 +1940,8 @@
 				}
 			],
 			"dependencies": {
-				"@ethersproject/bytes": "^5.6.1",
-				"@ethersproject/logger": "^5.6.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
 				"bn.js": "^5.2.1"
 			}
 		},
@@ -1961,9 +1951,9 @@
 			"integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
 		},
 		"node_modules/@ethersproject/bytes": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
-			"integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+			"integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
 			"funding": [
 				{
 					"type": "individual",
@@ -1975,7 +1965,7 @@
 				}
 			],
 			"dependencies": {
-				"@ethersproject/logger": "^5.6.0"
+				"@ethersproject/logger": "^5.7.0"
 			}
 		},
 		"node_modules/@ethersproject/constants": {
@@ -2024,9 +2014,9 @@
 			}
 		},
 		"node_modules/@ethersproject/contracts/node_modules/@ethersproject/address": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-			"integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+			"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
 			"funding": [
 				{
 					"type": "individual",
@@ -2038,11 +2028,11 @@
 				}
 			],
 			"dependencies": {
-				"@ethersproject/bignumber": "^5.6.2",
-				"@ethersproject/bytes": "^5.6.1",
-				"@ethersproject/keccak256": "^5.6.1",
-				"@ethersproject/logger": "^5.6.0",
-				"@ethersproject/rlp": "^5.6.1"
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/keccak256": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/rlp": "^5.7.0"
 			}
 		},
 		"node_modules/@ethersproject/hash": {
@@ -2071,9 +2061,9 @@
 			}
 		},
 		"node_modules/@ethersproject/hash/node_modules/@ethersproject/address": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-			"integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+			"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
 			"funding": [
 				{
 					"type": "individual",
@@ -2085,11 +2075,11 @@
 				}
 			],
 			"dependencies": {
-				"@ethersproject/bignumber": "^5.6.2",
-				"@ethersproject/bytes": "^5.6.1",
-				"@ethersproject/keccak256": "^5.6.1",
-				"@ethersproject/logger": "^5.6.0",
-				"@ethersproject/rlp": "^5.6.1"
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/keccak256": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/rlp": "^5.7.0"
 			}
 		},
 		"node_modules/@ethersproject/hdnode": {
@@ -2152,9 +2142,9 @@
 			}
 		},
 		"node_modules/@ethersproject/json-wallets/node_modules/@ethersproject/address": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-			"integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+			"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
 			"funding": [
 				{
 					"type": "individual",
@@ -2166,11 +2156,11 @@
 				}
 			],
 			"dependencies": {
-				"@ethersproject/bignumber": "^5.6.2",
-				"@ethersproject/bytes": "^5.6.1",
-				"@ethersproject/keccak256": "^5.6.1",
-				"@ethersproject/logger": "^5.6.0",
-				"@ethersproject/rlp": "^5.6.1"
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/keccak256": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/rlp": "^5.7.0"
 			}
 		},
 		"node_modules/@ethersproject/json-wallets/node_modules/aes-js": {
@@ -2179,9 +2169,9 @@
 			"integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
 		},
 		"node_modules/@ethersproject/keccak256": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.1.tgz",
-			"integrity": "sha512-bB7DQHCTRDooZZdL3lk9wpL0+XuG3XLGHLh3cePnybsO3V0rdCAOQGpn/0R3aODmnTOOkCATJiD2hnL+5bwthA==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+			"integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
 			"funding": [
 				{
 					"type": "individual",
@@ -2193,14 +2183,14 @@
 				}
 			],
 			"dependencies": {
-				"@ethersproject/bytes": "^5.6.1",
+				"@ethersproject/bytes": "^5.7.0",
 				"js-sha3": "0.8.0"
 			}
 		},
 		"node_modules/@ethersproject/logger": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
-			"integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+			"integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
 			"funding": [
 				{
 					"type": "individual",
@@ -2304,9 +2294,9 @@
 			}
 		},
 		"node_modules/@ethersproject/providers/node_modules/@ethersproject/address": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-			"integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+			"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
 			"funding": [
 				{
 					"type": "individual",
@@ -2318,11 +2308,11 @@
 				}
 			],
 			"dependencies": {
-				"@ethersproject/bignumber": "^5.6.2",
-				"@ethersproject/bytes": "^5.6.1",
-				"@ethersproject/keccak256": "^5.6.1",
-				"@ethersproject/logger": "^5.6.0",
-				"@ethersproject/rlp": "^5.6.1"
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/keccak256": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/rlp": "^5.7.0"
 			}
 		},
 		"node_modules/@ethersproject/providers/node_modules/ws": {
@@ -2365,9 +2355,9 @@
 			}
 		},
 		"node_modules/@ethersproject/rlp": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.1.tgz",
-			"integrity": "sha512-uYjmcZx+DKlFUk7a5/W9aQVaoEC7+1MOBgNtvNg13+RnuUwT4F0zTovC0tmay5SmRslb29V1B7Y5KCri46WhuQ==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+			"integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
 			"funding": [
 				{
 					"type": "individual",
@@ -2379,8 +2369,8 @@
 				}
 			],
 			"dependencies": {
-				"@ethersproject/bytes": "^5.6.1",
-				"@ethersproject/logger": "^5.6.0"
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0"
 			}
 		},
 		"node_modules/@ethersproject/sha2": {
@@ -2500,9 +2490,9 @@
 			}
 		},
 		"node_modules/@ethersproject/transactions/node_modules/@ethersproject/address": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-			"integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+			"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
 			"funding": [
 				{
 					"type": "individual",
@@ -2514,11 +2504,11 @@
 				}
 			],
 			"dependencies": {
-				"@ethersproject/bignumber": "^5.6.2",
-				"@ethersproject/bytes": "^5.6.1",
-				"@ethersproject/keccak256": "^5.6.1",
-				"@ethersproject/logger": "^5.6.0",
-				"@ethersproject/rlp": "^5.6.1"
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/keccak256": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/rlp": "^5.7.0"
 			}
 		},
 		"node_modules/@ethersproject/units": {
@@ -2574,9 +2564,9 @@
 			}
 		},
 		"node_modules/@ethersproject/wallet/node_modules/@ethersproject/address": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-			"integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+			"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
 			"funding": [
 				{
 					"type": "individual",
@@ -2588,11 +2578,11 @@
 				}
 			],
 			"dependencies": {
-				"@ethersproject/bignumber": "^5.6.2",
-				"@ethersproject/bytes": "^5.6.1",
-				"@ethersproject/keccak256": "^5.6.1",
-				"@ethersproject/logger": "^5.6.0",
-				"@ethersproject/rlp": "^5.6.1"
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/keccak256": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/rlp": "^5.7.0"
 			}
 		},
 		"node_modules/@ethersproject/web": {
@@ -2885,9 +2875,9 @@
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -2901,14 +2891,14 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
+			"version": "1.4.14",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.14",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-			"integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
@@ -5217,15 +5207,15 @@
 			"dev": true
 		},
 		"node_modules/@tsconfig/node12": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.10.tgz",
-			"integrity": "sha512-N+srakvPaYMGkwjNDx3ASx65Zl3QG8dJgVtIB+YMOkucU+zctlv/hdP5250VKdDHSDoW9PFZoCqbqNcAPjCjXA==",
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
 			"dev": true
 		},
 		"node_modules/@tsconfig/node14": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.2.tgz",
-			"integrity": "sha512-YwrUA5ysDXHFYfL0Xed9x3sNS4P+aKlCOnnbqUa2E5HdQshHFleCJVrj1PlGTb4GgFUCDyte1v3JWLy2sz8Oqg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
 			"dev": true
 		},
 		"node_modules/@tsconfig/node16": {
@@ -5317,9 +5307,9 @@
 			"integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
 		},
 		"node_modules/@types/lodash": {
-			"version": "4.14.182",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-			"integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
+			"version": "4.14.184",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.184.tgz",
+			"integrity": "sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q=="
 		},
 		"node_modules/@types/lodash.isnumber": {
 			"version": "3.0.6",
@@ -6757,9 +6747,9 @@
 			}
 		},
 		"node_modules/bignumber.js": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-			"integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
+			"integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
 			"engines": {
 				"node": "*"
 			}
@@ -7536,14 +7526,14 @@
 			}
 		},
 		"node_modules/caniuse-db": {
-			"version": "1.0.30001373",
-			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001373.tgz",
-			"integrity": "sha512-NOoFLQ0w7geqot8ENHEE/cRqQN0HdVtJeG2h+2cjmEYb07X0HGwBQxREKWpt5YUhNPmAxHKVGPbak1FLey6GGw=="
+			"version": "1.0.30001382",
+			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001382.tgz",
+			"integrity": "sha512-VhX4bbUVWrak/xe8Y6BWWD3TltpFUCmDSQWVi+CQgWqKXy3CIx+6Ev6oyjTPrR1HrGd5vuWsxzoopIYditgwsg=="
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001373",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
-			"integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==",
+			"version": "1.0.30001382",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001382.tgz",
+			"integrity": "sha512-2rtJwDmSZ716Pxm1wCtbPvHtbDWAreTPxXbkc5RkKglow3Ig/4GNGazDI9/BVnXbG/wnv6r3B5FEbkfg9OcTGg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -8547,9 +8537,9 @@
 			}
 		},
 		"node_modules/copy-to-clipboard": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
-			"integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.2.tgz",
+			"integrity": "sha512-Vme1Z6RUDzrb6xAI7EZlVZ5uvOk2F//GaxKUxajDqm9LhOVM1inxNAD2vy+UZDYsd0uyA9s7b3/FVZPSxqrCfg==",
 			"dependencies": {
 				"toggle-selection": "^1.0.6"
 			}
@@ -9155,9 +9145,9 @@
 			}
 		},
 		"node_modules/dayjs": {
-			"version": "1.11.4",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.4.tgz",
-			"integrity": "sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g=="
+			"version": "1.11.5",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.5.tgz",
+			"integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA=="
 		},
 		"node_modules/debug": {
 			"version": "3.1.0",
@@ -9643,9 +9633,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.208",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.208.tgz",
-			"integrity": "sha512-diMr4t69FigAGUk2KovP0bygEtN/9AkqEVkzjEp0cu+zFFbZMVvwACpTTfuj1mAmFR5kNoSW8wGKDFWIvmThiQ=="
+			"version": "1.4.228",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.228.tgz",
+			"integrity": "sha512-XfDHCvou7CsDMlFwb0WZ1tWmW48e7Sn7VBRyPfZsZZila9esRsJl1trO+OqDNV97GggFSt0ISbWslKXfQkG//g=="
 		},
 		"node_modules/elliptic": {
 			"version": "6.5.4",
@@ -9878,9 +9868,9 @@
 			}
 		},
 		"node_modules/es5-ext": {
-			"version": "0.10.61",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-			"integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+			"version": "0.10.62",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+			"integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"es6-iterator": "^2.0.3",
@@ -11949,9 +11939,9 @@
 			}
 		},
 		"node_modules/ext/node_modules/type": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/type/-/type-2.6.1.tgz",
-			"integrity": "sha512-OvgH5rB0XM+iDZGQ1Eg/o7IZn0XYJFVrN/9FQ4OWIYILyJJgVP2s1hLTOFn6UOZoDUI/HctGa0PFlE2n2HW3NQ=="
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+			"integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
 		},
 		"node_modules/extend": {
 			"version": "3.0.2",
@@ -18393,9 +18383,9 @@
 			}
 		},
 		"node_modules/node-abi": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.23.0.tgz",
-			"integrity": "sha512-XWte/uvq7hmgY27WesfxLUAPejKUlkEbikhBFaIhxe+XkHa57rXBwYqGjsIyfVXaU8kC0Wp2p/qQroauDKs1XA==",
+			"version": "3.24.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.24.0.tgz",
+			"integrity": "sha512-YPG3Co0luSu6GwOBsmIdGW6Wx0NyNDLg/hriIyDllVsNwnI6UeqaWShxC3lbH4LtEQUgoLP3XR1ndXiDAWvmRw==",
 			"dependencies": {
 				"semver": "^7.3.5"
 			},
@@ -22186,9 +22176,9 @@
 			"integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
 		},
 		"node_modules/rollup": {
-			"version": "2.77.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
-			"integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
+			"version": "2.78.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+			"integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
 			"peer": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -26088,21 +26078,36 @@
 			"integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q=="
 		},
 		"node_modules/ts-loader": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.2.tgz",
-			"integrity": "sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==",
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.4.0.tgz",
+			"integrity": "sha512-6nFY3IZ2//mrPc+ImY3hNWx1vCHyEhl6V+wLmL4CZcm6g1CqX7UKrkc6y0i4FwcfOhxyMPCfaEvh20f4r9GNpw==",
 			"dependencies": {
-				"chalk": "^2.3.0",
+				"chalk": "^4.1.0",
 				"enhanced-resolve": "^4.0.0",
-				"loader-utils": "^1.0.2",
+				"loader-utils": "^2.0.0",
 				"micromatch": "^4.0.0",
-				"semver": "^6.0.0"
+				"semver": "^7.3.4"
 			},
 			"engines": {
-				"node": ">=8.6"
+				"node": ">=10.0.0"
 			},
 			"peerDependencies": {
-				"typescript": "*"
+				"typescript": "*",
+				"webpack": "*"
+			}
+		},
+		"node_modules/ts-loader/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/ts-loader/node_modules/braces": {
@@ -26116,6 +26121,37 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/ts-loader/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/ts-loader/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/ts-loader/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+		},
 		"node_modules/ts-loader/node_modules/fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -26127,12 +26163,44 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/ts-loader/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/ts-loader/node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"engines": {
 				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/ts-loader/node_modules/loader-utils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+			"integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+			"dependencies": {
+				"big.js": "^5.2.2",
+				"emojis-list": "^3.0.0",
+				"json5": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=8.9.0"
+			}
+		},
+		"node_modules/ts-loader/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/ts-loader/node_modules/micromatch": {
@@ -26148,11 +26216,28 @@
 			}
 		},
 		"node_modules/ts-loader/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
 			"bin": {
 				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/ts-loader/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/ts-loader/node_modules/to-regex-range": {
@@ -26165,6 +26250,11 @@
 			"engines": {
 				"node": ">=8.0"
 			}
+		},
+		"node_modules/ts-loader/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"node_modules/ts-node": {
 			"version": "10.8.1",
@@ -26210,9 +26300,9 @@
 			}
 		},
 		"node_modules/ts-node/node_modules/acorn": {
-			"version": "8.7.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-			"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+			"version": "8.8.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -26328,9 +26418,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.6.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-			"integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+			"version": "4.7.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -27246,9 +27336,9 @@
 			}
 		},
 		"node_modules/web3-eth-abi/node_modules/@ethersproject/address": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-			"integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+			"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
 			"funding": [
 				{
 					"type": "individual",
@@ -27260,11 +27350,11 @@
 				}
 			],
 			"dependencies": {
-				"@ethersproject/bignumber": "^5.6.2",
-				"@ethersproject/bytes": "^5.6.1",
-				"@ethersproject/keccak256": "^5.6.1",
-				"@ethersproject/logger": "^5.6.0",
-				"@ethersproject/rlp": "^5.6.1"
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/keccak256": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/rlp": "^5.7.0"
 			}
 		},
 		"node_modules/web3-eth-accounts": {
@@ -28652,9 +28742,9 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.18.8",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
-			"integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ=="
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.13.tgz",
+			"integrity": "sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw=="
 		},
 		"@babel/core": {
 			"version": "7.8.3",
@@ -28694,11 +28784,11 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-			"integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.13.tgz",
+			"integrity": "sha512-CkPg8ySSPuHTYPJYo7IRALdqyjM9HCbt/3uOBEFbzyGVP6Mn8bwFPB0jX6982JVNBlYzM1nnPkfjuXSOPtQeEQ==",
 			"requires": {
-				"@babel/types": "^7.18.10",
+				"@babel/types": "^7.18.13",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"jsesc": "^2.5.1"
 			}
@@ -28739,9 +28829,9 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.9.tgz",
-			"integrity": "sha512-WvypNAYaVh23QcjpMR24CwZY2Nz6hqdOcFdPbNpV56hL5H6KiFheO7Xm1aPdlLQ7d5emYZX7VZwPp9x3z+2opw==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.13.tgz",
+			"integrity": "sha512-hDvXp+QYxSRL+23mpAlSGxHMDyIGChm0/AwTfTAAK5Ufe40nCsyNdaYCGuK91phn/fVu9kqayImRDkvNAgdrsA==",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
 				"@babel/helper-environment-visitor": "^7.18.9",
@@ -28931,13 +29021,13 @@
 			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw=="
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.18.10.tgz",
-			"integrity": "sha512-95NLBP59VWdfK2lyLKe6eTMq9xg+yWKzxzxbJ1wcYNi1Auz200+83fMDADjRxBvc2QQor5zja2yTQzXGhk2GtQ==",
+			"version": "7.18.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.18.11.tgz",
+			"integrity": "sha512-oBUlbv+rjZLh2Ks9SKi4aL7eKaAXBWleHzU89mP0G6BMUlRxSckk9tSIkgDGydhgFxHuGSlBQZfnaD47oBEB7w==",
 			"requires": {
 				"@babel/helper-function-name": "^7.18.9",
 				"@babel/template": "^7.18.10",
-				"@babel/traverse": "^7.18.10",
+				"@babel/traverse": "^7.18.11",
 				"@babel/types": "^7.18.10"
 			}
 		},
@@ -28984,9 +29074,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.10.tgz",
-			"integrity": "sha512-TYk3OA0HKL6qNryUayb5UUEhM/rkOQozIBEA5ITXh5DWrSp0TlUQXMyZmnWxG/DizSWBeeQ0Zbc5z8UGaaqoeg=="
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.13.tgz",
+			"integrity": "sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg=="
 		},
 		"@babel/plugin-external-helpers": {
 			"version": "7.18.6",
@@ -29254,9 +29344,9 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.9.tgz",
-			"integrity": "sha512-p5VCYNddPLkZTq4XymQIaIfZNJwT9YsjkPOhkVEqt6QIpQFZVM9IltqqYpOEkJoN1DPznmxUDyZ5CTZs/ZCuHA==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.13.tgz",
+			"integrity": "sha512-TodpQ29XekIsex2A+YJPj5ax2plkGa8YYY6mFjCohk/IG9IY42Rtuj1FuDeemfg2ipxIFLzPeA83SIBnlhSIow==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.18.9"
 			}
@@ -29537,9 +29627,9 @@
 			}
 		},
 		"@babel/plugin-transform-typescript": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.10.tgz",
-			"integrity": "sha512-j2HQCJuMbi88QftIb5zlRu3c7PU+sXNnscqsrjqegoGiCgXR569pEdben9vly5QHKL2ilYkfnSwu64zsZo/VYQ==",
+			"version": "7.18.12",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.12.tgz",
+			"integrity": "sha512-2vjjam0cum0miPkenUbQswKowuxs/NjMwIKEq0zwegRxXk12C9YOF9STXnaUptITOtOJHKHpzvvWYOjbm6tc0w==",
 			"requires": {
 				"@babel/helper-create-class-features-plugin": "^7.18.9",
 				"@babel/helper-plugin-utils": "^7.18.9",
@@ -29686,18 +29776,18 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.10.tgz",
-			"integrity": "sha512-J7ycxg0/K9XCtLyHf0cz2DqDihonJeIo+z+HEdRe9YuT8TY4A66i+Ab2/xZCEW7Ro60bPCBBfqqboHSamoV3+g==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.13.tgz",
+			"integrity": "sha512-N6kt9X1jRMLPxxxPYWi7tgvJRH/rtoU+dbKAPDM44RFHiMH8igdsaSBgFeskhSl/kLWLDUvIh1RXCrTmg0/zvA==",
 			"requires": {
 				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.18.10",
+				"@babel/generator": "^7.18.13",
 				"@babel/helper-environment-visitor": "^7.18.9",
 				"@babel/helper-function-name": "^7.18.9",
 				"@babel/helper-hoist-variables": "^7.18.6",
 				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.18.10",
-				"@babel/types": "^7.18.10",
+				"@babel/parser": "^7.18.13",
+				"@babel/types": "^7.18.13",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -29718,9 +29808,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.10.tgz",
-			"integrity": "sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.13.tgz",
+			"integrity": "sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==",
 			"requires": {
 				"@babel/helper-string-parser": "^7.18.10",
 				"@babel/helper-validator-identifier": "^7.18.6",
@@ -29750,18 +29840,6 @@
 			"dev": true,
 			"requires": {
 				"@jridgewell/trace-mapping": "0.3.9"
-			},
-			"dependencies": {
-				"@jridgewell/trace-mapping": {
-					"version": "0.3.9",
-					"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-					"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-					"dev": true,
-					"requires": {
-						"@jridgewell/resolve-uri": "^3.0.3",
-						"@jridgewell/sourcemap-codec": "^1.4.10"
-					}
-				}
 			}
 		},
 		"@discordjs/collection": {
@@ -29798,15 +29876,15 @@
 			},
 			"dependencies": {
 				"@ethersproject/address": {
-					"version": "5.6.1",
-					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-					"integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+					"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
 					"requires": {
-						"@ethersproject/bignumber": "^5.6.2",
-						"@ethersproject/bytes": "^5.6.1",
-						"@ethersproject/keccak256": "^5.6.1",
-						"@ethersproject/logger": "^5.6.0",
-						"@ethersproject/rlp": "^5.6.1"
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/keccak256": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/rlp": "^5.7.0"
 					}
 				}
 			}
@@ -29868,12 +29946,12 @@
 			}
 		},
 		"@ethersproject/bignumber": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.2.tgz",
-			"integrity": "sha512-v7+EEUbhGqT3XJ9LMPsKvXYHFc8eHxTowFCG/HgJErmq4XHJ2WR7aeyICg3uTOAQ7Icn0GFHAohXEhxQHq4Ubw==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+			"integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
 			"requires": {
-				"@ethersproject/bytes": "^5.6.1",
-				"@ethersproject/logger": "^5.6.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
 				"bn.js": "^5.2.1"
 			},
 			"dependencies": {
@@ -29885,11 +29963,11 @@
 			}
 		},
 		"@ethersproject/bytes": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
-			"integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+			"integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
 			"requires": {
-				"@ethersproject/logger": "^5.6.0"
+				"@ethersproject/logger": "^5.7.0"
 			}
 		},
 		"@ethersproject/constants": {
@@ -29918,15 +29996,15 @@
 			},
 			"dependencies": {
 				"@ethersproject/address": {
-					"version": "5.6.1",
-					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-					"integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+					"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
 					"requires": {
-						"@ethersproject/bignumber": "^5.6.2",
-						"@ethersproject/bytes": "^5.6.1",
-						"@ethersproject/keccak256": "^5.6.1",
-						"@ethersproject/logger": "^5.6.0",
-						"@ethersproject/rlp": "^5.6.1"
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/keccak256": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/rlp": "^5.7.0"
 					}
 				}
 			}
@@ -29947,15 +30025,15 @@
 			},
 			"dependencies": {
 				"@ethersproject/address": {
-					"version": "5.6.1",
-					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-					"integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+					"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
 					"requires": {
-						"@ethersproject/bignumber": "^5.6.2",
-						"@ethersproject/bytes": "^5.6.1",
-						"@ethersproject/keccak256": "^5.6.1",
-						"@ethersproject/logger": "^5.6.0",
-						"@ethersproject/rlp": "^5.6.1"
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/keccak256": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/rlp": "^5.7.0"
 					}
 				}
 			}
@@ -30000,15 +30078,15 @@
 			},
 			"dependencies": {
 				"@ethersproject/address": {
-					"version": "5.6.1",
-					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-					"integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+					"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
 					"requires": {
-						"@ethersproject/bignumber": "^5.6.2",
-						"@ethersproject/bytes": "^5.6.1",
-						"@ethersproject/keccak256": "^5.6.1",
-						"@ethersproject/logger": "^5.6.0",
-						"@ethersproject/rlp": "^5.6.1"
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/keccak256": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/rlp": "^5.7.0"
 					}
 				},
 				"aes-js": {
@@ -30019,18 +30097,18 @@
 			}
 		},
 		"@ethersproject/keccak256": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.1.tgz",
-			"integrity": "sha512-bB7DQHCTRDooZZdL3lk9wpL0+XuG3XLGHLh3cePnybsO3V0rdCAOQGpn/0R3aODmnTOOkCATJiD2hnL+5bwthA==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+			"integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
 			"requires": {
-				"@ethersproject/bytes": "^5.6.1",
+				"@ethersproject/bytes": "^5.7.0",
 				"js-sha3": "0.8.0"
 			}
 		},
 		"@ethersproject/logger": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
-			"integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg=="
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+			"integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig=="
 		},
 		"@ethersproject/networks": {
 			"version": "5.3.1",
@@ -30084,15 +30162,15 @@
 			},
 			"dependencies": {
 				"@ethersproject/address": {
-					"version": "5.6.1",
-					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-					"integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+					"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
 					"requires": {
-						"@ethersproject/bignumber": "^5.6.2",
-						"@ethersproject/bytes": "^5.6.1",
-						"@ethersproject/keccak256": "^5.6.1",
-						"@ethersproject/logger": "^5.6.0",
-						"@ethersproject/rlp": "^5.6.1"
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/keccak256": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/rlp": "^5.7.0"
 					}
 				},
 				"ws": {
@@ -30113,12 +30191,12 @@
 			}
 		},
 		"@ethersproject/rlp": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.1.tgz",
-			"integrity": "sha512-uYjmcZx+DKlFUk7a5/W9aQVaoEC7+1MOBgNtvNg13+RnuUwT4F0zTovC0tmay5SmRslb29V1B7Y5KCri46WhuQ==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+			"integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
 			"requires": {
-				"@ethersproject/bytes": "^5.6.1",
-				"@ethersproject/logger": "^5.6.0"
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0"
 			}
 		},
 		"@ethersproject/sha2": {
@@ -30190,15 +30268,15 @@
 			},
 			"dependencies": {
 				"@ethersproject/address": {
-					"version": "5.6.1",
-					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-					"integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+					"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
 					"requires": {
-						"@ethersproject/bignumber": "^5.6.2",
-						"@ethersproject/bytes": "^5.6.1",
-						"@ethersproject/keccak256": "^5.6.1",
-						"@ethersproject/logger": "^5.6.0",
-						"@ethersproject/rlp": "^5.6.1"
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/keccak256": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/rlp": "^5.7.0"
 					}
 				}
 			}
@@ -30236,15 +30314,15 @@
 			},
 			"dependencies": {
 				"@ethersproject/address": {
-					"version": "5.6.1",
-					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-					"integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+					"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
 					"requires": {
-						"@ethersproject/bignumber": "^5.6.2",
-						"@ethersproject/bytes": "^5.6.1",
-						"@ethersproject/keccak256": "^5.6.1",
-						"@ethersproject/logger": "^5.6.0",
-						"@ethersproject/rlp": "^5.6.1"
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/keccak256": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/rlp": "^5.7.0"
 					}
 				}
 			}
@@ -30495,9 +30573,9 @@
 			}
 		},
 		"@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA=="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
 		},
 		"@jridgewell/set-array": {
 			"version": "1.1.2",
@@ -30505,14 +30583,14 @@
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
 		},
 		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
+			"version": "1.4.14",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
 		},
 		"@jridgewell/trace-mapping": {
-			"version": "0.3.14",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-			"integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 			"requires": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
@@ -32414,15 +32492,15 @@
 			"dev": true
 		},
 		"@tsconfig/node12": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.10.tgz",
-			"integrity": "sha512-N+srakvPaYMGkwjNDx3ASx65Zl3QG8dJgVtIB+YMOkucU+zctlv/hdP5250VKdDHSDoW9PFZoCqbqNcAPjCjXA==",
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
 			"dev": true
 		},
 		"@tsconfig/node14": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.2.tgz",
-			"integrity": "sha512-YwrUA5ysDXHFYfL0Xed9x3sNS4P+aKlCOnnbqUa2E5HdQshHFleCJVrj1PlGTb4GgFUCDyte1v3JWLy2sz8Oqg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
 			"dev": true
 		},
 		"@tsconfig/node16": {
@@ -32513,9 +32591,9 @@
 			"integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
 		},
 		"@types/lodash": {
-			"version": "4.14.182",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-			"integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
+			"version": "4.14.184",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.184.tgz",
+			"integrity": "sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q=="
 		},
 		"@types/lodash.isnumber": {
 			"version": "3.0.6",
@@ -33744,9 +33822,9 @@
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
 		},
 		"bignumber.js": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-			"integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
+			"integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A=="
 		},
 		"binary-extensions": {
 			"version": "1.13.1",
@@ -34390,14 +34468,14 @@
 			}
 		},
 		"caniuse-db": {
-			"version": "1.0.30001373",
-			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001373.tgz",
-			"integrity": "sha512-NOoFLQ0w7geqot8ENHEE/cRqQN0HdVtJeG2h+2cjmEYb07X0HGwBQxREKWpt5YUhNPmAxHKVGPbak1FLey6GGw=="
+			"version": "1.0.30001382",
+			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001382.tgz",
+			"integrity": "sha512-VhX4bbUVWrak/xe8Y6BWWD3TltpFUCmDSQWVi+CQgWqKXy3CIx+6Ev6oyjTPrR1HrGd5vuWsxzoopIYditgwsg=="
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001373",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
-			"integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ=="
+			"version": "1.0.30001382",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001382.tgz",
+			"integrity": "sha512-2rtJwDmSZ716Pxm1wCtbPvHtbDWAreTPxXbkc5RkKglow3Ig/4GNGazDI9/BVnXbG/wnv6r3B5FEbkfg9OcTGg=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",
@@ -35242,9 +35320,9 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"copy-to-clipboard": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
-			"integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.2.tgz",
+			"integrity": "sha512-Vme1Z6RUDzrb6xAI7EZlVZ5uvOk2F//GaxKUxajDqm9LhOVM1inxNAD2vy+UZDYsd0uyA9s7b3/FVZPSxqrCfg==",
 			"requires": {
 				"toggle-selection": "^1.0.6"
 			}
@@ -35735,9 +35813,9 @@
 			"dev": true
 		},
 		"dayjs": {
-			"version": "1.11.4",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.4.tgz",
-			"integrity": "sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g=="
+			"version": "1.11.5",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.5.tgz",
+			"integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA=="
 		},
 		"debug": {
 			"version": "3.1.0",
@@ -36132,9 +36210,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.208",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.208.tgz",
-			"integrity": "sha512-diMr4t69FigAGUk2KovP0bygEtN/9AkqEVkzjEp0cu+zFFbZMVvwACpTTfuj1mAmFR5kNoSW8wGKDFWIvmThiQ=="
+			"version": "1.4.228",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.228.tgz",
+			"integrity": "sha512-XfDHCvou7CsDMlFwb0WZ1tWmW48e7Sn7VBRyPfZsZZila9esRsJl1trO+OqDNV97GggFSt0ISbWslKXfQkG//g=="
 		},
 		"elliptic": {
 			"version": "6.5.4",
@@ -36326,9 +36404,9 @@
 			}
 		},
 		"es5-ext": {
-			"version": "0.10.61",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-			"integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+			"version": "0.10.62",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+			"integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
 			"requires": {
 				"es6-iterator": "^2.0.3",
 				"es6-symbol": "^3.1.3",
@@ -38116,9 +38194,9 @@
 			},
 			"dependencies": {
 				"type": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/type/-/type-2.6.1.tgz",
-					"integrity": "sha512-OvgH5rB0XM+iDZGQ1Eg/o7IZn0XYJFVrN/9FQ4OWIYILyJJgVP2s1hLTOFn6UOZoDUI/HctGa0PFlE2n2HW3NQ=="
+					"version": "2.7.2",
+					"resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+					"integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
 				}
 			}
 		},
@@ -43220,9 +43298,9 @@
 			"integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
 		},
 		"node-abi": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.23.0.tgz",
-			"integrity": "sha512-XWte/uvq7hmgY27WesfxLUAPejKUlkEbikhBFaIhxe+XkHa57rXBwYqGjsIyfVXaU8kC0Wp2p/qQroauDKs1XA==",
+			"version": "3.24.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.24.0.tgz",
+			"integrity": "sha512-YPG3Co0luSu6GwOBsmIdGW6Wx0NyNDLg/hriIyDllVsNwnI6UeqaWShxC3lbH4LtEQUgoLP3XR1ndXiDAWvmRw==",
 			"requires": {
 				"semver": "^7.3.5"
 			},
@@ -46319,9 +46397,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.77.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
-			"integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
+			"version": "2.78.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+			"integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
 			"peer": true,
 			"requires": {
 				"fsevents": "~2.3.2"
@@ -49554,17 +49632,25 @@
 			"integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q=="
 		},
 		"ts-loader": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.2.tgz",
-			"integrity": "sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==",
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.4.0.tgz",
+			"integrity": "sha512-6nFY3IZ2//mrPc+ImY3hNWx1vCHyEhl6V+wLmL4CZcm6g1CqX7UKrkc6y0i4FwcfOhxyMPCfaEvh20f4r9GNpw==",
 			"requires": {
-				"chalk": "^2.3.0",
+				"chalk": "^4.1.0",
 				"enhanced-resolve": "^4.0.0",
-				"loader-utils": "^1.0.2",
+				"loader-utils": "^2.0.0",
 				"micromatch": "^4.0.0",
-				"semver": "^6.0.0"
+				"semver": "^7.3.4"
 			},
 			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
 				"braces": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -49572,6 +49658,28 @@
 					"requires": {
 						"fill-range": "^7.0.1"
 					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 				},
 				"fill-range": {
 					"version": "7.0.1",
@@ -49581,10 +49689,33 @@
 						"to-regex-range": "^5.0.1"
 					}
 				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
 				"is-number": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+				},
+				"loader-utils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+					"integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^2.1.2"
+					}
+				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
 				},
 				"micromatch": {
 					"version": "4.0.5",
@@ -49596,9 +49727,20 @@
 					}
 				},
 				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"version": "7.3.7",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
 				},
 				"to-regex-range": {
 					"version": "5.0.1",
@@ -49607,6 +49749,11 @@
 					"requires": {
 						"is-number": "^7.0.0"
 					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				}
 			}
 		},
@@ -49632,9 +49779,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "8.7.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-					"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+					"version": "8.8.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+					"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
 					"dev": true
 				}
 			}
@@ -49728,9 +49875,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.6.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-			"integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw=="
+			"version": "4.7.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
 		},
 		"ua-parser-js": {
 			"version": "0.7.31",
@@ -50446,15 +50593,15 @@
 					}
 				},
 				"@ethersproject/address": {
-					"version": "5.6.1",
-					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-					"integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+					"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
 					"requires": {
-						"@ethersproject/bignumber": "^5.6.2",
-						"@ethersproject/bytes": "^5.6.1",
-						"@ethersproject/keccak256": "^5.6.1",
-						"@ethersproject/logger": "^5.6.0",
-						"@ethersproject/rlp": "^5.6.1"
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/keccak256": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/rlp": "^5.7.0"
 					}
 				}
 			}

--- a/packages/helpers/iso-crypto/package.json
+++ b/packages/helpers/iso-crypto/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@walletconnect/crypto": "^1.0.2",
+    "@walletconnect/encoding": "^1.0.1",
     "@walletconnect/types": "^1.8.0",
     "@walletconnect/utils": "^1.8.0"
   },


### PR DESCRIPTION
`@walletconnect/iso-crypto` uses `@walletconnect/encoding` directly, so it should be listed as a dependency.

I'm not sure why the package-lock.json got reformatted to use two spaces instead of four after running `npm install`. Happy to update as needed.

Fixes #844. Closes #1049.