### PR TITLE
v2 Pass Storage Provider

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -56,7 +56,9 @@ export class Core extends ICore {
     this.logger = generateChildLogger(logger, this.name);
     this.heartbeat = new HeartBeat();
     this.crypto = new Crypto(this, this.logger, opts?.keychain);
-    this.storage = new KeyValueStorage({ ...CORE_STORAGE_OPTIONS, ...opts?.storageOptions });
+    this.storage = opts?.storage ?
+      opts.storage :
+      new KeyValueStorage({ ...CORE_STORAGE_OPTIONS, ...opts?.storageOptions });
 
     this.relayUrl = formatRelayRpcUrl(
       this.protocol,

--- a/packages/types/src/core/core.ts
+++ b/packages/types/src/core/core.ts
@@ -14,6 +14,7 @@ export declare namespace CoreTypes {
     relayUrl?: string;
     logger?: string | Logger;
     keychain?: IKeyChain;
+    storage?: IKeyValueStorage;
     storageOptions?: KeyValueStorageOptions;
   }
 }


### PR DESCRIPTION
In a previous beta version we were able to pass our own storage provider, as long as it followed the `IKeyValueStorage` interface. This is desirable for when we want to use something other than SQLite, eg: a simple in memory DB or file system storage. This PR reimplements that ability.