### PR TITLE
feat: log client ids when restart tests fail

### DIFF
--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -112,36 +112,58 @@ describe("Sign Client Integration", () => {
           deleteClients(clients);
         });
       });
-      it("clients can ping each other after restart", async () => {
-        const beforeClients = await initTwoClients(
-          {
-            storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
-          },
-          {
-            storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
-          },
-        );
-        const {
-          pairingA: { topic },
-        } = await testConnectMethod(beforeClients);
-        // ping
-        await beforeClients.A.ping({ topic });
-        await beforeClients.B.ping({ topic });
-        // delete
-        deleteClients(beforeClients);
-        // restart
-        const afterClients = await initTwoClients(
-          {
-            storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
-          },
-          {
-            storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
-          },
-        );
-        // ping
-        await afterClients.A.ping({ topic });
-        await afterClients.B.ping({ topic });
-        deleteClients(afterClients);
+      describe("after restart", () => {
+        let beforeClients;
+        let afterClients;
+        beforeEach(async () => {
+          beforeClients = await initTwoClients(
+            {
+              storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
+            },
+            {
+              storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
+            },
+          );
+        });
+        afterEach(async (done) => {
+          const { result } = done.meta;
+          if (result?.state.toString() !== "pass") {
+            console.log(
+              `Test ${
+                done.meta.name
+              } failed with before client ids: A:'${await beforeClients.A.core.crypto.getClientId()}';B:'${await beforeClients.B.core.crypto.getClientId()}'`,
+            );
+            if (!afterClients) return;
+            console.log(
+              `Test ${
+                done.meta.name
+              } failed with after client ids: A:'${await afterClients.A.core.crypto.getClientId()}';B:'${await afterClients.B.core.crypto.getClientId()}'`,
+            );
+          }
+        });
+        it("clients can ping each other", async () => {
+          const {
+            pairingA: { topic },
+          } = await testConnectMethod(beforeClients);
+          // ping
+          await beforeClients.A.ping({ topic });
+          await beforeClients.B.ping({ topic });
+          // delete
+          deleteClients(beforeClients);
+          // restart
+          afterClients = await initTwoClients(
+            {
+              storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
+            },
+            {
+              storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
+            },
+          );
+          // ping
+          await afterClients.A.ping({ topic });
+          await afterClients.B.ping({ topic });
+          deleteClients(afterClients);
+        });
       });
     });
     describe("session", () => {
@@ -175,36 +197,66 @@ describe("Sign Client Integration", () => {
           deleteClients(clients);
         });
       });
-      it("clients can ping each other after restart", async () => {
-        const beforeClients = await initTwoClients(
-          {
-            storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
-          },
-          {
-            storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
-          },
-        );
-        const {
-          sessionA: { topic },
-        } = await testConnectMethod(beforeClients);
-        // ping
-        await beforeClients.A.ping({ topic });
-        await beforeClients.B.ping({ topic });
-        // delete
-        deleteClients(beforeClients);
-        // restart
-        const afterClients = await initTwoClients(
-          {
-            storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
-          },
-          {
-            storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
-          },
-        );
-        // ping
-        await afterClients.A.ping({ topic });
-        await afterClients.B.ping({ topic });
-        deleteClients(afterClients);
+      describe("after restart", () => {
+        let beforeClients;
+        let afterClients;
+        beforeEach(async () => {
+          beforeClients = await initTwoClients(
+            {
+              storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
+            },
+            {
+              storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
+            },
+          );
+        });
+        afterEach(async (done) => {
+          const { result } = done.meta;
+          if (result?.state.toString() !== "pass") {
+            console.log(
+              `Test ${
+                done.meta.name
+              } failed with before client ids: A:'${await beforeClients.A.core.crypto.getClientId()}';B:'${await beforeClients.B.core.crypto.getClientId()}'`,
+            );
+            if (!afterClients) return;
+            console.log(
+              `Test ${
+                done.meta.name
+              } failed with after client ids: A:'${await afterClients.A.core.crypto.getClientId()}';B:'${await afterClients.B.core.crypto.getClientId()}'`,
+            );
+          }
+        });
+        it("clients can ping each other", async () => {
+          beforeClients = await initTwoClients(
+            {
+              storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
+            },
+            {
+              storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
+            },
+          );
+          const {
+            sessionA: { topic },
+          } = await testConnectMethod(beforeClients);
+          // ping
+          await beforeClients.A.ping({ topic });
+          await beforeClients.B.ping({ topic });
+          // delete
+          deleteClients(beforeClients);
+          // restart
+          afterClients = await initTwoClients(
+            {
+              storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
+            },
+            {
+              storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
+            },
+          );
+          // ping
+          await afterClients.A.ping({ topic });
+          await afterClients.B.ping({ topic });
+          deleteClients(afterClients);
+        });
       });
     });
   });

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -114,7 +114,6 @@ describe("Sign Client Integration", () => {
       });
       describe("after restart", () => {
         let beforeClients;
-        let afterClients;
         beforeEach(async () => {
           beforeClients = await initTwoClients(
             {
@@ -133,12 +132,6 @@ describe("Sign Client Integration", () => {
                 done.meta.name
               } failed with before client ids: A:'${await beforeClients.A.core.crypto.getClientId()}';B:'${await beforeClients.B.core.crypto.getClientId()}'`,
             );
-            if (!afterClients) return;
-            console.log(
-              `Test ${
-                done.meta.name
-              } failed with after client ids: A:'${await afterClients.A.core.crypto.getClientId()}';B:'${await afterClients.B.core.crypto.getClientId()}'`,
-            );
           }
         });
         it("clients can ping each other", async () => {
@@ -151,7 +144,7 @@ describe("Sign Client Integration", () => {
           // delete
           deleteClients(beforeClients);
           // restart
-          afterClients = await initTwoClients(
+          const afterClients = await initTwoClients(
             {
               storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
             },
@@ -199,7 +192,6 @@ describe("Sign Client Integration", () => {
       });
       describe("after restart", () => {
         let beforeClients;
-        let afterClients;
         beforeEach(async () => {
           beforeClients = await initTwoClients(
             {
@@ -217,12 +209,6 @@ describe("Sign Client Integration", () => {
               `Test ${
                 done.meta.name
               } failed with before client ids: A:'${await beforeClients.A.core.crypto.getClientId()}';B:'${await beforeClients.B.core.crypto.getClientId()}'`,
-            );
-            if (!afterClients) return;
-            console.log(
-              `Test ${
-                done.meta.name
-              } failed with after client ids: A:'${await afterClients.A.core.crypto.getClientId()}';B:'${await afterClients.B.core.crypto.getClientId()}'`,
             );
           }
         });
@@ -244,7 +230,7 @@ describe("Sign Client Integration", () => {
           // delete
           deleteClients(beforeClients);
           // restart
-          afterClients = await initTwoClients(
+          const afterClients = await initTwoClients(
             {
               storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
             },

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -114,6 +114,7 @@ describe("Sign Client Integration", () => {
       });
       describe("after restart", () => {
         let beforeClients;
+        let afterClients;
         beforeEach(async () => {
           beforeClients = await initTwoClients(
             {
@@ -127,10 +128,20 @@ describe("Sign Client Integration", () => {
         afterEach(async (done) => {
           const { result } = done.meta;
           if (result?.state.toString() !== "pass") {
+            if (!beforeClients) {
+              console.log('Clients failed to initialize');
+              return;
+            }
             console.log(
               `Test ${
                 done.meta.name
               } failed with before client ids: A:'${await beforeClients.A.core.crypto.getClientId()}';B:'${await beforeClients.B.core.crypto.getClientId()}'`,
+            );
+            if (!afterClients) return;
+            console.log(
+              `Test ${
+                done.meta.name
+              } failed with after client ids: A:'${await afterClients.A.core.crypto.getClientId()}';B:'${await afterClients.B.core.crypto.getClientId()}'`,
             );
           }
         });
@@ -144,7 +155,7 @@ describe("Sign Client Integration", () => {
           // delete
           deleteClients(beforeClients);
           // restart
-          const afterClients = await initTwoClients(
+          afterClients = await initTwoClients(
             {
               storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
             },
@@ -192,6 +203,7 @@ describe("Sign Client Integration", () => {
       });
       describe("after restart", () => {
         let beforeClients;
+        let afterClients;
         beforeEach(async () => {
           beforeClients = await initTwoClients(
             {
@@ -205,10 +217,20 @@ describe("Sign Client Integration", () => {
         afterEach(async (done) => {
           const { result } = done.meta;
           if (result?.state.toString() !== "pass") {
+            if (!beforeClients) {
+              console.log('Clients failed to initialize');
+              return;
+            }
             console.log(
               `Test ${
                 done.meta.name
               } failed with before client ids: A:'${await beforeClients.A.core.crypto.getClientId()}';B:'${await beforeClients.B.core.crypto.getClientId()}'`,
+            );
+            if (!afterClients) return;
+            console.log(
+              `Test ${
+                done.meta.name
+              } failed with after client ids: A:'${await afterClients.A.core.crypto.getClientId()}';B:'${await afterClients.B.core.crypto.getClientId()}'`,
             );
           }
         });
@@ -230,7 +252,7 @@ describe("Sign Client Integration", () => {
           // delete
           deleteClients(beforeClients);
           // restart
-          const afterClients = await initTwoClients(
+          afterClients = await initTwoClients(
             {
               storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
             },

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -128,7 +128,7 @@ describe("Sign Client Integration", () => {
         afterEach(async (done) => {
           const { result } = done.meta;
           if (result?.state.toString() !== "pass") {
-            if (!beforeClients) {
+            if (!beforeClients || !beforeClients.A || !beforeClients.B) {
               console.log('Clients failed to initialize');
               return;
             }
@@ -137,7 +137,7 @@ describe("Sign Client Integration", () => {
                 done.meta.name
               } failed with before client ids: A:'${await beforeClients.A.core.crypto.getClientId()}';B:'${await beforeClients.B.core.crypto.getClientId()}'`,
             );
-            if (!afterClients) return;
+            if (!afterClients || !afterClients.A || !afterClients.B) return;
             console.log(
               `Test ${
                 done.meta.name
@@ -217,7 +217,7 @@ describe("Sign Client Integration", () => {
         afterEach(async (done) => {
           const { result } = done.meta;
           if (result?.state.toString() !== "pass") {
-            if (!beforeClients) {
+            if (!beforeClients || !beforeClients.A || !beforeClients.B) {
               console.log('Clients failed to initialize');
               return;
             }
@@ -226,7 +226,7 @@ describe("Sign Client Integration", () => {
                 done.meta.name
               } failed with before client ids: A:'${await beforeClients.A.core.crypto.getClientId()}';B:'${await beforeClients.B.core.crypto.getClientId()}'`,
             );
-            if (!afterClients) return;
+            if (!afterClients || !afterClients.A || !afterClients.B) return;
             console.log(
               `Test ${
                 done.meta.name

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -38,9 +38,26 @@ describe("Sign Client Integration", () => {
   });
 
   describe("disconnect", () => {
+    let clients;
+    beforeEach(async () => {
+      clients = await initTwoClients();
+    });
+    afterEach(async (done) => {
+      const { result } = done.meta;
+      if (result?.state.toString() !== "pass") {
+        if (!clients || !clients.A || !clients.B) {
+          console.log("Clients failed to initialize");
+          return;
+        }
+        console.log(
+          `Test ${
+            done.meta.name
+          } failed with client ids: A:'${await clients.A.core.crypto.getClientId()}';B:'${await clients.B.core.crypto.getClientId()}'`,
+        );
+      }
+    });
     describe("pairing", () => {
       it("deletes the pairing on disconnect", async () => {
-        const clients = await initTwoClients();
         const {
           pairingA: { topic },
         } = await testConnectMethod(clients);
@@ -56,7 +73,6 @@ describe("Sign Client Integration", () => {
     });
     describe("session", () => {
       it("deletes the session on disconnect", async () => {
-        const clients = await initTwoClients();
         const {
           sessionA: { topic },
         } = await testConnectMethod(clients);
@@ -129,7 +145,7 @@ describe("Sign Client Integration", () => {
           const { result } = done.meta;
           if (result?.state.toString() !== "pass") {
             if (!beforeClients || !beforeClients.A || !beforeClients.B) {
-              console.log('Clients failed to initialize');
+              console.log("Clients failed to initialize");
               return;
             }
             console.log(
@@ -218,7 +234,7 @@ describe("Sign Client Integration", () => {
           const { result } = done.meta;
           if (result?.state.toString() !== "pass") {
             if (!beforeClients || !beforeClients.A || !beforeClients.B) {
-              console.log('Clients failed to initialize');
+              console.log("Clients failed to initialize");
               return;
             }
             console.log(


### PR DESCRIPTION
# Description

These tests occasionally fail in tests. When they do the tests would print client ids to allow for server-side debugging.

## How Has This Been Tested?

Ran tests locally.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
