### PR TITLE
chore: log runtime

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -62,7 +62,7 @@ describe("Canary", () => {
     const nowTimestamp = Date.now();
     const latencyMs = nowTimestamp - (result?.startTime || nowTimestamp);
     const successful = result?.state === "pass";
-    log(`Canary finished in state ${result?.state} took ${latencyMs}ms`)
+    log(`Canary finished in state ${result?.state} took ${latencyMs}ms`);
     await uploadCanaryResultsToCloudWatch(
       environment,
       TEST_RELAY_URL,

--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -60,12 +60,15 @@ describe("Canary", () => {
     const { suite, name, result } = done.meta;
     const metric_prefix = `${suite.name}.${name}`;
     const nowTimestamp = Date.now();
+    const latencyMs = nowTimestamp - (result?.startTime || nowTimestamp);
+    const successful = result?.state === "pass";
+    log(`Canary finished in state ${result?.state} took ${latencyMs}ms`)
     await uploadCanaryResultsToCloudWatch(
       environment,
       TEST_RELAY_URL,
       metric_prefix,
-      result?.state === "pass",
-      nowTimestamp - (result?.startTime || nowTimestamp),
+      successful,
+      latencyMs,
     );
   });
 });


### PR DESCRIPTION
# Description

We need to identify outliers of slow canary runs to investigate further.

Towards https://github.com/WalletConnect/rs-relay/issues/153

## How Has This Been Tested?

Not tested

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
