### PR TITLE
feat: log client ids when tests fail

### DIFF
--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -138,7 +138,6 @@ describe("Sign Client Integration", () => {
         });
         afterEach(async (done) => {
           const { result } = done.meta;
-          console.log("dang", result?.state.toString());
           if (result?.state.toString() !== "pass") {
             console.log(
               `Test ${

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -131,21 +131,36 @@ describe("Sign Client Integration", () => {
       }, 20_000);
     });
     describe("session", () => {
-      it("A pings B with existing session", async () => {
-        const clients = await initTwoClients();
-        const {
-          sessionA: { topic },
-        } = await testConnectMethod(clients);
-        await clients.A.ping({ topic });
-        deleteClients(clients);
-      });
-      it("B pings A with existing session", async () => {
-        const clients = await initTwoClients();
-        const {
-          sessionA: { topic },
-        } = await testConnectMethod(clients);
-        await clients.B.ping({ topic });
-        deleteClients(clients);
+      describe("existing session", () => {
+        let clients;
+        beforeEach(async () => {
+          clients = await initTwoClients();
+        });
+        afterEach(async (done) => {
+          const { result } = done.meta;
+          console.log("dang", result?.state.toString());
+          if (result?.state.toString() !== "pass") {
+            console.log(
+              `Test ${
+                done.meta.name
+              } failed with client ids: A:'${await clients.A.core.crypto.getClientId()}';B:'${await clients.B.core.crypto.getClientId()}'`,
+            );
+          }
+        });
+        it("A pings B with existing session", async () => {
+          const {
+            sessionA: { topic },
+          } = await testConnectMethod(clients);
+          await clients.A.ping({ topic });
+          deleteClients(clients);
+        });
+        it("B pings A with existing session", async () => {
+          const {
+            sessionA: { topic },
+          } = await testConnectMethod(clients);
+          await clients.B.ping({ topic });
+          deleteClients(clients);
+        });
       });
       it("clients can ping each other after restart", async () => {
         const beforeClients = await initTwoClients(


### PR DESCRIPTION
# Description

These tests occasionally fail in the pipeline. In order to allow further debugging, log the client ids

## How Has This Been Tested?

Tested locally

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
