### PR TITLE
[v2] Add .getAll with optional filters to stores

### DIFF
--- a/packages/core/src/controllers/store.ts
+++ b/packages/core/src/controllers/store.ts
@@ -3,6 +3,7 @@ import { ICore, IStore, PairingTypes, ProposalTypes, SessionTypes } from "@walle
 import { ERROR, isProposalStruct, isSessionStruct } from "@walletconnect/utils";
 import { Logger } from "pino";
 import { CORE_STORAGE_PREFIX, STORE_STORAGE_VERSION } from "../constants";
+import isEqual from "lodash.isequal";
 
 type StoreStruct = SessionTypes.Struct | PairingTypes.Struct | ProposalTypes.Struct;
 
@@ -91,7 +92,7 @@ export class Store<Key, Data extends StoreStruct> extends IStore<Key, Data> {
     if (!filter) return this.values;
 
     return this.values.filter(value =>
-      Object.keys(filter).every(key => value[key] === filter[key]),
+      Object.keys(filter).every(key => isEqual(value[key], filter[key])),
     );
   };
 

--- a/packages/core/src/controllers/store.ts
+++ b/packages/core/src/controllers/store.ts
@@ -87,6 +87,14 @@ export class Store<Key, Data extends StoreStruct> extends IStore<Key, Data> {
     return value;
   };
 
+  public getAll: IStore<Key, Data>["getAll"] = filter => {
+    if (!filter) return this.values;
+
+    return this.values.filter(value =>
+      Object.keys(filter).every(key => value[key] === filter[key]),
+    );
+  };
+
   public update: IStore<Key, Data>["update"] = async (key, update) => {
     this.isInitialized();
     this.logger.debug(`Updating value`);

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -93,4 +93,25 @@ describe("Store", () => {
       expect(store.length).to.equal(0);
     });
   });
+
+  describe("getAll", () => {
+    const key1 = "key1";
+    const key2 = "key2";
+    const value1 = { topic: "abc123", expiry: 1000, active: false };
+    const value2 = { topic: "abc456", expiry: 1000, active: true };
+
+    it("returns all values if no filter was provided", async () => {
+      await store.set(key1, value1);
+      await store.set(key2, value2);
+      const all = store.getAll();
+      expect(all.length).to.equal(2);
+    });
+    it("only returns values that satisfy filter", async () => {
+      await store.set(key1, value1);
+      await store.set(key2, value2);
+      const filtered = store.getAll({ active: true });
+      expect(filtered.length).to.equal(1);
+      expect(filtered[0].active).to.equal(true);
+    });
+  });
 });

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -311,7 +311,7 @@ export class Engine extends IEngine {
 
   public find: IEngine["find"] = params => {
     this.isInitialized();
-    return this.client.session.values.filter(session => isSessionCompatible(session, params));
+    return this.client.session.getAll().filter(session => isSessionCompatible(session, params));
   };
 
   // ---------- Private Helpers --------------------------------------- //
@@ -411,13 +411,13 @@ export class Engine extends IEngine {
     const sessionTopics: string[] = [];
     const pairingTopics: string[] = [];
     const proposalIds: number[] = [];
-    this.client.session.values.forEach(session => {
+    this.client.session.getAll().forEach(session => {
       if (isExpired(session.expiry)) sessionTopics.push(session.topic);
     });
-    this.client.pairing.values.forEach(pairing => {
+    this.client.pairing.getAll().forEach(pairing => {
       if (isExpired(pairing.expiry)) pairingTopics.push(pairing.topic);
     });
-    this.client.proposal.values.forEach(proposal => {
+    this.client.proposal.getAll().forEach(proposal => {
       if (isExpired(proposal.expiry)) proposalIds.push(proposal.id);
     });
     await Promise.all([

--- a/packages/types/src/core/store.ts
+++ b/packages/types/src/core/store.ts
@@ -27,6 +27,8 @@ export abstract class IStore<Key, Value> {
 
   public abstract get(key: Key): Value;
 
+  public abstract getAll(filter?: Partial<Value>): Value[];
+
   public abstract update(key: Key, update: Partial<Value>): Promise<void>;
 
   public abstract delete(key: Key, reason: ErrorResponse): Promise<void>;


### PR DESCRIPTION
closes #1102

However I implemented it in a slightly different way. I created a `getAll` method on store that takes in optional filter object in form of partial store data struct i.e. you can do things like `getAll({ active: true })` to only return active sessions for example.

I think this way will enable all use-cases for #1102 without us needing to change too many things around. And it is more flexible for extra filtering if we need it in the future.