### PR TITLE
fix: missing metadata

### DIFF
--- a/packages/core/src/controllers/publisher.ts
+++ b/packages/core/src/controllers/publisher.ts
@@ -40,7 +40,7 @@ export class Publisher extends IPublisher {
       const params = { topic, message, opts: { ttl, relay, prompt, tag } };
       const hash = hashMessage(message);
       this.queue.set(hash, params);
-      await this.rpcPublish(topic, message, ttl, relay, prompt);
+      await this.rpcPublish(topic, message, ttl, relay, prompt, tag);
       this.onPublish(hash, params);
       this.logger.debug(`Successfully Published Payload`);
       this.logger.trace({ type: "method", method: "publish", params: { topic, message, opts } });
@@ -104,10 +104,10 @@ export class Publisher extends IPublisher {
       const {
         topic,
         message,
-        opts: { ttl, relay },
+        opts: { ttl, relay, prompt, tag },
       } = params;
       const hash = hashMessage(message);
-      await this.rpcPublish(topic, message, ttl, relay);
+      await this.rpcPublish(topic, message, ttl, relay, prompt, tag);
       this.onPublish(hash, params);
     });
   }

--- a/packages/core/test/publisher.spec.ts
+++ b/packages/core/test/publisher.spec.ts
@@ -67,12 +67,13 @@ describe("Publisher", () => {
           message,
           prompt: false,
           ttl: PUBLISHER_DEFAULT_TTL,
+          tag: 0,
         },
       });
     });
     it("allows overriding of defaults via `opts` param", async () => {
       const message = "test message";
-      const opts = { ttl: 1, prompt: true, relay: { protocol: "iridium" } };
+      const opts = { ttl: 1, prompt: true, relay: { protocol: "iridium" }, tag: 1 };
       await publisher.publish(topic, message, opts);
       expect(requestSpy.callCount).to.equal(1);
       expect(requestSpy.getCall(0).args[0]).to.deep.equal({
@@ -82,6 +83,7 @@ describe("Publisher", () => {
           message,
           prompt: opts.prompt,
           ttl: opts.ttl,
+          tag: opts.tag,
         },
       });
     });


### PR DESCRIPTION
Fixed a bug where `tag` property was not provided to `rpcPublish` method and sequentially was never received by the relay.

Also added the `tag` & `prompt` properties when the `checkQueue` method is invoked