### PR TITLE
chore: logs relay url

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -20,9 +20,9 @@ describe("Canary", () => {
   describe("HappyPath", () => {
     it("connects", async () => {
       const clients = await initTwoClients();
-      log("Clients initialized");
+      log(`Clients initialized (relay '${TEST_RELAY_URL}')`);
       const { sessionA } = await testConnectMethod(clients);
-      log("Clients connected");
+      log(`Clients connected (relay '${TEST_RELAY_URL}')`);
 
       await Promise.all([
         new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
# Description

We now run the canary against multiple targets and should display that.

## How Has This Been Tested?

Not tested

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
