### PR TITLE
README: Fix relay link to point to correct repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Open protocol for connecting Wallets to Dapps - https://walletconnect.com
 2. Install python3 and ensure `python` cli is linked (required to build some npm modules)
 3. Install workspace dependencies i.e. run `npm install` from root folder
 4. Install redis. We recommend running it as a [brew service](https://gist.github.com/tomysmile/1b8a321e7c58499ef9f9441b2faa0aa8)
-5. Pull and start ts-relay server ([separate repo](https://github.com/WalletConnect/ts-relay)) `PORT=5555 npm run start`
+5. Pull and start ts-relay server ([separate repo](https://github.com/WalletConnect/relay)) `PORT=5555 npm run start`
 6. Ensure everything runs correctly by executing `npm run check`
 
 ## Troubleshooting


### PR DESCRIPTION
The current link leads to a github 404. I think the repo was renamed to relay, doing this to help improve the README