### PR TITLE
chore: logs more verbosely to narrow down issue

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -11,11 +11,18 @@ import {
 
 const environment = process.env.ENVIRONMENT || "dev";
 
+const log = (log: string) => {
+  // eslint-disable-next-line no-console
+  console.log(log);
+};
+
 describe("Canary", () => {
   describe("HappyPath", () => {
     it("connects", async () => {
       const clients = await initTwoClients();
+      log('Clients initialized');
       const { sessionA } = await testConnectMethod(clients);
+      log('Clients connected');
 
       await Promise.all([
         new Promise<void>(async (resolve, reject) => {
@@ -41,8 +48,10 @@ describe("Canary", () => {
           resolve();
         }),
       ]);
+      log('Clients disconnected');
 
       deleteClients(clients);
+      log('Clients deleted');
     });
   });
   afterEach(function(done) {


### PR DESCRIPTION
Canary is failing a lot. Adding logs to narrow down where.

Context: https://discord.com/channels/492410046307631105/1001385939253342268/1001386220305252424

# Testing
Not tested