### PR TITLE
fix: loadtest timeout

### DIFF
--- a/packages/sign-client/test/concurrency/concurrency.spec.ts
+++ b/packages/sign-client/test/concurrency/concurrency.spec.ts
@@ -167,5 +167,5 @@ describe("Sign Client Concurrency", () => {
       deleteClients(data.clients);
     }
     clearInterval(heartBeat);
-  });
+  }, 600000);
 });

--- a/packages/sign-client/vitest.config.ts
+++ b/packages/sign-client/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    testTimeout: 600_000,
+    hookTimeout: 120_000,
+  },
+});

--- a/packages/sign-client/vitest.config.ts
+++ b/packages/sign-client/vitest.config.ts
@@ -1,8 +1,0 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-  test: {
-    testTimeout: 600_000,
-    hookTimeout: 120_000,
-  },
-});


### PR DESCRIPTION
Added custom vitest config for sign-client so we can run longer loadtests
