### PR TITLE
fix(deps): use exact walletconnect dep version when updating

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "npm run test --workspaces",
     "check": "npm run lint; npm run build; npm run test",
     "reset": "npm run clean; npm run check",
-    "new-version": "lerna version --no-git-tag-version",
+    "new-version": "lerna version --no-git-tag-version --exact",
     "pre-publish": "npm run new-version; npm run reset",
     "npm-publish:rc": "lerna exec -- npm publish --access public --tag rc",
     "npm-publish:latest": "lerna exec -- npm publish --access public --tag latest",


### PR DESCRIPTION
## Context

- I was seeing some odd dependency resolution issues when trying to supersede e.g. `^2.0.0-rc.1` with a canary version in the demo dapp/wallet, where e.g. `sign-client` would be updated to canary but sub-dependencies like `core` remained on `2.0.0-rc.1`
- This seems to be due to the sub-dependencies being specified with `^2.0.0-rc.1` in the lockfile, which yarn/npm seems to regard as the higher patch version compared to the canary, thus still resolving `rc.1` for the sub-dependencies.

## Solution

- Bump versions to exact new one (i.e. without semver `^`) via https://github.com/lerna/lerna/tree/main/commands/version#--exact, to ensure we're always dealing with the exact WalletConnect sub-dependencies we expect when testing canaries etc.