### PR TITLE
fix: not filtering out unsuccessful values

### DIFF
--- a/packages/sign-client/test/concurrency/concurrency.spec.ts
+++ b/packages/sign-client/test/concurrency/concurrency.spec.ts
@@ -145,7 +145,7 @@ describe("Sign Client Concurrency", () => {
           })
           .filter(
             (i: { handshakeLatencyMs: number; pairingLatencyMs: number }) =>
-              i.handshakeLatencyMs !== -1,
+              i.handshakeLatencyMs !== -1 && i.pairingLatencyMs !== -1,
           ),
       );
       const averagePairingLatency =

--- a/packages/sign-client/test/concurrency/concurrency.spec.ts
+++ b/packages/sign-client/test/concurrency/concurrency.spec.ts
@@ -123,8 +123,8 @@ describe("Sign Client Concurrency", () => {
               async (resolve) => {
                 const timeout = setTimeout(() => {
                   log(`Client ${i} hung up`);
-                  resolve({ handshakeLatencyMs: 0, pairingLatencyMs: 0 });
-                }, 90_000);
+                  resolve({ handshakeLatencyMs: -1, pairingLatencyMs: -1 });
+                }, 120_000);
 
                 const now = new Date().getTime();
                 const clients: Clients = await initTwoClients({ relayUrl });


### PR DESCRIPTION
# Description

We are filtering against `-1` not `0`

Towards https://github.com/WalletConnect/rs-relay/issues/153

## How Has This Been Tested?

Tested locally

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
