### PR TITLE
fix(test): push test fails occasionally

### DIFF
--- a/packages/sign-client/test/sdk/push.spec.ts
+++ b/packages/sign-client/test/sdk/push.spec.ts
@@ -7,6 +7,7 @@ import {
   TEST_EMIT_PARAMS,
   TEST_RELAY_URL,
   TEST_WEBHOOK_ENDPOINT,
+  throttle,
 } from "../shared";
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 
@@ -33,6 +34,10 @@ describe("Push", () => {
       ...TEST_EMIT_PARAMS,
     };
     await clients.A.emit(eventPayload);
+
+    // Relay processes webhooks in background
+    // Extend some time to relay to process it
+    await throttle(500);
 
     // Validate webhook was called
     const res = await axios.get(`${TEST_WEBHOOK_ENDPOINT}/${sessionA.topic}`);


### PR DESCRIPTION
# Description

As of this week the relay processes webhooks in background. Prior the message to the client would only be acked after processing the webhook. Hence, extend some time to the relay to process the webhook.

## How Has This Been Tested?

Tested locally

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
