### PR TITLE
feat(canary): granular latency metrics

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -54,7 +54,7 @@ describe("Canary", () => {
       const successful = true;
       const pairingLatency = latencyMs - qrCodeScanLatencyMs;
       console.log(`Clients paired after ${pairingLatency}ms`);
-      if (environment !== "hello") {
+      if (environment !== "dev") {
         await uploadCanaryResultsToCloudWatch(
           environment,
           region,

--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -54,7 +54,7 @@ describe("Canary", () => {
       const successful = true;
       const pairingLatency = latencyMs - qrCodeScanLatencyMs;
       console.log(`Clients paired after ${pairingLatency}ms`);
-      if (environment !== "dev") {
+      if (environment !== "hello") {
         await uploadCanaryResultsToCloudWatch(
           environment,
           region,

--- a/packages/sign-client/test/shared/connect.ts
+++ b/packages/sign-client/test/shared/connect.ts
@@ -20,6 +20,7 @@ export interface TestConnectParams {
 }
 
 export async function testConnectMethod(clients: Clients, params?: TestConnectParams) {
+  const start = Date.now();
   const { A, B } = clients;
 
   const connectParams: EngineTypes.ConnectParams = {
@@ -54,6 +55,7 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
   });
 
   const { uri, approval } = await A.connect(connectParams);
+  const clientAConnectLatencyMs = Date.now() - start;
 
   let pairingA: PairingTypes.Struct | undefined;
   let pairingB: PairingTypes.Struct | undefined;
@@ -111,6 +113,8 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
     }),
   ]);
 
+  const settlePairingLatencyMs = Date.now() - start;
+
   if (!sessionA) throw new Error("expect session A to be defined");
   if (!sessionB) throw new Error("expect session B to be defined");
 
@@ -156,7 +160,7 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
   expect(pairingA.peerMetadata).to.eql(sessionA.peer.metadata);
   expect(pairingB.peerMetadata).to.eql(sessionB.peer.metadata);
 
-  return { pairingA, sessionA };
+  return { pairingA, sessionA, clientAConnectLatencyMs, settlePairingLatencyMs };
 }
 
 export function batchArray(array: any[], size: number) {

--- a/packages/sign-client/test/shared/connect.ts
+++ b/packages/sign-client/test/shared/connect.ts
@@ -113,7 +113,7 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
     }),
   ]);
 
-  const settlePairingLatencyMs = Date.now() - start;
+  const settlePairingLatencyMs = Date.now() - start - (params?.qrCodeScanLatencyMs || 0);
 
   if (!sessionA) throw new Error("expect session A to be defined");
   if (!sessionB) throw new Error("expect session B to be defined");

--- a/packages/sign-client/test/shared/connect.ts
+++ b/packages/sign-client/test/shared/connect.ts
@@ -70,6 +70,9 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
     expect(pairingA.topic).to.eql(uriParams.topic);
     expect(pairingA.relay).to.eql(uriParams.relay);
   } else {
+    // This is a new pairing. Let's apply a timeout to mimick
+    // QR code scanning
+    if (params?.qrCodeScanLatencyMs) await throttle(params?.qrCodeScanLatencyMs);
     pairingA = A.pairing.get(connectParams.pairingTopic);
     pairingB = B.pairing.get(connectParams.pairingTopic);
   }

--- a/packages/sign-client/test/shared/connect.ts
+++ b/packages/sign-client/test/shared/connect.ts
@@ -70,9 +70,6 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
     expect(pairingA.topic).to.eql(uriParams.topic);
     expect(pairingA.relay).to.eql(uriParams.relay);
   } else {
-    // This is a new pairing. Let's apply a timeout to mimick
-    // QR code scanning
-    if (params?.qrCodeScanLatencyMs) await throttle(params?.qrCodeScanLatencyMs);
     pairingA = A.pairing.get(connectParams.pairingTopic);
     pairingB = B.pairing.get(connectParams.pairingTopic);
   }

--- a/packages/sign-client/test/shared/metrics.ts
+++ b/packages/sign-client/test/shared/metrics.ts
@@ -62,7 +62,8 @@ export const uploadCanaryResultsToCloudWatch = async (
     },
   ];
 
-  const latencies = Object.keys(otherLatencies).map((metricName) => {
+  const latencies = otherLatencies.map((metric) => {
+    const metricName = Object.keys(metric)[0];
     return {
       MetricName: `${metricsPrefix}.${metricName}`,
       Dimensions: [
@@ -76,7 +77,7 @@ export const uploadCanaryResultsToCloudWatch = async (
         },
       ],
       Unit: "Milliseconds",
-      Value: otherLatencies[metricName],
+      Value: metric[metricName],
       Timestamp: ts,
     };
   });


### PR DESCRIPTION
# Description

Exposes additional latency insights around the pairing flow.

## How Has This Been Tested?

Tested locally and built into the sign client image.

<img width="1256" alt="Screen Shot 2022-09-15 at 1 22 41 PM" src="https://user-images.githubusercontent.com/966091/190391459-bab9a80c-4ea6-4932-a66a-afe2a2cd8c34.png">

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
