### PR TITLE
fix: failed connections are still retried when closed

### DIFF
--- a/packages/helpers/socket-transport/src/index.ts
+++ b/packages/helpers/socket-transport/src/index.ts
@@ -100,6 +100,12 @@ class SocketTransport implements ITransportLib {
 
   public close() {
     this._socketClose();
+    if (this._nextSocket) {
+      this._nextSocket.onclose = () => {
+        // empty
+      };
+      this._nextSocket.close();
+    }
   }
 
   public send(message: string, topic?: string, silent?: boolean): void {
@@ -171,11 +177,6 @@ class SocketTransport implements ITransportLib {
         // empty
       };
       this._socket.close();
-    } else if (this._nextSocket) {
-      this._nextSocket.onclose = () => {
-        // empty
-      };
-      this._nextSocket.close();
     }
   }
 

--- a/packages/helpers/socket-transport/src/index.ts
+++ b/packages/helpers/socket-transport/src/index.ts
@@ -171,6 +171,11 @@ class SocketTransport implements ITransportLib {
         // empty
       };
       this._socket.close();
+    } else if (this._nextSocket) {
+      this._nextSocket.onclose = () => {
+        // empty
+      };
+      this._nextSocket.close();
     }
   }
 


### PR DESCRIPTION
# Description

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

If a wrong bridge is set, the `_nextSocket` will retry indefinitely. The `_nextSocket` does not stop when the connection is closed.


## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
