### PR TITLE
fix(test): ensure generated persistent DBs are always unique

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,10 +30,7 @@ zip
 tsconfig.tsbuildinfo
 test.db
 test.db-journal
-client_a.db
-client_a.db-journal
-client_b.db
-client_b.db-journal
+**/tmp
 setup
 result*
 ops/grafana/grafana.ini

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -22,7 +22,7 @@
     "build:types": "tsc",
     "build:source": "rollup --config rollup.config.js",
     "build": "npm run build:pre; npm run build:source; npm run build:types",
-    "test:pre": "rm -rf ./test/client_a.db ./test/client_b.db",
+    "test:pre": "rm -rf ./test/tmp && mkdir ./test/tmp",
     "test:run": "vitest run --dir test/sdk",
     "test:concurrency": "vitest run --dir test/concurrency",
     "test": "npm run test:pre; npm run test:run",

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -251,14 +251,6 @@ describe("Sign Client Integration", () => {
           }
         });
         it("clients can ping each other", async () => {
-          beforeClients = await initTwoClients(
-            {
-              storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
-            },
-            {
-              storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
-            },
-          );
           const {
             sessionA: { topic },
           } = await testConnectMethod(beforeClients);

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -1,4 +1,4 @@
-import { getSdkError, calcExpiry } from "@walletconnect/utils";
+import { getSdkError, generateRandomBytes32 } from "@walletconnect/utils";
 import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
 import SignClient from "../../src";
 import {
@@ -7,10 +7,9 @@ import {
   TEST_SIGN_CLIENT_OPTIONS,
   deleteClients,
 } from "../shared";
-import { SEVEN_DAYS } from "@walletconnect/time";
 
-const TEST_SIGN_CLIENT_A_DATABASE = "./test/client_a.db";
-const TEST_SIGN_CLIENT_B_DATABASE = "./test/client_b.db";
+const generateClientDbName = (prefix: string) =>
+  `./test/tmp/${prefix}_${generateRandomBytes32()}.db`;
 
 describe("Sign Client Integration", () => {
   it("init", async () => {
@@ -131,13 +130,15 @@ describe("Sign Client Integration", () => {
       describe("after restart", () => {
         let beforeClients;
         let afterClients;
+        const db_a = generateClientDbName("client_a");
+        const db_b = generateClientDbName("client_b");
         beforeEach(async () => {
           beforeClients = await initTwoClients(
             {
-              storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
+              storageOptions: { database: db_a },
             },
             {
-              storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
+              storageOptions: { database: db_b },
             },
           );
         });
@@ -173,10 +174,10 @@ describe("Sign Client Integration", () => {
           // restart
           afterClients = await initTwoClients(
             {
-              storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
+              storageOptions: { database: db_a },
             },
             {
-              storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
+              storageOptions: { database: db_b },
             },
           );
           // ping
@@ -220,13 +221,15 @@ describe("Sign Client Integration", () => {
       describe("after restart", () => {
         let beforeClients;
         let afterClients;
+        const db_a = generateClientDbName("client_a");
+        const db_b = generateClientDbName("client_b");
         beforeEach(async () => {
           beforeClients = await initTwoClients(
             {
-              storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
+              storageOptions: { database: db_a },
             },
             {
-              storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
+              storageOptions: { database: db_b },
             },
           );
         });
@@ -262,10 +265,10 @@ describe("Sign Client Integration", () => {
           // restart
           afterClients = await initTwoClients(
             {
-              storageOptions: { database: TEST_SIGN_CLIENT_A_DATABASE },
+              storageOptions: { database: db_a },
             },
             {
-              storageOptions: { database: TEST_SIGN_CLIENT_B_DATABASE },
+              storageOptions: { database: db_b },
             },
           );
           // ping


### PR DESCRIPTION
# Description

- Ensure that clients never reuse persistent DB instances between tests
- Also: fix(test): avoids unwanted reassign of beforeClients

## How Has This Been Tested?

- Tested locally via unit tests

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
