### PR TITLE
Set build target to ES2020

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,9 @@
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
-    "lib": ["ESNext", "DOM"],
-    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "module": "ES2020",
+    "target": "ES2020",
     "moduleResolution": "Node",
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
@@ -31,8 +32,7 @@
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "target": "ESNext"
+    "suppressImplicitAnyIndexErrors": true
   },
   "include": ["**/package.json", "packages", "providers"]
 }


### PR DESCRIPTION
# Description

We are currently targeting `ESNext` as our build target, which is probably not a good idea. This has been changed to target `ES2020` according to platforms we target and their compatibility with feature set in this spec of js, for more info see https://kangax.github.io/compat-table/es2016plus/

## How Has This Been Tested?
Ran build with target versions set to `ES2015` and `ES2020` to confirm that esbuild is correctly picking these settings up from tsconfig at the root (compared output files and they were indeed different, with 2015 version having bigger size as expected). Final build was set to `ES2020` and is passing.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
