### PR TITLE
fix: canary log

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -53,16 +53,15 @@ describe("Canary", () => {
       log("Clients deleted");
     });
   });
-  afterEach(function (done) {
+  afterEach(async (done) => {
     const { suite, name, result } = done.meta;
     const metric_prefix = `${suite.name}.${name}`;
     const nowTimestamp = Date.now();
-    uploadToCloudWatch(
+    await uploadToCloudWatch(
       environment,
       metric_prefix,
       result?.state === "pass",
       nowTimestamp - (result?.startTime || nowTimestamp),
-      done,
     );
   });
 });

--- a/packages/sign-client/test/shared/metrics.ts
+++ b/packages/sign-client/test/shared/metrics.ts
@@ -5,7 +5,6 @@ export const uploadToCloudWatch = async (
   metricsPrefix: string,
   isTestPassed: boolean,
   testDurationMs: number,
-  callback: Function,
 ) => {
   const cloudwatch = new CloudWatch({ region: "eu-central-1" });
   const ts = new Date();
@@ -33,13 +32,16 @@ export const uploadToCloudWatch = async (
     ],
     Namespace: `${env}_Canary_SignClient`,
   };
-  cloudwatch.putMetricData(params, function (err: Error) {
-    if (err) {
-      console.error(err, err.stack);
-      // Swallow error as
-      // Test shouldn't fail despite CW failing
-      // we will report on missing metrics
-    }
-    callback();
+
+  await new Promise<void>((resolve) => {
+    cloudwatch.putMetricData(params, function (err: Error) {
+      if (err) {
+        console.error(err, err.stack);
+        // Swallow error as
+        // Test shouldn't fail despite CW failing
+        // we will report on missing metrics
+      }
+      resolve();
+    });
   });
 };


### PR DESCRIPTION
The `afterEach` fx was not waiting for the canary log to upload and instead was exiting the process immediately.
Now will wait the `uploadToCloudWatch` to resolve