### PR TITLE
feat: Reorder clientMeta `||`

### DIFF
--- a/packages/clients/core/src/index.ts
+++ b/packages/clients/core/src/index.ts
@@ -118,7 +118,7 @@ class Connector implements IConnector {
   // -- constructor ----------------------------------------------------- //
 
   constructor(opts: IConnectorOpts) {
-    this._clientMeta = getClientMeta() || opts.connectorOpts.clientMeta || null;
+    this._clientMeta = opts.connectorOpts.clientMeta || getClientMeta() || null;
     this._cryptoLib = opts.cryptoLib;
     this._sessionStorage = opts.sessionStorage || new SessionStorage(opts.connectorOpts.storageId);
     this._qrcodeModal = opts.connectorOpts.qrcodeModal;


### PR DESCRIPTION
# Description
When `clientMeta` is set it defaults to the meta that is found on the page rather than the provided meta

## How Has This Been Tested?
Ran `npm test`

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
