### PR TITLE
fix(engine): ensure requesting client sets own record pre `sendRequest`

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -398,8 +398,8 @@ export class Engine extends IEngine {
     const payload = formatJsonRpcRequest(method, params);
     const message = await this.client.core.crypto.encode(topic, payload);
     const opts = ENGINE_RPC_OPTS[method].req;
-    await this.client.core.relayer.publish(topic, message, opts);
     this.client.history.set(topic, payload);
+    await this.client.core.relayer.publish(topic, message, opts);
 
     return payload.id;
   };


### PR DESCRIPTION

# Description

* Fixes race condition in setting of JSON-RPC history records in engine.
* Part of https://github.com/WalletConnect/rs-relay/issues/322

## Context

* Scenario: clientA sends `wc_pairingPing` to clientB
* clientA was setting the history record _after_ it sent a JSON-RPC request to its peer rather than before.
* rs-relay seems to sometimes process the full request-response so much faster that clientB had responded before the record for its own request had even been set by clientA.
* This caused the "no record in history" error when the response from clientB came back and `onRelayEventResponse > this.client.history.get(...)` was called.


## How Has This Been Tested?

- Verified that race condition no longer appears locally by doing 10-15 runs.
- CI runs in `rs-relay` against fix with additional logging: https://github.com/WalletConnect/rs-relay/runs/8211851657?check_suite_focus=true

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
