### PR TITLE
Make typing for store generic

### DIFF
--- a/packages/core/src/controllers/store.ts
+++ b/packages/core/src/controllers/store.ts
@@ -1,6 +1,11 @@
 import { generateChildLogger, getLoggerContext } from "@walletconnect/logger";
 import { ICore, IStore } from "@walletconnect/types";
-import { getInternalError, isProposalStruct, isSessionStruct } from "@walletconnect/utils";
+import {
+  getInternalError,
+  isProposalStruct,
+  isSessionStruct,
+  isUndefined,
+} from "@walletconnect/utils";
 import { Logger } from "pino";
 import { CORE_STORAGE_PREFIX, STORE_STORAGE_VERSION } from "../constants";
 import isEqual from "lodash.isequal";
@@ -52,11 +57,8 @@ export class Store<Key, Data extends Record<string, any>> extends IStore<Key, Da
         } else if (isSessionStruct(value)) {
           // TODO(pedro) revert type casting as any
           this.map.set(value.topic as any, value);
-        } else if (this.getKey) {
-          // Null checking to prevent undefined or null values to throw an error
-          if (value) {
-            this.map.set(this.getKey(value), value);
-          }
+        } else if (this.getKey && value !== null && !isUndefined(value)) {
+          this.map.set(this.getKey(value), value);
         }
       });
 

--- a/packages/core/src/controllers/store.ts
+++ b/packages/core/src/controllers/store.ts
@@ -5,7 +5,7 @@ import { Logger } from "pino";
 import { CORE_STORAGE_PREFIX, STORE_STORAGE_VERSION } from "../constants";
 import isEqual from "lodash.isequal";
 
-export class Store<Key, Data extends Object> extends IStore<Key, Data> {
+export class Store<Key, Data extends Record<string, any>> extends IStore<Key, Data> {
   public map = new Map<Key, Data>();
   public version = STORE_STORAGE_VERSION;
 

--- a/packages/core/src/controllers/store.ts
+++ b/packages/core/src/controllers/store.ts
@@ -1,13 +1,11 @@
 import { generateChildLogger, getLoggerContext } from "@walletconnect/logger";
-import { ICore, IStore, PairingTypes, ProposalTypes, SessionTypes } from "@walletconnect/types";
+import { ICore, IStore } from "@walletconnect/types";
 import { getInternalError, isProposalStruct, isSessionStruct } from "@walletconnect/utils";
 import { Logger } from "pino";
 import { CORE_STORAGE_PREFIX, STORE_STORAGE_VERSION } from "../constants";
 import isEqual from "lodash.isequal";
 
-type StoreStruct = SessionTypes.Struct | PairingTypes.Struct | ProposalTypes.Struct;
-
-export class Store<Key, Data extends StoreStruct> extends IStore<Key, Data> {
+export class Store<Key, Data extends Object> extends IStore<Key, Data> {
   public map = new Map<Key, Data>();
   public version = STORE_STORAGE_VERSION;
 

--- a/packages/core/src/controllers/store.ts
+++ b/packages/core/src/controllers/store.ts
@@ -53,7 +53,10 @@ export class Store<Key, Data extends Record<string, any>> extends IStore<Key, Da
           // TODO(pedro) revert type casting as any
           this.map.set(value.topic as any, value);
         } else if (this.getKey) {
-          this.map.set(this.getKey(value), value);
+          // Null checking to prevent undefined or null values to throw an error
+          if (value) {
+            this.map.set(this.getKey(value), value);
+          }
         }
       });
 

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -30,11 +30,11 @@ describe("Store", () => {
   describe("init", () => {
     type MockValue = { id: string; value: string };
     const ids = ["1", "2", "3", "foo"];
+    const STORAGE_KEY = CORE_STORAGE_PREFIX + STORE_STORAGE_VERSION + "//" + MOCK_STORE_NAME;
 
     beforeEach(() => {
-      const storageKey = CORE_STORAGE_PREFIX + STORE_STORAGE_VERSION + "//" + MOCK_STORE_NAME;
       const cachedValues = ids.map((id) => ({ id, value: "foo" }));
-      core.storage.setItem(storageKey, cachedValues);
+      core.storage.setItem(STORAGE_KEY, cachedValues);
     });
 
     it("retreives from cache using getKey", async () => {
@@ -52,6 +52,19 @@ describe("Store", () => {
     });
 
     it("safely overwrites values when retreiving from cache using getKey", async () => {
+      const store = new Store<string, MockValue>(
+        core,
+        logger,
+        MOCK_STORE_NAME,
+        undefined,
+        (val) => val.value,
+      );
+      await store.init();
+      expect(store.keys).to.eql(["foo"]);
+    });
+
+    it("handles null and undefined cases", async () => {
+      core.storage.setItem(STORAGE_KEY, [undefined, null, { id: 1, value: "foo" }]);
       const store = new Store<string, MockValue>(
         core,
         logger,

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -27,6 +27,43 @@ describe("Store", () => {
     );
   });
 
+  describe("init", () => {
+    type MockValue = { id: string; value: string };
+    const ids = ["1", "2", "3", "foo"];
+
+    beforeEach(() => {
+      const storageKey = CORE_STORAGE_PREFIX + STORE_STORAGE_VERSION + "//" + MOCK_STORE_NAME;
+      const cachedValues = ids.map((id) => ({ id, value: "foo" }));
+      core.storage.setItem(storageKey, cachedValues);
+    });
+
+    it("retreives from cache using getKey", async () => {
+      const store = new Store<string, MockValue>(
+        core,
+        logger,
+        MOCK_STORE_NAME,
+        undefined,
+        (val) => val.id,
+      );
+      await store.init();
+      for (let id of ids) {
+        expect(store.keys).includes(id);
+      }
+    });
+
+    it("safely overwrites values when retreiving from cache using getKey", async () => {
+      const store = new Store<string, MockValue>(
+        core,
+        logger,
+        MOCK_STORE_NAME,
+        undefined,
+        (val) => val.value,
+      );
+      await store.init();
+      expect(store.keys).to.eql(["foo"]);
+    });
+  });
+
   describe("set", () => {
     it("creates a new entry for a new key", async () => {
       const key = "newKey";


### PR DESCRIPTION
# Description

- Make typing for store generic to make extending it easier

The store controller is generic and should not make assumptions on the object
types stored by it

## How Has This Been Tested?

2 new tests in `store.spec.ts` to check for retrieving from cached data and duplicate keys 

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [x] Breaking change
* [x] Requires a documentation update
* [x] Requires a e2e/integration test update
