### PR TITLE
feat: connect in batches

### DIFF
--- a/packages/sign-client/test/concurrency/concurrency.spec.ts
+++ b/packages/sign-client/test/concurrency/concurrency.spec.ts
@@ -109,23 +109,25 @@ describe("Sign Client Concurrency", () => {
     // init clients and pair
     // we connect 10 clients at a time
     for await (const batch of batchArray(Array.from(Array(clientPairs).keys()), 10)) {
-      await Promise.all(batch.map((i) => {
-        return new Promise<void>(async (resolve) => {
-          const timeout = setTimeout(() => {
-            log(`Client ${i} hung up`);
-            resolve();
-          }, 10_000);
+      await Promise.all(
+        batch.map((i) => {
+          return new Promise<void>(async (resolve) => {
+            const timeout = setTimeout(() => {
+              log(`Client ${i} hung up`);
+              resolve();
+            }, 10_000);
 
-          const clients: Clients = await initTwoClients({ relayUrl });
-          await throttle(10);
-          expect(clients.A instanceof SignClient).to.eql(true);
-          expect(clients.B instanceof SignClient).to.eql(true);
-          const { sessionA } = await testConnectMethod(clients);
-          pairings.push({ clients, sessionA });
-          clearTimeout(timeout);
-          resolve();
-        });
-      }));
+            const clients: Clients = await initTwoClients({ relayUrl });
+            await throttle(10);
+            expect(clients.A instanceof SignClient).to.eql(true);
+            expect(clients.B instanceof SignClient).to.eql(true);
+            const { sessionA } = await testConnectMethod(clients);
+            pairings.push({ clients, sessionA });
+            clearTimeout(timeout);
+            resolve();
+          });
+        }),
+      );
     }
 
     // process all messages between clients in parallel

--- a/packages/sign-client/test/shared/connect.ts
+++ b/packages/sign-client/test/shared/connect.ts
@@ -151,10 +151,10 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
 }
 
 export function batchArray(array: any[], size: number) {
-  let result: any[] = []
+  let result: any[] = [];
   for (let i = 0; i < array.length; i += size) {
-    let batch: any = array.slice(i, i + size)
-    result.push(batch)
+    let batch: any = array.slice(i, i + size);
+    result.push(batch);
   }
-  return result
+  return result;
 }

--- a/packages/sign-client/test/shared/connect.ts
+++ b/packages/sign-client/test/shared/connect.ts
@@ -149,3 +149,12 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
 
   return { pairingA, sessionA };
 }
+
+export function batchArray(array: any[], size: number) {
+  let result: any[] = []
+  for (let i = 0; i < array.length; i += size) {
+    let batch: any = array.slice(i, i + size)
+    result.push(batch)
+  }
+  return result
+}


### PR DESCRIPTION
# Description

Currently it takes too long to connect clients. In our load test we want to achieve ~500k connected clients. This speeds this up by ~10x.

Towards https://github.com/WalletConnect/rs-relay/issues/153

## How Has This Been Tested?

Tested locally.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
