### PR TITLE
feat(canary): run against multiple regions

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -62,6 +62,7 @@ describe("Canary", () => {
     }, 240_000);
   });
   afterEach(async (done) => {
+    if (environment === 'dev') return;
     const { suite, name, result } = done.meta;
     const metric_prefix = `${suite.name}.${name}`;
     const nowTimestamp = Date.now();


### PR DESCRIPTION
# Description

We now expose the relay in multiple regions via region specific endpoints. We should run the canary against these endpoints to capture latency and ensure they are working.

Resolves https://github.com/WalletConnect/rs-relay/issues/436

## How Has This Been Tested?

Tested locally

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
