### PR TITLE
fix(tests): ensures expected test env vars are passed to Relayer

### DIFF
--- a/packages/core/test/publisher.spec.ts
+++ b/packages/core/test/publisher.spec.ts
@@ -19,7 +19,12 @@ describe("Publisher", () => {
   beforeEach(async () => {
     const core = new Core(TEST_CORE_OPTIONS);
     await core.start();
-    relayer = new Relayer({ core, logger });
+    relayer = new Relayer({
+      core,
+      logger,
+      relayUrl: TEST_CORE_OPTIONS.relayUrl,
+      projectId: TEST_CORE_OPTIONS.projectId,
+    });
     await relayer.init();
     publisher = new Publisher(relayer, logger);
   });

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -25,7 +25,12 @@ describe("Relayer", () => {
   beforeEach(async () => {
     core = new Core(TEST_CORE_OPTIONS);
     await core.start();
-    relayer = new Relayer({ core, logger });
+    relayer = new Relayer({
+      core,
+      logger,
+      relayUrl: TEST_CORE_OPTIONS.relayUrl,
+      projectId: TEST_CORE_OPTIONS.projectId,
+    });
   });
 
   describe("init", () => {

--- a/packages/core/test/subscriber.spec.ts
+++ b/packages/core/test/subscriber.spec.ts
@@ -26,7 +26,12 @@ describe("Subscriber", () => {
   beforeEach(async () => {
     const core = new Core(TEST_CORE_OPTIONS);
     await core.start();
-    relayer = new Relayer({ core, logger });
+    relayer = new Relayer({
+      core,
+      logger,
+      relayUrl: TEST_CORE_OPTIONS.relayUrl,
+      projectId: TEST_CORE_OPTIONS.projectId,
+    });
     await relayer.init();
     subscriber = new Subscriber(relayer, logger);
     subscriber.relayer.provider.request = () => Promise.resolve({} as any);


### PR DESCRIPTION
# Description

* These tests seemingly broke after rs-relay went live on prod, unrelated to any code changes.
* Turns out that the way `Relayer` was being instantiated in tests, it didn't receive any of the provided env vars and defaulted to `relay.walletconnect.com` without a `projectId`, which broke once rs-relay went live 🙃 

## How Has This Been Tested?

- Validated locally
- Will run in CI on this PR

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
