### PR TITLE
feat: implement first iteration of core/pairing

### DIFF
--- a/packages/core/src/constants/history.ts
+++ b/packages/core/src/constants/history.ts
@@ -1,0 +1,10 @@
+export const HISTORY_EVENTS = {
+  created: "history_created",
+  updated: "history_updated",
+  deleted: "history_deleted",
+  sync: "history_sync",
+};
+
+export const HISTORY_CONTEXT = "history";
+
+export const HISTORY_STORAGE_VERSION = "0.3";

--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -7,3 +7,4 @@ export * from "./relayer";
 export * from "./store";
 export * from "./subscriber";
 export * from "./pairing";
+export * from "./history";

--- a/packages/core/src/constants/pairing.ts
+++ b/packages/core/src/constants/pairing.ts
@@ -1,7 +1,41 @@
 import { THIRTY_DAYS } from "@walletconnect/time";
+import { RelayerTypes, PairingJsonRpcTypes } from "@walletconnect/types";
 
 export const PAIRING_CONTEXT = "pairing";
 
 export const PAIRING_STORAGE_VERSION = "0.3";
 
 export const PAIRING_DEFAULT_TTL = THIRTY_DAYS;
+
+export const PAIRING_RPC_OPTS: Record<
+  PairingJsonRpcTypes.WcMethod,
+  {
+    req: RelayerTypes.PublishOptions;
+    res: RelayerTypes.PublishOptions;
+  }
+> = {
+  wc_pairingDelete: {
+    req: {
+      // ttl: ONE_DAY,
+      prompt: false,
+      tag: 1000,
+    },
+    res: {
+      // ttl: ONE_DAY,
+      prompt: false,
+      tag: 1001,
+    },
+  },
+  wc_pairingPing: {
+    req: {
+      // ttl: THIRTY_SECONDS,
+      prompt: false,
+      tag: 1002,
+    },
+    res: {
+      // ttl: THIRTY_SECONDS,
+      prompt: false,
+      tag: 1003,
+    },
+  },
+};

--- a/packages/core/src/controllers/history.ts
+++ b/packages/core/src/controllers/history.ts
@@ -1,0 +1,225 @@
+import { formatJsonRpcRequest, isJsonRpcError } from "@walletconnect/jsonrpc-utils";
+import { generateChildLogger, getLoggerContext } from "@walletconnect/logger";
+import { IJsonRpcHistory, JsonRpcRecord, RequestEvent, ICore } from "@walletconnect/types";
+import { getInternalError } from "@walletconnect/utils";
+import { EventEmitter } from "events";
+import { Logger } from "pino";
+import {
+  CORE_STORAGE_PREFIX,
+  HISTORY_CONTEXT,
+  HISTORY_EVENTS,
+  HISTORY_STORAGE_VERSION,
+} from "../constants";
+
+export class JsonRpcHistory extends IJsonRpcHistory {
+  public records = new Map<number, JsonRpcRecord>();
+  public events = new EventEmitter();
+  public name = HISTORY_CONTEXT;
+  public version = HISTORY_STORAGE_VERSION;
+  private cached: JsonRpcRecord[] = [];
+  private initialized = false;
+
+  private storagePrefix = CORE_STORAGE_PREFIX;
+
+  constructor(public core: ICore, public logger: Logger) {
+    super(core, logger);
+    this.logger = generateChildLogger(logger, this.name);
+  }
+
+  public init: IJsonRpcHistory["init"] = async () => {
+    if (!this.initialized) {
+      this.logger.trace(`Initialized`);
+      await this.restore();
+      this.cached.forEach((record) => this.records.set(record.id, record));
+      this.cached = [];
+      this.registerEventListeners();
+      this.initialized = true;
+    }
+  };
+
+  get context(): string {
+    return getLoggerContext(this.logger);
+  }
+
+  get storageKey(): string {
+    return this.storagePrefix + this.version + "//" + this.name;
+  }
+
+  get size(): number {
+    return this.records.size;
+  }
+
+  get keys(): number[] {
+    return Array.from(this.records.keys());
+  }
+
+  get values() {
+    return Array.from(this.records.values());
+  }
+
+  get pending(): RequestEvent[] {
+    const requests: RequestEvent[] = [];
+    this.values.forEach((record) => {
+      if (typeof record.response !== "undefined") return;
+      const requestEvent: RequestEvent = {
+        topic: record.topic,
+        request: formatJsonRpcRequest(record.request.method, record.request.params, record.id),
+        chainId: record.chainId,
+      };
+      return requests.push(requestEvent);
+    });
+    return requests;
+  }
+
+  public set: IJsonRpcHistory["set"] = (topic, request, chainId) => {
+    this.isInitialized();
+    this.logger.debug(`Setting JSON-RPC request history record`);
+    this.logger.trace({ type: "method", method: "set", topic, request, chainId });
+    if (this.records.has(request.id)) return;
+    const record: JsonRpcRecord = {
+      id: request.id,
+      topic,
+      request: { method: request.method, params: request.params || null },
+      chainId,
+    };
+    this.records.set(record.id, record);
+    this.events.emit(HISTORY_EVENTS.created, record);
+  };
+
+  public resolve: IJsonRpcHistory["resolve"] = async (response) => {
+    this.isInitialized();
+    this.logger.debug(`Updating JSON-RPC response history record`);
+    this.logger.trace({ type: "method", method: "update", response });
+    if (!this.records.has(response.id)) return;
+    const record = await this.getRecord(response.id);
+    if (typeof record.response !== "undefined") return;
+    record.response = isJsonRpcError(response)
+      ? { error: response.error }
+      : { result: response.result };
+    this.records.set(record.id, record);
+    this.events.emit(HISTORY_EVENTS.updated, record);
+  };
+
+  public get: IJsonRpcHistory["get"] = async (topic, id) => {
+    this.isInitialized();
+    this.logger.debug(`Getting record`);
+    this.logger.trace({ type: "method", method: "get", topic, id });
+    const record = await this.getRecord(id);
+    if (record.topic !== topic) {
+      const { message } = getInternalError("MISMATCHED_TOPIC", `${this.name}, ${id}`);
+      this.logger.error(message);
+      throw new Error(message);
+    }
+    return record;
+  };
+
+  public delete: IJsonRpcHistory["delete"] = (topic, id) => {
+    this.isInitialized();
+    this.logger.debug(`Deleting record`);
+    this.logger.trace({ type: "method", method: "delete", id });
+    this.values.forEach((record: JsonRpcRecord) => {
+      if (record.topic === topic) {
+        if (typeof id !== "undefined" && record.id !== id) return;
+        this.records.delete(record.id);
+        this.events.emit(HISTORY_EVENTS.deleted, record);
+      }
+    });
+  };
+
+  public exists: IJsonRpcHistory["exists"] = async (topic, id) => {
+    this.isInitialized();
+    if (!this.records.has(id)) return false;
+    const record = await this.getRecord(id);
+    return record.topic === topic;
+  };
+
+  public on: IJsonRpcHistory["on"] = (event, listener) => {
+    this.events.on(event, listener);
+  };
+
+  public once: IJsonRpcHistory["once"] = (event, listener) => {
+    this.events.once(event, listener);
+  };
+
+  public off: IJsonRpcHistory["off"] = (event, listener) => {
+    this.events.off(event, listener);
+  };
+
+  public removeListener: IJsonRpcHistory["removeListener"] = (event, listener) => {
+    this.events.removeListener(event, listener);
+  };
+
+  // ---------- Private ----------------------------------------------- //
+
+  private async setJsonRpcRecords(records: JsonRpcRecord[]): Promise<void> {
+    await this.core.storage.setItem<JsonRpcRecord[]>(this.storageKey, records);
+  }
+
+  private async getJsonRpcRecords(): Promise<JsonRpcRecord[] | undefined> {
+    const records = await this.core.storage.getItem<JsonRpcRecord[]>(this.storageKey);
+    return records;
+  }
+
+  private getRecord(id: number) {
+    this.isInitialized();
+    const record = this.records.get(id);
+    if (!record) {
+      const { message } = getInternalError("NO_MATCHING_KEY", `${this.name}: ${id}`);
+      throw new Error(message);
+    }
+    return record;
+  }
+
+  private async persist() {
+    await this.setJsonRpcRecords(this.values);
+    this.events.emit(HISTORY_EVENTS.sync);
+  }
+
+  private async restore() {
+    try {
+      const persisted = await this.getJsonRpcRecords();
+      if (typeof persisted === "undefined") return;
+      if (!persisted.length) return;
+      if (this.records.size) {
+        const { message } = getInternalError("RESTORE_WILL_OVERRIDE", this.name);
+        this.logger.error(message);
+        throw new Error(message);
+      }
+      this.cached = persisted;
+      this.logger.debug(`Successfully Restored records for ${this.name}`);
+      this.logger.trace({ type: "method", method: "restore", records: this.values });
+    } catch (e) {
+      this.logger.debug(`Failed to Restore records for ${this.name}`);
+      this.logger.error(e as any);
+    }
+  }
+
+  private registerEventListeners(): void {
+    this.events.on(HISTORY_EVENTS.created, (record: JsonRpcRecord) => {
+      const eventName = HISTORY_EVENTS.created;
+      this.logger.info(`Emitting ${eventName}`);
+      this.logger.debug({ type: "event", event: eventName, record });
+      this.persist();
+    });
+    this.events.on(HISTORY_EVENTS.updated, (record: JsonRpcRecord) => {
+      const eventName = HISTORY_EVENTS.updated;
+      this.logger.info(`Emitting ${eventName}`);
+      this.logger.debug({ type: "event", event: eventName, record });
+      this.persist();
+    });
+
+    this.events.on(HISTORY_EVENTS.deleted, (record: JsonRpcRecord) => {
+      const eventName = HISTORY_EVENTS.deleted;
+      this.logger.info(`Emitting ${eventName}`);
+      this.logger.debug({ type: "event", event: eventName, record });
+      this.persist();
+    });
+  }
+
+  private isInitialized() {
+    if (!this.initialized) {
+      const { message } = getInternalError("NOT_INITIALIZED", this.name);
+      throw new Error(message);
+    }
+  }
+}

--- a/packages/core/src/controllers/index.ts
+++ b/packages/core/src/controllers/index.ts
@@ -4,3 +4,5 @@ export * from "./relayer";
 export * from "./store";
 export * from "./subscriber";
 export * from "./keychain";
+export * from "./pairing";
+export * from "./history";

--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -1,16 +1,53 @@
 import { generateChildLogger, getLoggerContext } from "@walletconnect/logger";
-import { ICore, PairingTypes, IPairing, IStore } from "@walletconnect/types";
-import { getInternalError } from "@walletconnect/utils";
+import {
+  ICore,
+  PairingTypes,
+  IPairing,
+  IPairingPrivate,
+  IStore,
+  RelayerTypes,
+  PairingJsonRpcTypes,
+} from "@walletconnect/types";
+import {
+  getInternalError,
+  parseUri,
+  calcExpiry,
+  generateRandomBytes32,
+  formatUri,
+  getSdkError,
+  engineEvent,
+  createDelayedPromise,
+} from "@walletconnect/utils";
+import {
+  formatJsonRpcRequest,
+  formatJsonRpcResult,
+  formatJsonRpcError,
+  isJsonRpcRequest,
+  isJsonRpcResponse,
+  isJsonRpcResult,
+  isJsonRpcError,
+} from "@walletconnect/jsonrpc-utils";
+import { FIVE_MINUTES, THIRTY_DAYS } from "@walletconnect/time";
+import EventEmitter from "events";
 import { Logger } from "pino";
-import { PAIRING_CONTEXT, PAIRING_STORAGE_VERSION, CORE_STORAGE_PREFIX } from "../constants";
+import {
+  PAIRING_CONTEXT,
+  PAIRING_STORAGE_VERSION,
+  CORE_STORAGE_PREFIX,
+  RELAYER_DEFAULT_PROTOCOL,
+  PAIRING_RPC_OPTS,
+  RELAYER_EVENTS,
+} from "../constants";
 import { Store } from "../controllers/store";
+import { JsonRpcHistory } from "../controllers/history";
 
-// @ts-expect-error - other methods still to be added.
 export class Pairing implements IPairing {
   public name = PAIRING_CONTEXT;
   public version = PAIRING_STORAGE_VERSION;
 
+  public events = new EventEmitter();
   public pairings: IStore<string, PairingTypes.Struct>;
+  public history: IPairing["history"];
 
   private initialized = false;
   private storagePrefix = CORE_STORAGE_PREFIX;
@@ -19,12 +56,15 @@ export class Pairing implements IPairing {
     this.core = core;
     this.logger = generateChildLogger(logger, this.name);
     this.pairings = new Store(this.core, this.logger, this.name, this.storagePrefix);
+    this.history = new JsonRpcHistory(this.core, this.logger);
   }
 
   public init: IPairing["init"] = async () => {
     if (!this.initialized) {
       this.logger.trace(`Initialized`);
       await this.pairings.init();
+      await this.history.init();
+      this.registerRelayerEvents();
       this.initialized = true;
     }
   };
@@ -33,13 +73,217 @@ export class Pairing implements IPairing {
     return getLoggerContext(this.logger);
   }
 
-  // ---------- Private ----------------------------------------------- //
+  public create: IPairing["create"] = async () => {
+    const symKey = generateRandomBytes32();
+    const topic = await this.core.crypto.setSymKey(symKey);
+    const expiry = calcExpiry(FIVE_MINUTES);
+    const relay = { protocol: RELAYER_DEFAULT_PROTOCOL };
+    const pairing = { topic, expiry, relay, active: false };
+    const uri = formatUri({
+      protocol: this.core.protocol,
+      version: this.core.version,
+      topic,
+      symKey,
+      relay,
+    });
+    await this.pairings.set(topic, pairing);
+    await this.core.relayer.subscribe(topic);
 
-  // @ts-expect-error - will be used with once methods are implemented.
+    // FIXME: We need to move expirer to core for this to work.
+    // this.core.expirer.set(topic, expiry);
+
+    return { topic, uri };
+  };
+
+  public pair: IPairing["pair"] = async (params) => {
+    this.isInitialized();
+    // TODO: move validation logic from SignClient.Engine to this class.
+    // this.isValidPair(params);
+    const { topic, symKey, relay } = parseUri(params.uri);
+    const expiry = calcExpiry(FIVE_MINUTES);
+    const pairing = { topic, relay, expiry, active: false };
+    await this.pairings.set(topic, pairing);
+    await this.core.crypto.setSymKey(symKey, topic);
+    await this.core.relayer.subscribe(topic, { relay });
+
+    // FIXME: We need to move expirer to core for this to work.
+    // this.core.expirer.set(topic, expiry);
+
+    return pairing;
+  };
+
+  public activate: IPairing["activate"] = async ({ topic }) => {
+    const expiry = calcExpiry(THIRTY_DAYS);
+    await this.pairings.update(topic, { active: true, expiry });
+
+    // FIXME: We need to move expirer to core for this to work.
+    // this.core.expirer.set(topic, expiry);
+  };
+
+  public ping: IPairing["ping"] = async (params) => {
+    this.isInitialized();
+    // TODO: adapt validation logic from SignClient.Engine
+    // await this.isValidPing(params);
+    const { topic } = params;
+    if (this.pairings.keys.includes(topic)) {
+      const id = await this.sendRequest(topic, "wc_pairingPing", {});
+      const { done, resolve, reject } = createDelayedPromise<void>();
+      this.events.once(engineEvent("pairing_ping", id), ({ error }) => {
+        if (error) reject(error);
+        else resolve();
+      });
+      await done();
+    }
+  };
+
+  public updateExpiry: IPairing["updateExpiry"] = async ({ topic, expiry }) => {
+    await this.pairings.update(topic, { expiry });
+  };
+
+  public updateMetadata: IPairing["updateMetadata"] = async ({ topic, metadata }) => {
+    await this.pairings.update(topic, { peerMetadata: metadata });
+  };
+
+  public getPairings: IPairing["getPairings"] = () => {
+    return this.pairings.values;
+  };
+
+  public disconnect: IPairing["disconnect"] = async (params) => {
+    this.isInitialized();
+    // TODO: move validation logic from SignClient.Engine to this class.
+    // await this.isValidDisconnect(params);
+    const { topic } = params;
+    if (this.pairings.keys.includes(topic)) {
+      await this.sendRequest(topic, "wc_pairingDelete", getSdkError("USER_DISCONNECTED"));
+      await this.deletePairing(topic);
+    }
+  };
+
+  // ---------- Private Helpers ----------------------------------------------- //
+
+  private sendRequest: IPairingPrivate["sendRequest"] = async (topic, method, params) => {
+    const payload = formatJsonRpcRequest(method, params);
+    const message = await this.core.crypto.encode(topic, payload);
+    const opts = PAIRING_RPC_OPTS[method].req;
+    this.history.set(topic, payload);
+    await this.core.relayer.publish(topic, message, opts);
+
+    return payload.id;
+  };
+
+  private sendResult: IPairingPrivate["sendResult"] = async (id, topic, result) => {
+    const payload = formatJsonRpcResult(id, result);
+    const message = await this.core.crypto.encode(topic, payload);
+    const record = await this.history.get(topic, id);
+    const opts = PAIRING_RPC_OPTS[record.request.method].res;
+    await this.core.relayer.publish(topic, message, opts);
+    await this.history.resolve(payload);
+  };
+
+  private sendError: IPairingPrivate["sendError"] = async (id, topic, error) => {
+    const payload = formatJsonRpcError(id, error);
+    const message = await this.core.crypto.encode(topic, payload);
+    const record = await this.history.get(topic, id);
+    const opts = PAIRING_RPC_OPTS[record.request.method].res;
+    await this.core.relayer.publish(topic, message, opts);
+    await this.history.resolve(payload);
+  };
+
+  private deletePairing: IPairingPrivate["deletePairing"] = async (topic, _expirerHasDeleted) => {
+    // Await the unsubscribe first to avoid deleting the symKey too early below.
+    await this.core.relayer.unsubscribe(topic);
+    await Promise.all([
+      this.pairings.delete(topic, getSdkError("USER_DISCONNECTED")),
+      this.core.crypto.deleteSymKey(topic),
+      // FIXME: We need to move expirer to core for this to work.
+      // expirerHasDeleted ? Promise.resolve() : this.core.expirer.del(topic),
+    ]);
+  };
+
   private isInitialized() {
     if (!this.initialized) {
       const { message } = getInternalError("NOT_INITIALIZED", this.name);
       throw new Error(message);
     }
   }
+
+  // ---------- Relay Events Router ----------------------------------- //
+
+  private registerRelayerEvents() {
+    this.core.relayer.on(RELAYER_EVENTS.message, async (event: RelayerTypes.MessageEvent) => {
+      const { topic, message } = event;
+      const payload = await this.core.crypto.decode(topic, message);
+      if (isJsonRpcRequest(payload)) {
+        this.history.set(topic, payload);
+        this.onRelayEventRequest({ topic, payload });
+      } else if (isJsonRpcResponse(payload)) {
+        await this.history.resolve(payload);
+        this.onRelayEventResponse({ topic, payload });
+      }
+    });
+  }
+
+  private onRelayEventRequest = (event: any) => {
+    const { topic, payload } = event;
+    const reqMethod = payload.method as PairingJsonRpcTypes.WcMethod;
+
+    switch (reqMethod) {
+      case "wc_pairingPing":
+        return this.onPairingPingRequest(topic, payload);
+      case "wc_pairingDelete":
+        return this.onPairingDeleteRequest(topic, payload);
+      default:
+        return this.logger.info(`Unsupported request method ${reqMethod}`);
+    }
+  };
+
+  private onRelayEventResponse = async (event: any) => {
+    const { topic, payload } = event;
+    const record = await this.history.get(topic, payload.id);
+    const resMethod = record.request.method as PairingJsonRpcTypes.WcMethod;
+
+    switch (resMethod) {
+      case "wc_pairingPing":
+        return this.onPairingPingResponse(topic, payload);
+      default:
+        return this.logger.info(`Unsupported response method ${resMethod}`);
+    }
+  };
+
+  private onPairingPingRequest = async (topic: string, payload: any) => {
+    const { id } = payload;
+    try {
+      // TODO: adapt validation logic from SignClient.Engine.
+      // this.isValidPing({ topic });
+      await this.sendResult<"wc_pairingPing">(id, topic, true);
+      this.events.emit("pairing_ping", { id, topic });
+    } catch (err: any) {
+      await this.sendError(id, topic, err);
+      this.logger.error(err);
+    }
+  };
+
+  private onPairingPingResponse = (_topic: string, payload: any) => {
+    const { id } = payload;
+    if (isJsonRpcResult(payload)) {
+      this.events.emit(engineEvent("pairing_ping", id), {});
+    } else if (isJsonRpcError(payload)) {
+      this.events.emit(engineEvent("pairing_ping", id), { error: payload.error });
+    }
+  };
+
+  private onPairingDeleteRequest = async (topic: string, payload: any) => {
+    const { id } = payload;
+    try {
+      // TODO: adapt validation logic from SignClient.Engine.
+      // this.isValidDisconnect({ topic, reason: payload.params });
+      // RPC request needs to happen before deletion as it utilises pairing encryption
+      await this.sendResult<"wc_pairingDelete">(id, topic, true);
+      await this.deletePairing(topic);
+      this.events.emit("pairing_delete", { id, topic });
+    } catch (err: any) {
+      await this.sendError(id, topic, err);
+      this.logger.error(err);
+    }
+  };
 }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -10,7 +10,7 @@ import {
 } from "@walletconnect/logger";
 import { CoreTypes, ICore } from "@walletconnect/types";
 
-import { Crypto, Relayer } from "./controllers";
+import { Crypto, Relayer, Pairing } from "./controllers";
 import {
   CORE_CONTEXT,
   CORE_DEFAULT,
@@ -32,6 +32,7 @@ export class Core extends ICore {
   public relayer: ICore["relayer"];
   public crypto: ICore["crypto"];
   public storage: ICore["storage"];
+  public pairing: ICore["pairing"];
 
   private initialized = false;
 
@@ -62,6 +63,7 @@ export class Core extends ICore {
       relayUrl: opts?.relayUrl,
       projectId: this.projectId,
     });
+    this.pairing = new Pairing(this, this.logger);
   }
 
   get context() {
@@ -101,6 +103,7 @@ export class Core extends ICore {
       await this.crypto.init();
       await this.relayer.init();
       await this.heartbeat.init();
+      await this.pairing.init();
       this.initialized = true;
       this.logger.info(`Core Initilization Success`);
     } catch (error) {

--- a/packages/core/test/pairing.spec.ts
+++ b/packages/core/test/pairing.spec.ts
@@ -1,0 +1,130 @@
+import { expect, describe, it, beforeEach } from "vitest";
+import { getDefaultLoggerOptions } from "@walletconnect/logger";
+import { IPairing } from "@walletconnect/types";
+import pino from "pino";
+import { Core, CORE_DEFAULT, CORE_PROTOCOL, CORE_VERSION, Pairing } from "../src";
+import { TEST_CORE_OPTIONS } from "./shared";
+
+const waitForEvent = async (checkForEvent: (...args: any[]) => boolean) => {
+  await new Promise((resolve) => {
+    const intervalId = setInterval(() => {
+      if (checkForEvent()) {
+        clearInterval(intervalId);
+        resolve({});
+      }
+    }, 100);
+  });
+};
+
+const createPairingClient: () => Promise<IPairing> = async () => {
+  const core = new Core(TEST_CORE_OPTIONS);
+  await core.start();
+  return core.pairing;
+};
+
+describe("Pairing", () => {
+  describe("init", () => {
+    it("initializes", async () => {
+      const pairing = await createPairingClient();
+      expect(pairing.pairings).toBeDefined();
+    });
+  });
+
+  describe("create", () => {
+    it("returns the pairing topic and URI in expected format", async () => {
+      const pairing = await createPairingClient();
+      const { topic, uri } = await pairing.create();
+      expect(topic.length).toBe(64);
+      expect(uri.startsWith(`${CORE_PROTOCOL}:${topic}@${CORE_VERSION}`)).toBe(true);
+    });
+  });
+
+  describe("pair", () => {
+    it("can pair via provided URI", async () => {
+      const pairing = await createPairingClient();
+      const pairingPeer = await createPairingClient();
+      const { uri } = await pairing.create();
+      await pairingPeer.pair({ uri });
+
+      expect(pairing.pairings.keys.length).toBe(1);
+      expect(pairingPeer.pairings.keys.length).toBe(1);
+      expect(pairing.pairings.keys).to.deep.equal(pairingPeer.pairings.keys);
+    });
+  });
+
+  describe("activate", () => {
+    it("can activate a pairing", async () => {
+      const pairing = await createPairingClient();
+      const { topic } = await pairing.create();
+
+      const inactivePairing = pairing.pairings.get(topic);
+      expect(inactivePairing.active).toBe(false);
+      await pairing.activate({ topic });
+      expect(pairing.pairings.get(topic).active).toBe(true);
+      expect(pairing.pairings.get(topic).expiry > inactivePairing.expiry).toBe(true);
+    });
+  });
+
+  describe("updateExpiry", () => {
+    it("can update a pairing's expiry", async () => {
+      const mockExpiry = 11111111;
+      const pairing = await createPairingClient();
+      const { topic } = await pairing.create();
+
+      await pairing.updateExpiry({ topic, expiry: mockExpiry });
+      expect(pairing.pairings.get(topic).expiry).toBe(mockExpiry);
+    });
+  });
+
+  describe("updateMetadata", () => {
+    it("can update a pairing's `peerMetadata`", async () => {
+      const mockMetadata = { name: "Mock", description: "Mock Metadata" };
+      const pairing = await createPairingClient();
+      const { topic } = await pairing.create();
+
+      expect(pairing.pairings.get(topic).peerMetadata).toBeUndefined();
+      await pairing.updateMetadata({ topic, metadata: mockMetadata });
+      expect(pairing.pairings.get(topic).peerMetadata).toEqual(mockMetadata);
+    });
+  });
+
+  describe("ping", () => {
+    it("clients can ping each other", async () => {
+      const pairing = await createPairingClient();
+      const pairingPeer = await createPairingClient();
+      const { uri, topic } = await pairing.create();
+      let gotPing = false;
+
+      pairingPeer.events.on("pairing_ping", () => {
+        gotPing = true;
+      });
+
+      await pairingPeer.pair({ uri });
+      await pairing.ping({ topic });
+      await waitForEvent(() => gotPing);
+
+      expect(gotPing).toBe(true);
+    });
+  });
+
+  describe("disconnect", () => {
+    it("can disconnect a known pairing", async () => {
+      const pairing = await createPairingClient();
+      const pairingPeer = await createPairingClient();
+      const { uri, topic } = await pairing.create();
+      let hasDeleted = false;
+
+      pairing.events.on("pairing_delete", () => {
+        hasDeleted = true;
+      });
+
+      await pairingPeer.pair({ uri });
+      await pairingPeer.disconnect({ topic });
+      await waitForEvent(() => hasDeleted);
+
+      expect(pairing.pairings.keys.length).toBe(0);
+      expect(pairingPeer.pairings.keys.length).toBe(0);
+      expect(pairing.pairings.keys).to.deep.equal(pairingPeer.pairings.keys);
+    });
+  });
+});

--- a/packages/types/src/core/core.ts
+++ b/packages/types/src/core/core.ts
@@ -6,6 +6,7 @@ import { IKeyValueStorage, KeyValueStorageOptions } from "@walletconnect/keyvalu
 import { ICrypto } from "./crypto";
 import { IRelayer } from "./relayer";
 import { IKeyChain } from "./keychain";
+import { IPairing } from "./pairing";
 
 export declare namespace CoreTypes {
   interface Options {
@@ -33,6 +34,7 @@ export abstract class ICore extends IEvents {
   public abstract crypto: ICrypto;
   public abstract relayer: IRelayer;
   public abstract storage: IKeyValueStorage;
+  public abstract pairing: IPairing;
 
   constructor(public opts?: CoreTypes.Options) {
     super();


### PR DESCRIPTION
# Description

- Part of: #1477 

- feat: implements Pairing class public interface
- feat: integrate relayer logic for pairing-specific events
- test: expands pairing test suite happy path
- feat: initialize Pairing controller as part of Core class

### TODO:

- Adjust and re-enable validation checks
- `expirer` has not yet been ported to `core` from `sign-client`
- Expand test suite, port from sign-client where appropriate (e.g. `pair` validations, part of `disconnect` validations etc)

### Next steps

- Tackle above todos
- Start integration into/dogfooding via SignClient

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
