### PR TITLE
feat(canary): depict region

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -10,6 +10,7 @@ import { TEST_RELAY_URL } from "./../shared/values";
 import { describe, it, expect, afterEach } from "vitest";
 
 const environment = process.env.ENVIRONMENT || "dev";
+const region = process.env.REGION || "unknown";
 
 const log = (log: string) => {
   // eslint-disable-next-line no-console
@@ -67,6 +68,7 @@ describe("Canary", () => {
     log(`Canary finished in state ${result?.state} took ${latencyMs}ms`);
     await uploadCanaryResultsToCloudWatch(
       environment,
+      region,
       TEST_RELAY_URL,
       metric_prefix,
       successful,

--- a/packages/sign-client/test/shared/metrics.ts
+++ b/packages/sign-client/test/shared/metrics.ts
@@ -2,6 +2,7 @@ import CloudWatch from "aws-sdk/clients/cloudwatch";
 
 export const uploadCanaryResultsToCloudWatch = async (
   env: string,
+  region: string,
   target: string,
   metricsPrefix: string,
   isTestPassed: boolean,
@@ -19,6 +20,10 @@ export const uploadCanaryResultsToCloudWatch = async (
             Name: "Target",
             Value: target,
           },
+          {
+            Name: "Region",
+            Value: region,
+          },
         ],
         Unit: "Count",
         Value: isTestPassed ? 1 : 0,
@@ -31,6 +36,10 @@ export const uploadCanaryResultsToCloudWatch = async (
             Name: "Target",
             Value: target,
           },
+          {
+            Name: "Region",
+            Value: region,
+          },
         ],
         Unit: "Count",
         Value: isTestPassed ? 0 : 1,
@@ -42,6 +51,10 @@ export const uploadCanaryResultsToCloudWatch = async (
           {
             Name: "Target",
             Value: target,
+          },
+          {
+            Name: "Region",
+            Value: region,
           },
         ],
         Unit: "Milliseconds",


### PR DESCRIPTION
# Description

We are regionalizing the sign backend and want to use the canary as a baseline to get a rough understanding of what customer's latency is from different regions.

## How Has This Been Tested?

Ran prettier

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
