### PR TITLE
feat(canary): log client id

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -23,7 +23,9 @@ describe("Canary", () => {
       log(`Clients initialized (relay '${TEST_RELAY_URL}')`);
       const { pairingA, sessionA } = await testConnectMethod(clients);
       log(
-        `Clients connected (relay '${TEST_RELAY_URL}', pairing topic '${pairingA.topic}', session topic '${sessionA.topic}')`,
+        `Clients connected (relay '${TEST_RELAY_URL}', client ids: A:'${await clients.A.core.crypto.getClientId()}';B:'${await clients.B.core.crypto.getClientId()}' pairing topic '${
+          pairingA.topic
+        }', session topic '${sessionA.topic}')`,
       );
 
       await Promise.all([


### PR DESCRIPTION
# Description

It helps to know the client id during investigations. Thus far we've tried to infer it but this is better.

Towards #153

## How Has This Been Tested?

Tested locally

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
