### PR TITLE
chore(test): log client ids proper when tests fail

### DIFF
--- a/packages/sign-client/test/sdk/events.spec.ts
+++ b/packages/sign-client/test/sdk/events.spec.ts
@@ -26,10 +26,18 @@ describe("Sign Client Events Validation", () => {
     afterEach(async (done) => {
       const { result } = done.meta;
       if (result?.state.toString() !== "pass") {
+        if (!clients) {
+          console.log("Clients not defined");
+          return;
+        }
+        const clientAId =
+          (clients.A && (await clients.A.core.crypto.getClientId())) ||
+          "not initialized or removed";
+        const clientBId =
+          (clients.B && (await clients.B.core.crypto.getClientId())) ||
+          "not initialized or removed";
         console.log(
-          `Test ${
-            done.meta.name
-          } failed with client ids: A:'${await clients.A.core.crypto.getClientId()}';B:'${await clients.B.core.crypto.getClientId()}'`,
+          `Test ${done.meta.name} failed with client ids: A:'${clientAId}';B:'${clientBId}'`,
         );
       }
     });
@@ -221,7 +229,10 @@ describe("Sign Client Events Validation", () => {
               resolve();
             });
 
-            clients.A.disconnect({ topic: sessionA.topic, reason: getSdkError("USER_DISCONNECTED") });
+            clients.A.disconnect({
+              topic: sessionA.topic,
+              reason: getSdkError("USER_DISCONNECTED"),
+            });
           } catch (e) {
             reject(e);
           }

--- a/packages/sign-client/test/sdk/push.spec.ts
+++ b/packages/sign-client/test/sdk/push.spec.ts
@@ -39,6 +39,11 @@ describe("Push", () => {
     expect(res.status).to.eql(200);
   });
   afterEach(async () => {
+    if (!sessionA) {
+      console.log("No session to disconnect");
+      return;
+    }
+
     // disconnect clients
     await Promise.all([
       new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## How Has This Been Tested?

Ran tests locally

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
