### PR TITLE
Fix/restart test

### DIFF
--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -179,7 +179,7 @@ describe("Sign Client Integration", () => {
             );
           }
         });
-        it("clients can ping each other", async () => {
+        it.only("clients can ping each other", async () => {
           const {
             pairingA: { topic },
           } = await testConnectMethod(beforeClients);
@@ -208,20 +208,17 @@ describe("Sign Client Integration", () => {
           if (afterClients) {
             await deleteClients(afterClients);
           }
+
           // restart
           afterClients = await initTwoClients(
             {
               storageOptions: { database: db_a },
-              name: "client_a",
             },
             {
               storageOptions: { database: db_b },
-              name: "client_b",
             },
             { logger: "error" },
           );
-
-          await testConnectMethod(afterClients);
 
           // ping
           await afterClients.A.ping({ topic });

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -179,7 +179,7 @@ describe("Sign Client Integration", () => {
             );
           }
         });
-        it.only("clients can ping each other", async () => {
+        it("clients can ping each other", async () => {
           const {
             pairingA: { topic },
           } = await testConnectMethod(beforeClients);


### PR DESCRIPTION
# Description

The `restart` test was not actually using the old pairing but creating a new one.

## How Has This Been Tested?

Tested locally

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
