### PR TITLE
feat: don't export metrics in dev

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -62,6 +62,7 @@ describe("Canary", () => {
     }, 240_000);
   });
   afterEach(async (done) => {
+    if (environment === 'dev') return;
     const { suite, name, result } = done.meta;
     const metric_prefix = `${suite.name}.${name}`;
     const nowTimestamp = Date.now();

--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -62,7 +62,7 @@ describe("Canary", () => {
     }, 240_000);
   });
   afterEach(async (done) => {
-    if (environment === 'dev') return;
+    if (environment === "dev") return;
     const { suite, name, result } = done.meta;
     const metric_prefix = `${suite.name}.${name}`;
     const nowTimestamp = Date.now();


### PR DESCRIPTION
# Description

We don't run the canary in dev and hence don't need the cloudwatch export which barfs locally.

## How Has This Been Tested?

Tested locally.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
