### PR TITLE
fix: loadtest getting stuck

### DIFF
--- a/packages/sign-client/test/concurrency/concurrency.spec.ts
+++ b/packages/sign-client/test/concurrency/concurrency.spec.ts
@@ -110,7 +110,7 @@ describe("Sign Client Concurrency", () => {
     for await (const i of Array.from(Array(clientPairs).keys())) {
       await new Promise<void>(async resolve => {
         const timeout = setTimeout(() => {
-          log(`stuck ${i}`);
+          log(`Client ${i} hung up`);
           resolve();
         }, 5000);
 

--- a/packages/sign-client/test/concurrency/concurrency.spec.ts
+++ b/packages/sign-client/test/concurrency/concurrency.spec.ts
@@ -32,7 +32,7 @@ describe("Sign Client Concurrency", () => {
       console.log(log);
     };
 
-    const heatBeat = setInterval(() => {
+    const heartBeat = setInterval(() => {
       log(`initialized pairs - ${pairings.length}`);
       log(
         `total messages exchanged - ${Object.values(messagesReceived).reduce(
@@ -167,6 +167,6 @@ describe("Sign Client Concurrency", () => {
     for (const data of pairings) {
       deleteClients(data.clients);
     }
-    clearInterval(heatBeat);
+    clearInterval(heartBeat);
   });
 });

--- a/packages/sign-client/test/concurrency/concurrency.spec.ts
+++ b/packages/sign-client/test/concurrency/concurrency.spec.ts
@@ -110,7 +110,7 @@ describe("Sign Client Concurrency", () => {
     for await (const i of Array.from(Array(clientPairs).keys())) {
       await new Promise<void>(async resolve => {
         const timeout = setTimeout(() => {
-          log(`struck ${i}`);
+          log(`stuck ${i}`);
           resolve();
         }, 5000);
 


### PR DESCRIPTION
Implemented an improvement in the load test where the process no longer gets stuck if a pairing doesn't resolve successfully