### PR TITLE
fix(engine): avoids race condition when deleting pairing/session

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -353,8 +353,9 @@ export class Engine extends IEngine {
 
   private deleteSession: EnginePrivate["deleteSession"] = async (topic) => {
     const { self } = this.client.session.get(topic);
+    // Await the unsubscribe first to avoid deleting the symKey too early below.
+    await this.client.core.relayer.unsubscribe(topic);
     await Promise.all([
-      this.client.core.relayer.unsubscribe(topic),
       this.client.session.delete(topic, getSdkError("USER_DISCONNECTED")),
       this.client.core.crypto.deleteKeyPair(self.publicKey),
       this.client.core.crypto.deleteSymKey(topic),
@@ -363,8 +364,9 @@ export class Engine extends IEngine {
   };
 
   private deletePairing: EnginePrivate["deleteSession"] = async (topic) => {
+    // Await the unsubscribe first to avoid deleting the symKey too early below.
+    await this.client.core.relayer.unsubscribe(topic);
     await Promise.all([
-      this.client.core.relayer.unsubscribe(topic),
       this.client.pairing.delete(topic, getSdkError("USER_DISCONNECTED")),
       this.client.core.crypto.deleteSymKey(topic),
       this.client.expirer.del(topic),


### PR DESCRIPTION
# Description

- Ensure `relayer.unsubscribe` is awaited on delete, before performing further cleanup actions.
- Part of https://github.com/WalletConnect/rs-relay/issues/322
- Fixes #1386 

## Context

- Running the sign-client against rs-relay uncovered that it is possible for `crypto.deleteSymKey` to be called before the invoking client receives the JSON-RPC result from its peer.
- In this scenario, the lower-level `decode` call for the JSON-RPC result failed on the client invoking the delete, because the symKey required for decoding had already been deleted.

## How Has This Been Tested?

- Did multiple test runs against rs-relay locally: `TEST_PROJECT_ID=e899c82be21d4acca2c8aec45e893598 TEST_RELAY_URL=wss://staging.rust-relay.walletconnect.com yarn test`
- Should pass on CI now without errors.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
