### PR TITLE
feat(tests): Add xregion testing for new relayerURLs

### DIFF
--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -25,6 +25,7 @@
     "test:pre": "rm -rf ./test/client_a.db ./test/client_b.db",
     "test:run": "vitest run --dir test/sdk",
     "test:concurrency": "vitest run --dir test/concurrency",
+    "test:xregion": "vitest run --dir test/xregion",
     "test": "npm run test:pre; npm run test:run",
     "test:ignoreUnhandled": "npm run test:pre; npm run test:run -- --dangerouslyIgnoreUnhandledErrors",
     "test:canary": "vitest run --dir test/canary",

--- a/packages/sign-client/test/shared/values.ts
+++ b/packages/sign-client/test/shared/values.ts
@@ -6,6 +6,10 @@ export const TEST_RELAY_URL = process.env.TEST_RELAY_URL
   ? process.env.TEST_RELAY_URL
   : "ws://0.0.0.0:5555";
 
+export const TEST_RELAY_URL_US = "wss://us-east-1.relay.walletconnect.com/";
+export const TEST_RELAY_URL_EU = "wss://eu-central-1.relay.walletconnect.com/";
+export const TEST_RELAY_URL_AP = "wss://ap-southeast-1.relay.walletconnect.com/";
+
 // See https://github.com/WalletConnect/push-webhook-test-server
 export const TEST_WEBHOOK_ENDPOINT = "https://webhook-push-test.walletconnect.com/";
 
@@ -16,6 +20,33 @@ export const TEST_PROJECT_ID = process.env.TEST_PROJECT_ID
 export const TEST_SIGN_CLIENT_OPTIONS: SignClientTypes.Options = {
   logger: "fatal",
   relayUrl: TEST_RELAY_URL,
+  projectId: TEST_PROJECT_ID,
+  storageOptions: {
+    database: ":memory:",
+  },
+};
+
+export const TEST_SIGN_CLIENT_OPTIONS_USA: SignClientTypes.Options = {
+  logger: "fatal",
+  relayUrl: TEST_RELAY_URL_US,
+  projectId: TEST_PROJECT_ID,
+  storageOptions: {
+    database: ":memory:",
+  },
+};
+
+export const TEST_SIGN_CLIENT_OPTIONS_EU: SignClientTypes.Options = {
+  logger: "fatal",
+  relayUrl: TEST_RELAY_URL_EU,
+  projectId: TEST_PROJECT_ID,
+  storageOptions: {
+    database: ":memory:",
+  },
+};
+
+export const TEST_SIGN_CLIENT_OPTIONS_AP: SignClientTypes.Options = {
+  logger: "fatal",
+  relayUrl: TEST_RELAY_URL_AP,
   projectId: TEST_PROJECT_ID,
   storageOptions: {
     database: ":memory:",
@@ -145,4 +176,9 @@ export const TEST_RESPOND_PARAMS = {
 export const TEST_EMIT_PARAMS = {
   event: { name: TEST_EVENTS[0], data: "" },
   chainId: TEST_CHAINS[0],
+};
+
+type RelayerType = {
+  value: string;
+  label: string;
 };

--- a/packages/sign-client/test/xregion/xregion.spec.ts
+++ b/packages/sign-client/test/xregion/xregion.spec.ts
@@ -1,0 +1,57 @@
+import { expect, describe, it } from "vitest";
+import SignClient from "../../src";
+import {
+  TEST_SIGN_CLIENT_OPTIONS,
+  TEST_RELAY_URL,
+  TEST_RELAY_URL_US,
+  TEST_SIGN_CLIENT_OPTIONS_USA,
+  TEST_RELAY_URL_AP,
+  TEST_RELAY_URL_EU,
+  TEST_SIGN_CLIENT_OPTIONS_AP,
+  TEST_SIGN_CLIENT_OPTIONS_EU,
+} from "../shared";
+
+describe("X Region", () => {
+  it("init", async () => {
+    const client = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS);
+    expect(client).to.be.exist;
+  });
+
+  describe("connect", () => {
+    it("connect with default region: ", async () => {
+      const client = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS);
+      const defaultRelayerRegion = await client.opts?.relayUrl;
+      expect(defaultRelayerRegion).to.be.equal(TEST_RELAY_URL);
+    });
+    it("connect with default region, then switch to USA", async () => {
+      const defaultRelayerClient = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS);
+      await defaultRelayerClient.disconnect;
+      const usRelayerClient = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS_USA);
+      const usRelayerRegion = await usRelayerClient.opts?.relayUrl;
+      expect(usRelayerRegion).to.be.equal(TEST_RELAY_URL_US);
+    });
+    it("connect with default region, then switch to EU", async () => {
+      const defaultRelayerClient = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS);
+      await defaultRelayerClient.disconnect;
+      const usRelayerClient = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS_EU);
+      const usRelayerRegion = await usRelayerClient.opts?.relayUrl;
+      expect(usRelayerRegion).to.be.equal(TEST_RELAY_URL_EU);
+    });
+    it("connect with default region, then switch to AP", async () => {
+      const defaultRelayerClient = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS);
+      await defaultRelayerClient.disconnect;
+      const usRelayerClient = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS_AP);
+      const usRelayerRegion = await usRelayerClient.opts?.relayUrl;
+      expect(usRelayerRegion).to.be.equal(TEST_RELAY_URL_AP);
+    });
+    it("connect with default region, switch to US, then back to default", async () => {
+      const defaultRelayerClient = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS);
+      await defaultRelayerClient.disconnect;
+      const usRelayerClient = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS_AP);
+      await usRelayerClient.disconnect;
+      const defaultRelayerClientTwo = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS);
+      const defaultRelayerRegion = await defaultRelayerClientTwo.opts?.relayUrl;
+      expect(defaultRelayerRegion).to.be.equal(TEST_RELAY_URL);
+    });
+  });
+});


### PR DESCRIPTION
# Description

Added xRegion testing for connecting to different relay regions (Default / US / EU / AP)
Process involves adding new constants for new `relayerURLS` + variations of `TEST_SIGN_CLIENT_OPTIONS`

Resolves #1425 

## How Has This Been Tested?

- Clean `npm install` + run docker
- Added `test:xregion` to `package.json`
- Added the env vars + run `npm run test:xregion`
- Expected Result: 1 passed + 6 passed

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
