### PR TITLE
feat(test): log client ids

### DIFF
--- a/packages/sign-client/test/sdk/events.spec.ts
+++ b/packages/sign-client/test/sdk/events.spec.ts
@@ -1,5 +1,5 @@
 import { getSdkError, parseUri } from "@walletconnect/utils";
-import { expect, describe, it } from "vitest";
+import { expect, describe, it, beforeEach, afterEach } from "vitest";
 import SignClient from "../../src";
 import {
   initTwoClients,
@@ -18,207 +18,216 @@ describe("Sign Client Events Validation", () => {
     expect(client).to.be.exist;
   });
 
-  describe("session_proposal", () => {
-    it("emits and handles a valid session_proposal", async () => {
-      const clients = await initTwoClients();
-      const { A, B } = clients;
+  describe("session", () => {
+    let clients;
+    beforeEach(async () => {
+      clients = await initTwoClients();
+    });
+    afterEach(async (done) => {
+      const { result } = done.meta;
+      if (result?.state.toString() !== "pass") {
+        console.log(
+          `Test ${
+            done.meta.name
+          } failed with client ids: A:'${await clients.A.core.crypto.getClientId()}';B:'${await clients.B.core.crypto.getClientId()}'`,
+        );
+      }
+    });
+    describe("session_proposal", () => {
+      it("emits and handles a valid session_proposal", async () => {
+        const { A, B } = clients;
 
-      const connectParams: EngineTypes.ConnectParams = {
-        requiredNamespaces: TEST_REQUIRED_NAMESPACES,
-        relays: undefined,
-        pairingTopic: undefined,
-      };
+        const connectParams: EngineTypes.ConnectParams = {
+          requiredNamespaces: TEST_REQUIRED_NAMESPACES,
+          relays: undefined,
+          pairingTopic: undefined,
+        };
 
-      const approveParams: Omit<EngineTypes.ApproveParams, "id"> = {
-        namespaces: TEST_NAMESPACES,
-      };
+        const approveParams: Omit<EngineTypes.ApproveParams, "id"> = {
+          namespaces: TEST_NAMESPACES,
+        };
 
-      const { uri, approval } = await A.connect(connectParams);
+        const { uri, approval } = await A.connect(connectParams);
 
-      let pairingA: PairingTypes.Struct | undefined;
-      let pairingB: PairingTypes.Struct | undefined;
+        let pairingA: PairingTypes.Struct | undefined;
+        let pairingB: PairingTypes.Struct | undefined;
 
-      if (!uri) throw new Error("uri is missing");
+        if (!uri) throw new Error("uri is missing");
 
-      const uriParams = parseUri(uri);
+        const uriParams = parseUri(uri);
 
-      // eslint-disable-next-line prefer-const
-      pairingA = A.pairing.get(uriParams.topic);
-      expect(pairingA.topic).to.eql(uriParams.topic);
-      expect(pairingA.relay).to.eql(uriParams.relay);
+        // eslint-disable-next-line prefer-const
+        pairingA = A.pairing.get(uriParams.topic);
+        expect(pairingA.topic).to.eql(uriParams.topic);
+        expect(pairingA.relay).to.eql(uriParams.relay);
 
-      if (!pairingA) throw new Error("expect pairing A to be defined");
+        if (!pairingA) throw new Error("expect pairing A to be defined");
 
-      let sessionA: SessionTypes.Struct;
-      let sessionB: SessionTypes.Struct;
+        let sessionA: SessionTypes.Struct;
+        let sessionB: SessionTypes.Struct;
 
-      await Promise.all([
-        new Promise<void>((resolve, reject) => {
-          B.once("session_proposal", async (proposal) => {
+        await Promise.all([
+          new Promise<void>((resolve, reject) => {
+            B.once("session_proposal", async (proposal) => {
+              try {
+                expect(proposal.params.requiredNamespaces).to.eql(connectParams.requiredNamespaces);
+                const { acknowledged } = await B.approve({
+                  id: proposal.id,
+                  ...approveParams,
+                });
+                if (!sessionB) {
+                  sessionB = await acknowledged();
+                }
+                resolve();
+              } catch (e) {
+                reject(e);
+              }
+            });
+          }),
+          new Promise<void>(async (resolve, reject) => {
             try {
-              expect(proposal.params.requiredNamespaces).to.eql(connectParams.requiredNamespaces);
-              const { acknowledged } = await B.approve({
-                id: proposal.id,
-                ...approveParams,
-              });
-              if (!sessionB) {
-                sessionB = await acknowledged();
+              if (uri) {
+                pairingB = await B.pair({ uri });
+                if (!pairingA) throw new Error("pairingA is missing");
+                expect(pairingB.topic).to.eql(pairingA.topic);
+                expect(pairingB.relay).to.eql(pairingA.relay);
+                resolve();
+              } else {
+                reject(new Error("missing uri"));
+              }
+            } catch (error) {
+              reject(error);
+            }
+          }),
+          new Promise<void>(async (resolve, reject) => {
+            try {
+              if (!sessionA) {
+                sessionA = await approval();
               }
               resolve();
-            } catch (e) {
-              reject(e);
+            } catch (error) {
+              reject(error);
             }
-          });
-        }),
-        new Promise<void>(async (resolve, reject) => {
+          }),
+        ]);
+
+        deleteClients(clients);
+      });
+    });
+    describe("session_update", () => {
+      it("emits and handles a valid session_update", async () => {
+        const { sessionA } = await testConnectMethod(clients);
+
+        await new Promise<void>(async (resolve, reject) => {
           try {
-            if (uri) {
-              pairingB = await B.pair({ uri });
-              if (!pairingA) throw new Error("pairingA is missing");
-              expect(pairingB.topic).to.eql(pairingA.topic);
-              expect(pairingB.relay).to.eql(pairingA.relay);
+            const namespacesBefore = sessionA.namespaces;
+            const namespacesAfter = {
+              ...namespacesBefore,
+              eip9001: {
+                accounts: ["eip9001:1:0x000000000000000000000000000000000000dead"],
+                methods: ["eth_sendTransaction"],
+                events: ["accountsChanged"],
+              },
+            };
+
+            clients.B.once("session_update", () => {
+              expect(clients.A.session.get(sessionA.topic).namespaces).to.eql(namespacesAfter);
               resolve();
-            } else {
-              reject(new Error("missing uri"));
-            }
-          } catch (error) {
-            reject(error);
+            });
+
+            const { acknowledged } = await clients.A.update({
+              topic: sessionA.topic,
+              namespaces: namespacesAfter,
+            });
+            await acknowledged();
+          } catch (e) {
+            reject(e);
           }
-        }),
-        new Promise<void>(async (resolve, reject) => {
+        });
+
+        deleteClients(clients);
+      });
+    });
+    describe("session_ping", () => {
+      it("emits and handles a valid session_ping", async () => {
+        const { sessionA } = await testConnectMethod(clients);
+
+        await new Promise<void>(async (resolve, reject) => {
           try {
-            if (!sessionA) {
-              sessionA = await approval();
-            }
-            resolve();
-          } catch (error) {
-            reject(error);
+            clients.B.once("session_ping", (event) => {
+              expect(sessionA.topic).to.eql(event.topic);
+              resolve();
+            });
+
+            await clients.A.ping({ topic: sessionA.topic });
+          } catch (e) {
+            reject(e);
           }
-        }),
-      ]);
+        });
 
-      deleteClients(clients);
-    });
-  });
-  describe("session_update", () => {
-    it("emits and handles a valid session_update", async () => {
-      const clients = await initTwoClients();
-      const { sessionA } = await testConnectMethod(clients);
-
-      await new Promise<void>(async (resolve, reject) => {
-        try {
-          const namespacesBefore = sessionA.namespaces;
-          const namespacesAfter = {
-            ...namespacesBefore,
-            eip9001: {
-              accounts: ["eip9001:1:0x000000000000000000000000000000000000dead"],
-              methods: ["eth_sendTransaction"],
-              events: ["accountsChanged"],
-            },
-          };
-
-          clients.B.once("session_update", () => {
-            expect(clients.A.session.get(sessionA.topic).namespaces).to.eql(namespacesAfter);
-            resolve();
-          });
-
-          const { acknowledged } = await clients.A.update({
-            topic: sessionA.topic,
-            namespaces: namespacesAfter,
-          });
-          await acknowledged();
-        } catch (e) {
-          reject(e);
-        }
+        deleteClients(clients);
       });
-
-      deleteClients(clients);
     });
-  });
-  describe("session_ping", () => {
-    it("emits and handles a valid session_ping", async () => {
-      const clients = await initTwoClients();
-      const { sessionA } = await testConnectMethod(clients);
+    describe("session_event", () => {
+      it("emits and handles a valid session_event", async () => {
+        const connectParams: EngineTypes.ConnectParams = {
+          requiredNamespaces: TEST_REQUIRED_NAMESPACES,
+          relays: undefined,
+          pairingTopic: undefined,
+        };
 
-      await new Promise<void>(async (resolve, reject) => {
-        try {
-          clients.B.once("session_ping", (event) => {
-            expect(sessionA.topic).to.eql(event.topic);
-            resolve();
-          });
+        const { sessionA } = await testConnectMethod(clients, connectParams);
 
-          await clients.A.ping({ topic: sessionA.topic });
-        } catch (e) {
-          reject(e);
-        }
+        const eventPayload: EngineTypes.EmitParams = {
+          topic: sessionA.topic,
+          ...TEST_EMIT_PARAMS,
+        };
+
+        await new Promise<void>((resolve, reject) => {
+          try {
+            clients.B.on("session_event", (event) => {
+              expect(TEST_EMIT_PARAMS).to.eql(event.params);
+              expect(eventPayload.topic).to.eql(event.topic);
+              resolve();
+            });
+
+            clients.A.emit(eventPayload);
+          } catch (e) {
+            reject(e);
+          }
+        });
+        deleteClients(clients);
       });
-
-      deleteClients(clients);
     });
-  });
-  describe("session_event", () => {
-    it("emits and handles a valid session_event", async () => {
-      const clients = await initTwoClients();
+    describe("session_delete", () => {
+      it("emits and handles a valid session_delete", async () => {
+        const connectParams: EngineTypes.ConnectParams = {
+          requiredNamespaces: TEST_REQUIRED_NAMESPACES,
+          relays: undefined,
+          pairingTopic: undefined,
+        };
 
-      const connectParams: EngineTypes.ConnectParams = {
-        requiredNamespaces: TEST_REQUIRED_NAMESPACES,
-        relays: undefined,
-        pairingTopic: undefined,
-      };
+        const { sessionA } = await testConnectMethod(clients, connectParams);
 
-      const { sessionA } = await testConnectMethod(clients, connectParams);
+        const eventPayload: EngineTypes.EmitParams = {
+          topic: sessionA.topic,
+          ...TEST_EMIT_PARAMS,
+        };
 
-      const eventPayload: EngineTypes.EmitParams = {
-        topic: sessionA.topic,
-        ...TEST_EMIT_PARAMS,
-      };
+        await new Promise<void>((resolve, reject) => {
+          try {
+            clients.B.on("session_delete", (event) => {
+              expect(eventPayload.topic).to.eql(event.topic);
+              resolve();
+            });
 
-      await new Promise<void>((resolve, reject) => {
-        try {
-          clients.B.on("session_event", (event) => {
-            expect(TEST_EMIT_PARAMS).to.eql(event.params);
-            expect(eventPayload.topic).to.eql(event.topic);
-            resolve();
-          });
-
-          clients.A.emit(eventPayload);
-        } catch (e) {
-          reject(e);
-        }
+            clients.A.disconnect({ topic: sessionA.topic, reason: getSdkError("USER_DISCONNECTED") });
+          } catch (e) {
+            reject(e);
+          }
+        });
+        deleteClients(clients);
       });
-      deleteClients(clients);
-    });
-  });
-  describe("session_delete", () => {
-    it("emits and handles a valid session_delete", async () => {
-      const clients = await initTwoClients();
-
-      const connectParams: EngineTypes.ConnectParams = {
-        requiredNamespaces: TEST_REQUIRED_NAMESPACES,
-        relays: undefined,
-        pairingTopic: undefined,
-      };
-
-      const { sessionA } = await testConnectMethod(clients, connectParams);
-
-      const eventPayload: EngineTypes.EmitParams = {
-        topic: sessionA.topic,
-        ...TEST_EMIT_PARAMS,
-      };
-
-      await new Promise<void>((resolve, reject) => {
-        try {
-          clients.B.on("session_delete", (event) => {
-            expect(eventPayload.topic).to.eql(event.topic);
-            resolve();
-          });
-
-          clients.A.disconnect({ topic: sessionA.topic, reason: getSdkError("USER_DISCONNECTED") });
-        } catch (e) {
-          reject(e);
-        }
-      });
-      deleteClients(clients);
     });
   });
 });


### PR DESCRIPTION
# Description

We occasionally see event tests failing. This logs client ids if they fail.

Looks like a lot of changes by I only added a `beforeEach`/`afterEach` and intented code accordingly.

## How Has This Been Tested?

Tested locally.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
