### PR TITLE
test: adds `test:ignoreUnhandled` script to unblock rs-relay pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "prettier": "npm run prettier --workspaces --if-present",
     "build": "npm run build --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
+    "test:ignoreUnhandled": "npm run test:ignoreUnhandled --workspaces --if-present",
     "check": "npm run lint; npm run build; npm run test",
     "reset": "npm run clean; npm run check",
     "new-version": "lerna version --no-git-tag-version --exact",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "test:pre": "rm -rf ./test/test.db",
     "test:run": "vitest run --dir test",
     "test": "npm run test:pre; npm run test:run",
+    "test:ignoreUnhandled": "npm run test:pre; npm run test:run -- --dangerouslyIgnoreUnhandledErrors",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -26,6 +26,7 @@
     "test:run": "vitest run --dir test/sdk",
     "test:concurrency": "vitest run --dir test/concurrency",
     "test": "npm run test:pre; npm run test:run",
+    "test:ignoreUnhandled": "npm run test:pre; npm run test:run -- --dangerouslyIgnoreUnhandledErrors",
     "test:canary": "vitest run --dir test/canary",
     "canary": "npm run test:pre; npm run test:canary",
     "loadtest": "npm run test:pre; npm run test:concurrency",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -25,6 +25,7 @@
     "test:pre": "rm -rf ./test/test.db",
     "test:run": "vitest run --dir test",
     "test": "npm run test:pre; npm run test:run",
+    "test:ignoreUnhandled": "npm run test:pre; npm run test:run -- --dangerouslyIgnoreUnhandledErrors",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },

--- a/providers/ethereum-provider/package.json
+++ b/providers/ethereum-provider/package.json
@@ -30,6 +30,7 @@
     "test:pre": "rm -rf ./test/test.db",
     "test:run": "vitest run --dir test",
     "test": "npm run test:pre; npm run test:run",
+    "test:ignoreUnhandled": "npm run test:pre; npm run test:run -- --dangerouslyIgnoreUnhandledErrors",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },

--- a/providers/signer-connection/package.json
+++ b/providers/signer-connection/package.json
@@ -25,6 +25,7 @@
     "test:pre": "rm -rf ./test/test.db",
     "test:run": "vitest run --dir test",
     "test": "npm run test:pre; npm run test:run",
+    "test:ignoreUnhandled": "npm run test:pre; npm run test:run -- --dangerouslyIgnoreUnhandledErrors",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },


### PR DESCRIPTION
# Description

- Adds `test:ignoreUnhandled` script
- This is to unblock automatic deploys for rs-relay failing unnecessarily, but does not resolve the underlying issue/possible leftover race condition around `JsonRpcHistory` we still see only in the rs-relay `validate_js` pipeline: https://github.com/WalletConnect/rs-relay/actions/runs/3073322744/jobs/4965541078#step:4:105
- Once the cause of the unhandled `JsonRpcHistory` error in has been found, we should remove this script again.

## How Has This Been Tested?

- Tested locally

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
