### PR TITLE
refactor: canary test timeout

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -51,7 +51,7 @@ describe("Canary", () => {
 
       deleteClients(clients);
       log("Clients deleted");
-    });
+    }, 20000);
   });
   afterEach(async (done) => {
     const { suite, name, result } = done.meta;


### PR DESCRIPTION
Set the canary timeout to 20s as the default 5s is too short