### PR TITLE
feat: introduce qr code scan time

### DIFF
--- a/packages/sign-client/test/shared/connect.ts
+++ b/packages/sign-client/test/shared/connect.ts
@@ -59,7 +59,10 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
   let pairingB: PairingTypes.Struct | undefined;
 
   if (!connectParams.pairingTopic) {
+    // This is a new pairing. Let's apply a timeout to mimick
+    // QR code scanning
     if (!uri) throw new Error("uri is missing");
+    if (params?.qrCodeScanLatencyMs) await throttle(params?.qrCodeScanLatencyMs);
 
     const uriParams = parseUri(uri);
 
@@ -67,9 +70,6 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
     expect(pairingA.topic).to.eql(uriParams.topic);
     expect(pairingA.relay).to.eql(uriParams.relay);
   } else {
-    // This is a new pairing. Let's apply a timeout to mimick
-    // QR code scanning
-    if (params?.qrCodeScanLatencyMs) await throttle(params?.qrCodeScanLatencyMs);
     pairingA = A.pairing.get(connectParams.pairingTopic);
     pairingB = B.pairing.get(connectParams.pairingTopic);
   }

--- a/packages/sign-client/test/shared/connect.ts
+++ b/packages/sign-client/test/shared/connect.ts
@@ -6,6 +6,7 @@ import {
   ProposalTypes,
   SessionTypes,
 } from "@walletconnect/types";
+import { throttle } from "./../shared";
 import { TEST_RELAY_OPTIONS, TEST_NAMESPACES, TEST_REQUIRED_NAMESPACES } from "./values";
 import { Clients } from "./init";
 import { expect } from "vitest";
@@ -15,6 +16,7 @@ export interface TestConnectParams {
   namespaces?: SessionTypes.Namespaces;
   relays?: RelayerTypes.ProtocolOptions[];
   pairingTopic?: string;
+  qrCodeScanLatencyMs?: number;
 }
 
 export async function testConnectMethod(clients: Clients, params?: TestConnectParams) {
@@ -65,6 +67,9 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
     expect(pairingA.topic).to.eql(uriParams.topic);
     expect(pairingA.relay).to.eql(uriParams.relay);
   } else {
+    // This is a new pairing. Let's apply a timeout to mimick
+    // QR code scanning
+    if (params?.qrCodeScanLatencyMs) await throttle(params?.qrCodeScanLatencyMs);
     pairingA = A.pairing.get(connectParams.pairingTopic);
     pairingB = B.pairing.get(connectParams.pairingTopic);
   }


### PR DESCRIPTION
# Description

Users need time to scan the QR code. This should be reflected in the Canary to get a more realistic view into latency (allow the system to replicate).

Resolves https://github.com/WalletConnect/rs-relay/issues/440

## How Has This Been Tested?

Tested locally

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
