### PR TITLE
feat: concurrency test

### DIFF
--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -26,6 +26,7 @@
     "build": "run-s build:pre build:cjs build:esm build:umd",
     "test:pre": "rm -rf ./test/test.db",
     "test:run": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 10000 --exit --r ts-node/register ./test/**/*.spec.ts",
+    "test:concurrency": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 100000 --exit --r ts-node/register ./test/concurrency.spec.ts",
     "test": "run-s test:pre test:run",
     "test:canary": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 10000 --exit --r ts-node/register ./test/canary/**/*.spec.ts",
     "canary": "run-s test:pre test:canary",

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -30,6 +30,7 @@
     "test": "run-s test:pre test:run",
     "test:canary": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 10000 --exit --r ts-node/register ./test/canary/**/*.spec.ts",
     "canary": "run-s test:pre test:canary",
+    "loadtest": "run-s test:pre test:concurrency",
     "watch": "tsc -p tsconfig.json --watch",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
   },

--- a/packages/sign-client/test/concurrency.spec.ts
+++ b/packages/sign-client/test/concurrency.spec.ts
@@ -19,8 +19,6 @@ describe("Sign Client Concurrency", () => {
 
     // init clients and pair
     while (pairings.length < connections) {
-      console.log(pairings.length);
-
       const clients: Clients = await initTwoClients({ relayUrl });
 
       expect(clients.A instanceof SignClient).to.eql(true);

--- a/packages/sign-client/test/concurrency.spec.ts
+++ b/packages/sign-client/test/concurrency.spec.ts
@@ -1,0 +1,97 @@
+import { getSdkError } from "@walletconnect/utils";
+import "mocha";
+import SignClient from "../src";
+import {
+  expect,
+  initTwoClients,
+  testConnectMethod,
+  TEST_SIGN_CLIENT_OPTIONS,
+  deleteClients,
+  Clients,
+  TEST_EMIT_PARAMS,
+} from "./shared";
+
+describe("Sign Client Concurrency", () => {
+  it("should successfully handle concurrent clients", async () => {
+    const connections = process.env.CONNECTIONS || 300;
+    const relayUrl = process.env.RELAY_URL || TEST_SIGN_CLIENT_OPTIONS.relayUrl;
+    const pairings: any[] = [];
+
+    // init clients and pair
+    while (pairings.length < connections) {
+      console.log(pairings.length);
+
+      const clients: Clients = await initTwoClients({ relayUrl });
+
+      expect(clients.A instanceof SignClient).to.eql(true);
+      expect(clients.B instanceof SignClient).to.eql(true);
+
+      const { sessionA } = await testConnectMethod(clients);
+      pairings.push({ clients, sessionA });
+
+      await new Promise<void>(resolve =>
+        setTimeout(() => {
+          resolve();
+        }, 50),
+      );
+    }
+
+    // test communication between clients
+    for (const data of pairings) {
+      const { clients, sessionA } = data;
+
+      const eventPayload: any = {
+        topic: sessionA.topic,
+        ...TEST_EMIT_PARAMS,
+      };
+
+      await new Promise<void>(async (resolve, reject) => {
+        try {
+          clients.B.on("session_event", (event: any) => {
+            expect(TEST_EMIT_PARAMS).to.eql(event.params);
+            expect(eventPayload.topic).to.eql(event.topic);
+            resolve();
+          });
+
+          clients.A.emit(eventPayload);
+        } catch (e) {
+          reject(e);
+        }
+      });
+    }
+
+    // test session disconnect
+    for (const data of pairings) {
+      const { clients, sessionA } = data;
+
+      await Promise.all([
+        new Promise<void>(async (resolve, reject) => {
+          const eventPayload: any = {
+            topic: sessionA.topic,
+            ...TEST_EMIT_PARAMS,
+          };
+
+          try {
+            clients.B.on("session_delete", (event: any) => {
+              expect(eventPayload.topic).to.eql(event.topic);
+              resolve();
+            });
+          } catch (e) {
+            reject();
+          }
+        }),
+        new Promise<void>(resolve => {
+          clients.A.disconnect({
+            topic: sessionA.topic,
+            reason: getSdkError("USER_DISCONNECTED"),
+          });
+          resolve();
+        }),
+      ]);
+    }
+
+    for (const data of pairings) {
+      deleteClients(data.clients);
+    }
+  });
+});


### PR DESCRIPTION
Implemented a test that initializes multiple concurrent clients. 
The test aims to simulate usage and detect possible client and/or relay issues. 

It tests the following
- client initialization
- client pairing
- session update
- session disconnect