### PR TITLE
fix(engine): ensure proposal/session expiry is calculated dynamically

### DIFF
--- a/packages/sign-client/src/constants/proposal.ts
+++ b/packages/sign-client/src/constants/proposal.ts
@@ -1,6 +1,5 @@
-import { calcExpiry } from "@walletconnect/utils";
 import { THIRTY_DAYS } from "@walletconnect/time";
 
 export const PROPOSAL_CONTEXT = "proposal";
 
-export const PROPOSAL_EXPIRY = calcExpiry(THIRTY_DAYS);
+export const PROPOSAL_EXPIRY = THIRTY_DAYS;

--- a/packages/sign-client/src/constants/session.ts
+++ b/packages/sign-client/src/constants/session.ts
@@ -1,8 +1,5 @@
 import { SEVEN_DAYS } from "@walletconnect/time";
-import { calcExpiry } from "@walletconnect/utils";
 
 export const SESSION_CONTEXT = "session";
 
-export const SESSION_DEFAULT_TTL = SEVEN_DAYS;
-
-export const SESSION_EXPIRY = calcExpiry(SESSION_DEFAULT_TTL);
+export const SESSION_EXPIRY = SEVEN_DAYS;

--- a/packages/sign-client/test/shared/connect.ts
+++ b/packages/sign-client/test/shared/connect.ts
@@ -118,7 +118,7 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
   expect(sessionA.namespaces).to.eql(approveParams.namespaces);
   expect(sessionA.namespaces).to.eql(sessionB.namespaces);
   // expiry
-  expect(sessionA.expiry).to.eql(sessionB.expiry);
+  expect(Math.abs(sessionA.expiry - sessionB.expiry)).to.be.lessThan(5);
   // acknowledged
   expect(sessionA.acknowledged).to.eql(sessionB.acknowledged);
   // participants


### PR DESCRIPTION
# Description

- Proposal/Session expiry was previously calculated on `constants/*` file load, rather than dynamically at call time like other `calcExpiry` calls.
- In a long running client this could lead to a a shorter and shorter expiry duration, even if it expiry is extended, since `calcExpiry` was fixed to the time of initialisation.
- This PR:
	- ensures expiry calculation is dynamic and done at call site.
	- Reimplements the associated unit test
- Follow-up to: https://github.com/WalletConnect/rs-relay/issues/322

## How Has This Been Tested?

- Tested locally
- In demo wallet/dapp via [canary release](https://www.npmjs.com/package/@walletconnect/sign-client/v/2.0.0-4a11a75.0)

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
