### PR TITLE
Add Tags per RPC method for Sign Client

### DIFF
--- a/packages/sign-client/src/constants/engine.ts
+++ b/packages/sign-client/src/constants/engine.ts
@@ -1,3 +1,170 @@
+import { ONE_DAY, FIVE_MINUTES, THIRTY_SECONDS } from "@walletconnect/time";
+import { RelayerTypes, JsonRpcTypes } from "@walletconnect/types";
+
 export const ENGINE_CONTEXT = "engine";
 
-export const ENGINE_TAG = 1;
+// TODO: move interface to @walletconnect/types
+interface EngineRpcConfig {
+  method: string;
+  opts: {
+    req: RelayerTypes.PublishOptions;
+    res: RelayerTypes.PublishOptions;
+  };
+}
+
+// TODO: move type to @walletconnect/types
+type EngineRpcMap = Record<JsonRpcTypes.WcMethod, EngineRpcConfig>;
+
+export const ENGINE_RPC: EngineRpcMap = {
+  wc_pairingDelete: {
+    method: "wc_pairingDelete",
+    opts: {
+      req: {
+        ttl: ONE_DAY,
+        prompt: false,
+        tag: 1000,
+      },
+      res: {
+        ttl: ONE_DAY,
+        prompt: false,
+        tag: 1001,
+      },
+    },
+  },
+  wc_pairingPing: {
+    method: "wc_pairingPing",
+    opts: {
+      req: {
+        ttl: THIRTY_SECONDS,
+        prompt: false,
+        tag: 1002,
+      },
+      res: {
+        ttl: THIRTY_SECONDS,
+        prompt: false,
+        tag: 1003,
+      },
+    },
+  },
+  wc_sessionPropose: {
+    method: "wc_sessionPropose",
+    opts: {
+      req: {
+        ttl: FIVE_MINUTES,
+        prompt: true,
+        tag: 1100,
+      },
+      res: {
+        ttl: FIVE_MINUTES,
+        prompt: false,
+        tag: 1101,
+      },
+    },
+  },
+  wc_sessionSettle: {
+    method: "wc_sessionSettle",
+    opts: {
+      req: {
+        ttl: FIVE_MINUTES,
+        prompt: false,
+        tag: 1102,
+      },
+      res: {
+        ttl: FIVE_MINUTES,
+        prompt: false,
+        tag: 1103,
+      },
+    },
+  },
+  wc_sessionUpdate: {
+    method: "wc_sessionUpdate",
+    opts: {
+      req: {
+        ttl: ONE_DAY,
+        prompt: false,
+        tag: 1104,
+      },
+      res: {
+        ttl: ONE_DAY,
+        prompt: false,
+        tag: 1105,
+      },
+    },
+  },
+  wc_sessionExtend: {
+    method: "wc_sessionExtend",
+    opts: {
+      req: {
+        ttl: ONE_DAY,
+        prompt: false,
+        tag: 1106,
+      },
+      res: {
+        ttl: ONE_DAY,
+        prompt: false,
+        tag: 1107,
+      },
+    },
+  },
+  wc_sessionRequest: {
+    method: "wc_sessionRequest",
+    opts: {
+      req: {
+        ttl: FIVE_MINUTES,
+        prompt: true,
+        tag: 1108,
+      },
+      res: {
+        ttl: FIVE_MINUTES,
+        prompt: false,
+        tag: 1109,
+      },
+    },
+  },
+  wc_sessionEvent: {
+    method: "wc_sessionEvent",
+    opts: {
+      req: {
+        ttl: FIVE_MINUTES,
+        prompt: true,
+        tag: 1110,
+      },
+      res: {
+        ttl: FIVE_MINUTES,
+        prompt: false,
+        tag: 1111,
+      },
+    },
+  },
+
+  wc_sessionDelete: {
+    method: "wc_sessionDelete",
+    opts: {
+      req: {
+        ttl: ONE_DAY,
+        prompt: false,
+        tag: 1112,
+      },
+      res: {
+        ttl: ONE_DAY,
+        prompt: false,
+        tag: 1113,
+      },
+    },
+  },
+  wc_sessionPing: {
+    method: "wc_sessionPing",
+    opts: {
+      req: {
+        ttl: THIRTY_SECONDS,
+        prompt: false,
+        tag: 1114,
+      },
+      res: {
+        ttl: THIRTY_SECONDS,
+        prompt: false,
+        tag: 1115,
+      },
+    },
+  },
+};

--- a/packages/sign-client/src/constants/engine.ts
+++ b/packages/sign-client/src/constants/engine.ts
@@ -1,170 +1,128 @@
-import { ONE_DAY, FIVE_MINUTES, THIRTY_SECONDS } from "@walletconnect/time";
-import { RelayerTypes, JsonRpcTypes } from "@walletconnect/types";
+// import { ONE_DAY, FIVE_MINUTES, THIRTY_SECONDS } from "@walletconnect/time";
+import { EngineTypes } from "@walletconnect/types";
 
 export const ENGINE_CONTEXT = "engine";
 
-// TODO: move interface to @walletconnect/types
-interface EngineRpcConfig {
-  method: string;
-  opts: {
-    req: RelayerTypes.PublishOptions;
-    res: RelayerTypes.PublishOptions;
-  };
-}
-
-// TODO: move type to @walletconnect/types
-type EngineRpcMap = Record<JsonRpcTypes.WcMethod, EngineRpcConfig>;
-
-export const ENGINE_RPC: EngineRpcMap = {
+export const ENGINE_RPC_OPTS: EngineTypes.RpcOptsMap = {
   wc_pairingDelete: {
-    method: "wc_pairingDelete",
-    opts: {
-      req: {
-        ttl: ONE_DAY,
-        prompt: false,
-        tag: 1000,
-      },
-      res: {
-        ttl: ONE_DAY,
-        prompt: false,
-        tag: 1001,
-      },
+    req: {
+      // ttl: ONE_DAY,
+      prompt: false,
+      tag: 1000,
+    },
+    res: {
+      // ttl: ONE_DAY,
+      prompt: false,
+      tag: 1001,
     },
   },
   wc_pairingPing: {
-    method: "wc_pairingPing",
-    opts: {
-      req: {
-        ttl: THIRTY_SECONDS,
-        prompt: false,
-        tag: 1002,
-      },
-      res: {
-        ttl: THIRTY_SECONDS,
-        prompt: false,
-        tag: 1003,
-      },
+    req: {
+      // ttl: THIRTY_SECONDS,
+      prompt: false,
+      tag: 1002,
+    },
+    res: {
+      // ttl: THIRTY_SECONDS,
+      prompt: false,
+      tag: 1003,
     },
   },
   wc_sessionPropose: {
-    method: "wc_sessionPropose",
-    opts: {
-      req: {
-        ttl: FIVE_MINUTES,
-        prompt: true,
-        tag: 1100,
-      },
-      res: {
-        ttl: FIVE_MINUTES,
-        prompt: false,
-        tag: 1101,
-      },
+    req: {
+      // ttl: FIVE_MINUTES,
+      prompt: true,
+      tag: 1100,
+    },
+    res: {
+      // ttl: FIVE_MINUTES,
+      prompt: false,
+      tag: 1101,
     },
   },
   wc_sessionSettle: {
-    method: "wc_sessionSettle",
-    opts: {
-      req: {
-        ttl: FIVE_MINUTES,
-        prompt: false,
-        tag: 1102,
-      },
-      res: {
-        ttl: FIVE_MINUTES,
-        prompt: false,
-        tag: 1103,
-      },
+    req: {
+      // ttl: FIVE_MINUTES,
+      prompt: false,
+      tag: 1102,
+    },
+    res: {
+      // ttl: FIVE_MINUTES,
+      prompt: false,
+      tag: 1103,
     },
   },
   wc_sessionUpdate: {
-    method: "wc_sessionUpdate",
-    opts: {
-      req: {
-        ttl: ONE_DAY,
-        prompt: false,
-        tag: 1104,
-      },
-      res: {
-        ttl: ONE_DAY,
-        prompt: false,
-        tag: 1105,
-      },
+    req: {
+      // ttl: ONE_DAY,
+      prompt: false,
+      tag: 1104,
+    },
+    res: {
+      // ttl: ONE_DAY,
+      prompt: false,
+      tag: 1105,
     },
   },
   wc_sessionExtend: {
-    method: "wc_sessionExtend",
-    opts: {
-      req: {
-        ttl: ONE_DAY,
-        prompt: false,
-        tag: 1106,
-      },
-      res: {
-        ttl: ONE_DAY,
-        prompt: false,
-        tag: 1107,
-      },
+    req: {
+      // ttl: ONE_DAY,
+      prompt: false,
+      tag: 1106,
+    },
+    res: {
+      // ttl: ONE_DAY,
+      prompt: false,
+      tag: 1107,
     },
   },
   wc_sessionRequest: {
-    method: "wc_sessionRequest",
-    opts: {
-      req: {
-        ttl: FIVE_MINUTES,
-        prompt: true,
-        tag: 1108,
-      },
-      res: {
-        ttl: FIVE_MINUTES,
-        prompt: false,
-        tag: 1109,
-      },
+    req: {
+      // ttl: FIVE_MINUTES,
+      prompt: true,
+      tag: 1108,
+    },
+    res: {
+      // ttl: FIVE_MINUTES,
+      prompt: false,
+      tag: 1109,
     },
   },
   wc_sessionEvent: {
-    method: "wc_sessionEvent",
-    opts: {
-      req: {
-        ttl: FIVE_MINUTES,
-        prompt: true,
-        tag: 1110,
-      },
-      res: {
-        ttl: FIVE_MINUTES,
-        prompt: false,
-        tag: 1111,
-      },
+    req: {
+      // ttl: FIVE_MINUTES,
+      prompt: true,
+      tag: 1110,
+    },
+    res: {
+      // ttl: FIVE_MINUTES,
+      prompt: false,
+      tag: 1111,
     },
   },
 
   wc_sessionDelete: {
-    method: "wc_sessionDelete",
-    opts: {
-      req: {
-        ttl: ONE_DAY,
-        prompt: false,
-        tag: 1112,
-      },
-      res: {
-        ttl: ONE_DAY,
-        prompt: false,
-        tag: 1113,
-      },
+    req: {
+      // ttl: ONE_DAY,
+      prompt: false,
+      tag: 1112,
+    },
+    res: {
+      // ttl: ONE_DAY,
+      prompt: false,
+      tag: 1113,
     },
   },
   wc_sessionPing: {
-    method: "wc_sessionPing",
-    opts: {
-      req: {
-        ttl: THIRTY_SECONDS,
-        prompt: false,
-        tag: 1114,
-      },
-      res: {
-        ttl: THIRTY_SECONDS,
-        prompt: false,
-        tag: 1115,
-      },
+    req: {
+      // ttl: THIRTY_SECONDS,
+      prompt: false,
+      tag: 1114,
+    },
+    res: {
+      // ttl: THIRTY_SECONDS,
+      prompt: false,
+      tag: 1115,
     },
   },
 };

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -57,7 +57,7 @@ import {
   SESSION_EXPIRY,
   PROPOSAL_EXPIRY,
   ENGINE_CONTEXT,
-  ENGINE_TAG,
+  ENGINE_RPC,
 } from "../constants";
 
 export class Engine extends IEngine {
@@ -395,7 +395,7 @@ export class Engine extends IEngine {
   private sendRequest: EnginePrivate["sendRequest"] = async (topic, method, params) => {
     const payload = formatJsonRpcRequest(method, params);
     const message = await this.client.core.crypto.encode(topic, payload);
-    const opts = { tag: ENGINE_TAG };
+    const opts = ENGINE_RPC[method].opts.req;
     await this.client.core.relayer.publish(topic, message, opts);
     this.client.history.set(topic, payload);
 
@@ -405,7 +405,8 @@ export class Engine extends IEngine {
   private sendResult: EnginePrivate["sendResult"] = async (id, topic, result) => {
     const payload = formatJsonRpcResult(id, result);
     const message = await this.client.core.crypto.encode(topic, payload);
-    const opts = { tag: ENGINE_TAG };
+    const record = await this.client.history.get(topic, id);
+    const opts = ENGINE_RPC[record.request.method].opts.res;
     await this.client.core.relayer.publish(topic, message, opts);
     await this.client.history.resolve(payload);
   };
@@ -413,7 +414,8 @@ export class Engine extends IEngine {
   private sendError: EnginePrivate["sendError"] = async (id, topic, error) => {
     const payload = formatJsonRpcError(id, error);
     const message = await this.client.core.crypto.encode(topic, payload);
-    const opts = { tag: ENGINE_TAG };
+    const record = await this.client.history.get(topic, id);
+    const opts = ENGINE_RPC[record.request.method].opts.res;
     await this.client.core.relayer.publish(topic, message, opts);
     await this.client.history.resolve(payload);
   };

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -57,7 +57,7 @@ import {
   SESSION_EXPIRY,
   PROPOSAL_EXPIRY,
   ENGINE_CONTEXT,
-  ENGINE_RPC,
+  ENGINE_RPC_OPTS,
 } from "../constants";
 
 export class Engine extends IEngine {
@@ -395,7 +395,7 @@ export class Engine extends IEngine {
   private sendRequest: EnginePrivate["sendRequest"] = async (topic, method, params) => {
     const payload = formatJsonRpcRequest(method, params);
     const message = await this.client.core.crypto.encode(topic, payload);
-    const opts = ENGINE_RPC[method].opts.req;
+    const opts = ENGINE_RPC_OPTS[method].req;
     await this.client.core.relayer.publish(topic, message, opts);
     this.client.history.set(topic, payload);
 
@@ -406,7 +406,7 @@ export class Engine extends IEngine {
     const payload = formatJsonRpcResult(id, result);
     const message = await this.client.core.crypto.encode(topic, payload);
     const record = await this.client.history.get(topic, id);
-    const opts = ENGINE_RPC[record.request.method].opts.res;
+    const opts = ENGINE_RPC_OPTS[record.request.method].res;
     await this.client.core.relayer.publish(topic, message, opts);
     await this.client.history.resolve(payload);
   };
@@ -415,7 +415,7 @@ export class Engine extends IEngine {
     const payload = formatJsonRpcError(id, error);
     const message = await this.client.core.crypto.encode(topic, payload);
     const record = await this.client.history.get(topic, id);
-    const opts = ENGINE_RPC[record.request.method].opts.res;
+    const opts = ENGINE_RPC_OPTS[record.request.method].res;
     await this.client.core.relayer.publish(topic, message, opts);
     await this.client.history.resolve(payload);
   };

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -116,6 +116,13 @@ export declare namespace EngineTypes {
   }
 
   type AcknowledgedPromise = Promise<{ acknowledged: () => Promise<void> }>;
+
+  interface RpcOpts {
+    req: RelayerTypes.PublishOptions;
+    res: RelayerTypes.PublishOptions;
+  }
+
+  type RpcOptsMap = Record<JsonRpcTypes.WcMethod, RpcOpts>;
 }
 
 export abstract class IEngineEvents extends EventEmitter {


### PR DESCRIPTION
Everything works for Granular tags but unfortunately had to comment out the TTL because it was causing tests to sporadically fail..

So this PR is good enough for RC.1 but we need review specs for very short TTL such as 30 seconds for ping methods