### PR TITLE
feat: builds sign client into docker

### DIFF
--- a/.github/workflows/ci_sign_client.yml
+++ b/.github/workflows/ci_sign_client.yml
@@ -1,0 +1,64 @@
+name: ci_sign_client
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - v2.0
+    paths:
+      - 'packages/sign-client/**'
+
+concurrency: ${{ github.workflow }}
+
+env:
+  TERM: linux
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Checkout
+        uses: actions/checkout@v2
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build, tag, and push image to Amazon ECR
+        uses: docker/build-push-action@v2
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: sign-client
+          IMAGE_TAG: v2.0
+        with:
+          context: .
+          file: packages/sign-client/Dockerfile
+          push: true
+          tags: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/packages/sign-client/Dockerfile
+++ b/packages/sign-client/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:16.14-alpine as base
+
+WORKDIR /
+
+RUN apk --update --no-cache \
+    add g++ make python3
+
+FROM base as build
+
+WORKDIR /
+
+COPY ./packages/sign-client/ ./
+COPY ./tsconfig.json ./tsconfig.json.base
+RUN npm install -f
+RUN rm ./tsconfig.json
+RUN echo '{"extends": "./tsconfig.json.base","include": ["./src/**/*"],"compilerOptions": {"outDir": "./dist"}}' >> ./tsconfig.json
+RUN npm run build
+
+CMD ["node", "-v"]


### PR DESCRIPTION
We currently use the sign client for testing and we consume it as a Docker container. In a previous commit this was broken as the client is no longer available via Docker.

This fixes that regression.

This also improves the previous solution as the Container is now built automatically into the registry by GitHub Actions.

# Testing
Sample CI run: https://github.com/WalletConnect/walletconnect-monorepo/actions/runs/2614023780