### PR TITLE
fix(engine): avoids unwanted expirer deletion attempts post-expiry

### DIFF
--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -164,11 +164,11 @@ export interface EnginePrivate {
 
   activatePairing(topic: string): Promise<void>;
 
-  deleteSession(topic: string): Promise<void>;
+  deleteSession(topic: string, expirerHasDeleted?: boolean): Promise<void>;
 
-  deletePairing(topic: string): Promise<void>;
+  deletePairing(topic: string, expirerHasDeleted?: boolean): Promise<void>;
 
-  deleteProposal(id: number): Promise<void>;
+  deleteProposal(id: number, expirerHasDeleted?: boolean): Promise<void>;
 
   setExpiry(topic: string, expiry: number): Promise<void>;
 


### PR DESCRIPTION
# Description

- Mentioned in (but not cause of) #1364 
- We sometimes see expirer error logging (e.g. `context: "client/expirer" ERROR 'No matching key. expirer: topic:09d4...'`) when a pairing or proposal is being cleaned up on expiry of said proposal/pairing.
- The cause of this is:

1. proposal/pairing/session expiry is detected inside `expirer` via heartbeat checks, **`expirer` deletes the tracked expiry internally immediately**
2. `EXPIRER_EVENTS.expired` gets called in engine and triggers e.g. `deleteProposal`/`deletePairing`/`deleteSession`
3. The delete helper tries to re-delete the already removed expiry via `expirer.del` -> triggering a "key not found" error.

- In cases where the trigger for deletion is not the expirer events (e.g. when `this.deletePairing()` is called explicitly inside the engine) we DO want to explicitly call `expirer.del`
- To disambiguate these two scenarios handled by the delete helpers, I've added the optional `expirerHasDeleted` param.

## How Has This Been Tested?

- Tested locally against example dapp
- Unit tests

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
