### PR TITLE
chore: allot 10s to tests

### DIFF
--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -33,7 +33,7 @@ describe("Sign Client Integration", () => {
         pairingTopic,
       });
       deleteClients(clients);
-    });
+    }, 20_000);
   });
 
   describe("disconnect", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    testTimeout: 120_000,
-    hookTimeout: 120_000,
+    testTimeout: 10_000,
+    hookTimeout: 10_000,
   },
 });


### PR DESCRIPTION
# Description

In the worst case the test suite runs > 40mins. This change reduces the worst case to ~4mins.

Resolves #1376 

## How Has This Been Tested?

* `sign-client` tests `TEST_RELAY_URL=wss://relay.walletconnect.com npm run test`
* `core` tests `TEST_RELAY_URL=wss://relay.walletconnect.com npm run test`
* package root tests `TEST_RELAY_URL=wss://relay.walletconnect.com npm run test`

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
