### PR TITLE
feat: distinguish canary target in metrics

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -6,6 +6,7 @@ import {
   uploadToCloudWatch,
   TEST_EMIT_PARAMS,
 } from "../shared";
+import { TEST_RELAY_URL } from "./../shared/values";
 import { describe, it, expect, afterEach } from "vitest";
 
 const environment = process.env.ENVIRONMENT || "dev";
@@ -59,6 +60,7 @@ describe("Canary", () => {
     const nowTimestamp = Date.now();
     await uploadToCloudWatch(
       environment,
+      TEST_RELAY_URL,
       metric_prefix,
       result?.state === "pass",
       nowTimestamp - (result?.startTime || nowTimestamp),

--- a/packages/sign-client/test/shared/metrics.ts
+++ b/packages/sign-client/test/shared/metrics.ts
@@ -2,6 +2,7 @@ import CloudWatch from "aws-sdk/clients/cloudwatch";
 
 export const uploadToCloudWatch = async (
   env: string,
+  target: string,
   metricsPrefix: string,
   isTestPassed: boolean,
   testDurationMs: number,
@@ -13,6 +14,10 @@ export const uploadToCloudWatch = async (
     MetricData: [
       {
         MetricName: `${metricsPrefix}.success`,
+        Dimensions: [{
+          Name: "Target",
+          Value: target
+        }],
         Unit: "Count",
         Value: isTestPassed ? 1 : 0,
         Timestamp: ts,

--- a/packages/sign-client/test/shared/metrics.ts
+++ b/packages/sign-client/test/shared/metrics.ts
@@ -14,10 +14,12 @@ export const uploadToCloudWatch = async (
     MetricData: [
       {
         MetricName: `${metricsPrefix}.success`,
-        Dimensions: [{
-          Name: "Target",
-          Value: target
-        }],
+        Dimensions: [
+          {
+            Name: "Target",
+            Value: target,
+          },
+        ],
         Unit: "Count",
         Value: isTestPassed ? 1 : 0,
         Timestamp: ts,

--- a/packages/sign-client/test/shared/metrics.ts
+++ b/packages/sign-client/test/shared/metrics.ts
@@ -26,12 +26,24 @@ export const uploadToCloudWatch = async (
       },
       {
         MetricName: `${metricsPrefix}.failure`,
+        Dimensions: [
+          {
+            Name: "Target",
+            Value: target,
+          },
+        ],
         Unit: "Count",
         Value: isTestPassed ? 0 : 1,
         Timestamp: ts,
       },
       {
         MetricName: `${metricsPrefix}.latency`,
+        Dimensions: [
+          {
+            Name: "Target",
+            Value: target,
+          },
+        ],
         Unit: "Milliseconds",
         Value: testDurationMs,
         Timestamp: ts,


### PR DESCRIPTION
# Description

Canary users need to know which endpoint is up/down through metrics.

Resolves #1377

## How Has This Been Tested?

Build image via dev branch and tested downstream in metrics https://github.com/WalletConnect/walletconnect-monorepo/runs/8023969616?check_suite_focus=true

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
