### PR TITLE
feat(canary): timeout connect

### DIFF
--- a/packages/sign-client/test/shared/connect.ts
+++ b/packages/sign-client/test/shared/connect.ts
@@ -54,7 +54,20 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
     });
   });
 
-  const { uri, approval } = await A.connect(connectParams);
+  const connect: Promise<{
+    uri?: string | undefined;
+    approval: () => Promise<SessionTypes.Struct>;
+  }> = new Promise(async function (resolve, reject) {
+    const connectTimeoutMs = 20_000;
+    const timeout = setTimeout(() => {
+      return reject(new Error(`Connect timed out after ${connectTimeoutMs}ms`));
+    }, connectTimeoutMs);
+    const result = await A.connect(connectParams);
+    clearTimeout(timeout);
+    return resolve(result);
+  });
+
+  const { uri, approval } = await connect;
   const clientAConnectLatencyMs = Date.now() - start;
 
   let pairingA: PairingTypes.Struct | undefined;


### PR DESCRIPTION
# Description

Sometimes the `connect` method stalls and then consumes the entire timeout of the test which in the case of the Canary is multiple minutes. This is unnecessary and we can fail it faster.

## How Has This Been Tested?

Tested locally.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
