### PR TITLE
fix: pings race condition

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -697,11 +697,15 @@ export class Engine extends IEngine {
 
   private onSessionPingResponse: EnginePrivate["onSessionPingResponse"] = (_topic, payload) => {
     const { id } = payload;
-    if (isJsonRpcResult(payload)) {
-      this.events.emit(engineEvent("session_ping", id), {});
-    } else if (isJsonRpcError(payload)) {
-      this.events.emit(engineEvent("session_ping", id), { error: payload.error });
-    }
+    // put at the end of the stack to avoid a race condition
+    // where session_ping listener is not yet initialized
+    setTimeout(() => {
+      if (isJsonRpcResult(payload)) {
+        this.events.emit(engineEvent("session_ping", id), {});
+      } else if (isJsonRpcError(payload)) {
+        this.events.emit(engineEvent("session_ping", id), { error: payload.error });
+      }
+    }, 200);
   };
 
   private onPairingPingRequest: EnginePrivate["onPairingPingRequest"] = async (topic, payload) => {
@@ -718,11 +722,15 @@ export class Engine extends IEngine {
 
   private onPairingPingResponse: EnginePrivate["onPairingPingResponse"] = (_topic, payload) => {
     const { id } = payload;
-    if (isJsonRpcResult(payload)) {
-      this.events.emit(engineEvent("pairing_ping", id), {});
-    } else if (isJsonRpcError(payload)) {
-      this.events.emit(engineEvent("pairing_ping", id), { error: payload.error });
-    }
+    // put at the end of the stack to avoid a race condition
+    // where pairing_ping listener is not yet initialized
+    setTimeout(() => {
+      if (isJsonRpcResult(payload)) {
+        this.events.emit(engineEvent("pairing_ping", id), {});
+      } else if (isJsonRpcError(payload)) {
+        this.events.emit(engineEvent("pairing_ping", id), { error: payload.error });
+      }
+    }, 200);
   };
 
   private onSessionDeleteRequest: EnginePrivate["onSessionDeleteRequest"] = async (

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -705,7 +705,7 @@ export class Engine extends IEngine {
       } else if (isJsonRpcError(payload)) {
         this.events.emit(engineEvent("session_ping", id), { error: payload.error });
       }
-    }, 200);
+    }, 500);
   };
 
   private onPairingPingRequest: EnginePrivate["onPairingPingRequest"] = async (topic, payload) => {
@@ -730,7 +730,7 @@ export class Engine extends IEngine {
       } else if (isJsonRpcError(payload)) {
         this.events.emit(engineEvent("pairing_ping", id), { error: payload.error });
       }
-    }, 200);
+    }, 500);
   };
 
   private onSessionDeleteRequest: EnginePrivate["onSessionDeleteRequest"] = async (


### PR DESCRIPTION
# Description
Adding a timeout before emitting the following events

- session_ping
- pairing_ping

This is required due to the occasional race condition where the listeners for the said events are not yet initialized at the time of emitting causing the workflow to hang indefinitely

Resolves # ([browse](https://github.com/WalletConnect/walletconnect-monorepo/issues) or [create](https://github.com/WalletConnect/walletconnect-monorepo/issues/new/choose))

## How Has This Been Tested?
npm run test
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
