### PR TITLE
fix(): signTypedData_v4 for metamask

### DIFF
--- a/packages/providers/web3-provider/src/index.ts
+++ b/packages/providers/web3-provider/src/index.ts
@@ -121,7 +121,12 @@ class WalletConnectProvider extends ProviderEngine {
       return;
     }
 
-    return this.sendAsyncPromise(payload.method, payload.params);
+    if(payload.method === "eth_signTypedData_v4" && this.walletMeta?.name === "MetaMask") {
+      const { result } =  await this.handleOtherRequests(payload);
+      return result
+    } else {
+      return this.sendAsyncPromise(payload.method, payload.params);
+    }
   };
 
   onConnect = (callback: any) => {


### PR DESCRIPTION
Fixes issue where we are unable to sign transactions if its a typed array on metamask connected via walletconnect. 

https://github.com/MetaMask/metamask-mobile/issues/4441