### PR TITLE
fix(test): fixes separate clients using same persistent DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ zip
 tsconfig.tsbuildinfo
 test.db
 test.db-journal
+client_a.db
+client_a.db-journal
+client_b.db
+client_b.db-journal
 setup
 result*
 ops/grafana/grafana.ini

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -22,7 +22,7 @@
     "build:types": "tsc",
     "build:source": "rollup --config rollup.config.js",
     "build": "npm run build:pre; npm run build:source; npm run build:types",
-    "test:pre": "rm -rf ./test/test.db",
+    "test:pre": "rm -rf ./test/client_a.db ./test/client_b.db",
     "test:run": "vitest run --dir test/sdk",
     "test:concurrency": "vitest run --dir test/concurrency",
     "test": "npm run test:pre; npm run test:run",

--- a/packages/sign-client/test/concurrency/concurrency.spec.ts
+++ b/packages/sign-client/test/concurrency/concurrency.spec.ts
@@ -127,7 +127,7 @@ describe("Sign Client Concurrency", () => {
                 }, 120_000);
 
                 const now = new Date().getTime();
-                const clients: Clients = await initTwoClients({ relayUrl });
+                const clients: Clients = await initTwoClients({}, {}, { relayUrl });
                 const handshakeLatencyMs = new Date().getTime() - now;
                 await throttle(10);
                 expect(clients.A instanceof SignClient).to.eql(true);

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -9,7 +9,8 @@ import {
 } from "../shared";
 import { SEVEN_DAYS } from "@walletconnect/time";
 
-const TEST_SIGN_CLIENT_DATABASE = "./test.db";
+const TEST_SIGN_CLIENT_A_DATABASE = "./test/client_a.db";
+const TEST_SIGN_CLIENT_B_DATABASE = "./test/client_b.db";
 
 describe("Sign Client Integration", () => {
   it("init", async () => {
@@ -98,9 +99,15 @@ describe("Sign Client Integration", () => {
         deleteClients(clients);
       });
       it("clients can ping each other after restart", async () => {
-        const beforeClients = await initTwoClients({
-          storageOptions: { database: TEST_SIGN_CLIENT_DATABASE },
-        });
+        const beforeClients = await initTwoClients(
+          {},
+          {
+            storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
+          },
+          {
+            storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
+          },
+        );
         const {
           pairingA: { topic },
         } = await testConnectMethod(beforeClients);
@@ -110,9 +117,15 @@ describe("Sign Client Integration", () => {
         // delete
         deleteClients(beforeClients);
         // restart
-        const afterClients = await initTwoClients({
-          storageOptions: { database: TEST_SIGN_CLIENT_DATABASE },
-        });
+        const afterClients = await initTwoClients(
+          {},
+          {
+            storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
+          },
+          {
+            storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
+          },
+        );
         // ping
         await afterClients.A.ping({ topic });
         await afterClients.B.ping({ topic });
@@ -137,9 +150,15 @@ describe("Sign Client Integration", () => {
         deleteClients(clients);
       });
       it("clients can ping each other after restart", async () => {
-        const beforeClients = await initTwoClients({
-          storageOptions: { database: TEST_SIGN_CLIENT_DATABASE },
-        });
+        const beforeClients = await initTwoClients(
+          {},
+          {
+            storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
+          },
+          {
+            storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
+          },
+        );
         const {
           sessionA: { topic },
         } = await testConnectMethod(beforeClients);
@@ -149,9 +168,15 @@ describe("Sign Client Integration", () => {
         // delete
         deleteClients(beforeClients);
         // restart
-        const afterClients = await initTwoClients({
-          storageOptions: { database: TEST_SIGN_CLIENT_DATABASE },
-        });
+        const afterClients = await initTwoClients(
+          {},
+          {
+            storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
+          },
+          {
+            storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
+          },
+        );
         // ping
         await afterClients.A.ping({ topic });
         await afterClients.B.ping({ topic });

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -100,7 +100,6 @@ describe("Sign Client Integration", () => {
       });
       it("clients can ping each other after restart", async () => {
         const beforeClients = await initTwoClients(
-          {},
           {
             storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
           },
@@ -118,7 +117,6 @@ describe("Sign Client Integration", () => {
         deleteClients(beforeClients);
         // restart
         const afterClients = await initTwoClients(
-          {},
           {
             storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
           },
@@ -151,7 +149,6 @@ describe("Sign Client Integration", () => {
       });
       it("clients can ping each other after restart", async () => {
         const beforeClients = await initTwoClients(
-          {},
           {
             storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
           },
@@ -169,7 +166,6 @@ describe("Sign Client Integration", () => {
         deleteClients(beforeClients);
         // restart
         const afterClients = await initTwoClients(
-          {},
           {
             storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
           },

--- a/packages/sign-client/test/shared/init.ts
+++ b/packages/sign-client/test/shared/init.ts
@@ -8,19 +8,19 @@ export interface Clients {
 }
 
 export async function initTwoClients(
-  clientOpts: SignClientTypes.Options = {},
-  overrideOptionsA: SignClientTypes.Options = {},
-  overrideOptionsB: SignClientTypes.Options = {},
+  clientOptsA: SignClientTypes.Options = {},
+  clientOptsB: SignClientTypes.Options = {},
+  sharedClientOpts: SignClientTypes.Options = {},
 ) {
   const A = await SignClient.init({
     ...TEST_SIGN_CLIENT_OPTIONS_A,
-    ...clientOpts,
-    ...overrideOptionsA,
+    ...sharedClientOpts,
+    ...clientOptsA,
   });
   const B = await SignClient.init({
     ...TEST_SIGN_CLIENT_OPTIONS_B,
-    ...clientOpts,
-    ...overrideOptionsB,
+    ...sharedClientOpts,
+    ...clientOptsB,
   });
   return { A, B };
 }

--- a/packages/sign-client/test/shared/init.ts
+++ b/packages/sign-client/test/shared/init.ts
@@ -7,8 +7,20 @@ export interface Clients {
   B: SignClient;
 }
 
-export async function initTwoClients(clientOpts: SignClientTypes.Options = {}) {
-  const A = await SignClient.init({ ...TEST_SIGN_CLIENT_OPTIONS_A, ...clientOpts });
-  const B = await SignClient.init({ ...TEST_SIGN_CLIENT_OPTIONS_B, ...clientOpts });
+export async function initTwoClients(
+  clientOpts: SignClientTypes.Options = {},
+  overrideOptionsA: SignClientTypes.Options = {},
+  overrideOptionsB: SignClientTypes.Options = {},
+) {
+  const A = await SignClient.init({
+    ...TEST_SIGN_CLIENT_OPTIONS_A,
+    ...clientOpts,
+    ...overrideOptionsA,
+  });
+  const B = await SignClient.init({
+    ...TEST_SIGN_CLIENT_OPTIONS_B,
+    ...clientOpts,
+    ...overrideOptionsB,
+  });
   return { A, B };
 }


### PR DESCRIPTION
# Description

- Ensures test clients are initialized with their own respective sqlite DBs when the relevant `storageOption` is passed.
- Also: fixes `test:pre` script not cleaning up test DBs as expected (creation and deletion paths were different)

### Context

@ennmichael discovered the following while running the sign-client tests against `rs-relay`:

> The `clients can ping each other after restart` test does in fact generate the same client IDs for client A and client B. The root cause of the issue is that `getClientSeed` returns the same value for both of them. 

- Since both clientA and clientB are initialised to use the same `test.db` reference and the key for the client seed is simply `"client_ed25519_seed"` (no namespacing), this resulted in both clients `get`'ing the same seed [here](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/packages/core/src/controllers/crypto.ts#L146) between them once one had been generated.



## How Has This Been Tested?

- Tested locally against rs-relay via `TEST_RELAY_URL=ws://127.0.0.1:8080 yarn test`

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
