### PR TITLE
chore: increase canary timeout

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -52,7 +52,7 @@ describe("Canary", () => {
 
       deleteClients(clients);
       log("Clients deleted");
-    }, 20000);
+    }, 60000);
   });
   afterEach(async (done) => {
     const { suite, name, result } = done.meta;


### PR DESCRIPTION
# Description

Canary timeout is too narrow currently. This will get an extra monitor but in some cases the canary succeeds after 40+ seconds.

## How Has This Been Tested?

Tested locally.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
