### PR TITLE
fix: tests have dependencies outside of the package

### DIFF
--- a/packages/sign-client/Dockerfile
+++ b/packages/sign-client/Dockerfile
@@ -10,8 +10,9 @@ FROM base as build
 WORKDIR /
 
 COPY ./packages/sign-client/ ./
+RUN rm -rf ./node_modules
 COPY ./tsconfig.json ./tsconfig.json.base
-RUN npm install -f
+RUN npm install
 RUN rm ./tsconfig.json
 RUN echo '{"extends": "./tsconfig.json.base","include": ["./src/**/*"],"compilerOptions": {"outDir": "./dist"}}' >> ./tsconfig.json
 RUN npm run build

--- a/packages/sign-client/test/client.spec.ts
+++ b/packages/sign-client/test/client.spec.ts
@@ -5,11 +5,12 @@ import {
   expect,
   initTwoClients,
   testConnectMethod,
-  TEST_SIGN_CLIENT_DATABASE,
   TEST_SIGN_CLIENT_OPTIONS,
   deleteClients,
 } from "./shared";
 import { SEVEN_DAYS } from "@walletconnect/time";
+
+const TEST_SIGN_CLIENT_DATABASE = "./test.db"
 
 describe("Sign Client Integration", () => {
   it("init", async () => {
@@ -149,6 +150,7 @@ describe("Sign Client Integration", () => {
         // delete
         deleteClients(beforeClients);
         // restart
+        console.log("Bang", TEST_SIGN_CLIENT_DATABASE);
         const afterClients = await initTwoClients({
           storageOptions: { database: TEST_SIGN_CLIENT_DATABASE },
         });

--- a/packages/sign-client/test/client.spec.ts
+++ b/packages/sign-client/test/client.spec.ts
@@ -150,7 +150,6 @@ describe("Sign Client Integration", () => {
         // delete
         deleteClients(beforeClients);
         // restart
-        console.log("Bang", TEST_SIGN_CLIENT_DATABASE);
         const afterClients = await initTwoClients({
           storageOptions: { database: TEST_SIGN_CLIENT_DATABASE },
         });

--- a/packages/sign-client/test/shared/values.ts
+++ b/packages/sign-client/test/shared/values.ts
@@ -1,9 +1,6 @@
 import path from "path";
 import { SignClientTypes, RelayerTypes } from "@walletconnect/types";
 
-// @ts-ignore
-import { ROOT_DIR } from "../../../../ops/js/shared";
-
 export const PACKAGE_NAME = "sign-client";
 
 export const TEST_RELAY_URL = process.env.TEST_RELAY_URL
@@ -22,14 +19,6 @@ export const TEST_SIGN_CLIENT_OPTIONS: SignClientTypes.Options = {
     database: ":memory:",
   },
 };
-
-export const TEST_SIGN_CLIENT_DATABASE = path.join(
-  ROOT_DIR,
-  "packages",
-  PACKAGE_NAME,
-  "test",
-  "test.db",
-);
 
 export const TEST_SIGN_CLIENT_NAME_A = "client_a";
 export const TEST_APP_METADATA_A: SignClientTypes.Metadata = {


### PR DESCRIPTION
Currently the tests resolve the root directory via a roundtrip to the parent directory. This doesn't work in the docker context and is also unnecessarily complex.

# Testing

`docker run -e TEST_RELAY_URL="wss://dev.relay.walletconnect.com" sign-client npm run test`