### PR TITLE
feat: extend more time to connect

### DIFF
--- a/packages/sign-client/test/concurrency/concurrency.spec.ts
+++ b/packages/sign-client/test/concurrency/concurrency.spec.ts
@@ -115,7 +115,7 @@ describe("Sign Client Concurrency", () => {
             const timeout = setTimeout(() => {
               log(`Client ${i} hung up`);
               resolve();
-            }, 10_000);
+            }, 60_000);
 
             const clients: Clients = await initTwoClients({ relayUrl });
             await throttle(10);


### PR DESCRIPTION
# Description

Allows more time to connect.

I see messages like `Client 2166 hung up` when running the load test

Towards https://github.com/WalletConnect/rs-relay/issues/153

## How Has This Been Tested?

Not tested

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
