### PR TITLE
fix: sockets remain open after test completion

### DIFF
--- a/packages/core/test/publisher.spec.ts
+++ b/packages/core/test/publisher.spec.ts
@@ -1,29 +1,25 @@
 import { expect, describe, it, beforeEach, afterEach } from "vitest";
-import pino from "pino";
 import Sinon from "sinon";
-import { getDefaultLoggerOptions } from "@walletconnect/logger";
-import { ICore, IPublisher, IRelayer } from "@walletconnect/types";
+import { ICore } from "@walletconnect/types";
 import { generateRandomBytes32, hashMessage } from "@walletconnect/utils";
 import { Publisher } from "../src/controllers/publisher";
 import { HEARTBEAT_EVENTS } from "@walletconnect/heartbeat";
 
-import { Core, CORE_DEFAULT, PUBLISHER_DEFAULT_TTL, Relayer } from "../src";
+import { Core, PUBLISHER_DEFAULT_TTL } from "../src";
 import { disconnectSocket, TEST_CORE_OPTIONS, throttle } from "./shared";
 
 describe("Publisher", () => {
-  const logger = pino(getDefaultLoggerOptions({ level: CORE_DEFAULT.logger }));
-
   let core: ICore;
   let publisher: Publisher;
 
   beforeEach(async () => {
-    if (core) {
-      await disconnectSocket(core);
-    }
-
     core = new Core(TEST_CORE_OPTIONS);
     await core.start();
     publisher = core.relayer.publisher as Publisher;
+  });
+
+  afterEach(async () => {
+    await disconnectSocket(core.relayer);
   });
 
   describe("init", () => {

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -23,19 +23,18 @@ describe("Relayer", () => {
   let relayer: IRelayer;
 
   beforeEach(async () => {
-    if (core) {
-      await disconnectSocket(core);
-    }
-
     core = new Core(TEST_CORE_OPTIONS);
     await core.start();
-
     relayer = core.relayer;
+  });
+
+  afterEach(async () => {
+    await disconnectSocket(core.relayer);
   });
 
   describe("init", () => {
     let initSpy: Sinon.SinonSpy;
-    beforeEach(() => {
+    beforeEach(async () => {
       initSpy = Sinon.spy();
       relayer = new Relayer({
         core,
@@ -43,6 +42,10 @@ describe("Relayer", () => {
         relayUrl: TEST_CORE_OPTIONS.relayUrl,
         projectId: TEST_CORE_OPTIONS.projectId,
       });
+    });
+
+    afterEach(async () => {
+      await disconnectSocket(relayer);
     });
 
     it("initializes a MessageTracker", async () => {
@@ -76,9 +79,20 @@ describe("Relayer", () => {
   });
 
   describe("publish", () => {
+    let relayer;
     beforeEach(async () => {
+      relayer = new Relayer({
+        core,
+        logger,
+        relayUrl: TEST_CORE_OPTIONS.relayUrl,
+        projectId: TEST_CORE_OPTIONS.projectId,
+      });
       await relayer.init();
     });
+    afterEach(async () => {
+      await disconnectSocket(relayer);
+    });
+
     const topic = "abc123";
     const message = "publish me";
     it("calls `publisher.publish` with provided args", async () => {
@@ -97,9 +111,20 @@ describe("Relayer", () => {
   });
 
   describe("subscribe", () => {
+    let relayer;
     beforeEach(async () => {
+      relayer = new Relayer({
+        core,
+        logger,
+        relayUrl: TEST_CORE_OPTIONS.relayUrl,
+        projectId: TEST_CORE_OPTIONS.projectId,
+      });
       await relayer.init();
     });
+    afterEach(async () => {
+      await disconnectSocket(relayer);
+    });
+
     it("returns the id provided by calling `subscriber.subscribe` with the passed topic", async () => {
       const spy = Sinon.spy(() => "mock-id");
       // @ts-expect-error
@@ -112,8 +137,18 @@ describe("Relayer", () => {
   });
 
   describe("unsubscribe", () => {
+    let relayer;
     beforeEach(async () => {
+      relayer = new Relayer({
+        core,
+        logger,
+        relayUrl: TEST_CORE_OPTIONS.relayUrl,
+        projectId: TEST_CORE_OPTIONS.projectId,
+      });
       await relayer.init();
+    });
+    afterEach(async () => {
+      await disconnectSocket(relayer);
     });
     it("calls `subscriber.unsubscribe` with the passed topic", async () => {
       const spy = Sinon.spy();
@@ -124,9 +159,20 @@ describe("Relayer", () => {
   });
 
   describe("onProviderPayload", () => {
+    let relayer;
     beforeEach(async () => {
+      relayer = new Relayer({
+        core,
+        logger,
+        relayUrl: TEST_CORE_OPTIONS.relayUrl,
+        projectId: TEST_CORE_OPTIONS.projectId,
+      });
       await relayer.init();
     });
+    afterEach(async () => {
+      await disconnectSocket(relayer);
+    });
+
     const validPayload: JsonRpcRequest = {
       id: 123,
       jsonrpc: "2.0",

--- a/packages/core/test/shared/ws.ts
+++ b/packages/core/test/shared/ws.ts
@@ -1,8 +1,10 @@
 import { IRelayer } from "@walletconnect/types";
+import EventEmitter from "events";
 
 export async function disconnectSocket(relayer: IRelayer) {
   if (relayer.connected) {
-    relayer.provider.connect = () => new Promise<void>((resolve) => resolve);
+    // override the events to disable reconnection
+    relayer.provider.events = new EventEmitter();
     await relayer.provider.connection.close();
   }
 }

--- a/packages/core/test/shared/ws.ts
+++ b/packages/core/test/shared/ws.ts
@@ -1,8 +1,8 @@
-import { ICore } from "@walletconnect/types";
+import { IRelayer } from "@walletconnect/types";
 
-export async function disconnectSocket(core: ICore) {
-  if (core.relayer.connected) {
-    core.relayer.provider.connect = () => new Promise<void>((resolve) => resolve);
-    await core.relayer.provider.connection.close();
+export async function disconnectSocket(relayer: IRelayer) {
+  if (relayer.connected) {
+    relayer.provider.connect = () => new Promise<void>((resolve) => resolve);
+    await relayer.provider.connection.close();
   }
 }

--- a/packages/core/test/shared/ws.ts
+++ b/packages/core/test/shared/ws.ts
@@ -1,10 +1,18 @@
+import { IJsonRpcConnection } from "@walletconnect/jsonrpc-utils";
 import { IRelayer } from "@walletconnect/types";
 import EventEmitter from "events";
 
 export async function disconnectSocket(relayer: IRelayer) {
   if (relayer.connected) {
-    // override the events to disable reconnection
     relayer.provider.events = new EventEmitter();
-    await relayer.provider.connection.close();
+    relayer.core.heartbeat.events = new EventEmitter();
+    relayer.provider.connection.on("open", async () => {
+      await disconnect(relayer.provider.connection);
+    });
+    await disconnect(relayer.provider.connection);
   }
+}
+
+function disconnect(socket: IJsonRpcConnection) {
+  return socket.close();
 }

--- a/packages/core/test/subscriber.spec.ts
+++ b/packages/core/test/subscriber.spec.ts
@@ -1,4 +1,4 @@
-import { expect, describe, it, beforeEach, afterEach } from "vitest";
+import { expect, describe, it, beforeEach, afterAll, afterEach } from "vitest";
 import pino from "pino";
 import Sinon from "sinon";
 import { getDefaultLoggerOptions } from "@walletconnect/logger";
@@ -16,15 +16,6 @@ import {
   SUBSCRIBER_CONTEXT,
 } from "../src";
 import { disconnectSocket, TEST_CORE_OPTIONS } from "./shared";
-const exec = require("child_process").exec;
-
-exec("cat /proc/sys/net/ipv4/tcp_mem", function (error, stdout, stderr) {
-  console.log("stdout: " + stdout);
-  console.log("stderr: " + stderr);
-  if (error !== null) {
-    console.log("exec error: " + error);
-  }
-});
 
 describe("Subscriber", () => {
   const logger = pino(getDefaultLoggerOptions({ level: CORE_DEFAULT.logger }));
@@ -34,10 +25,6 @@ describe("Subscriber", () => {
   let core: ICore;
 
   beforeEach(async () => {
-    if (core) {
-      await disconnectSocket(core);
-    }
-
     core = new Core(TEST_CORE_OPTIONS);
     await core.start();
 
@@ -45,6 +32,10 @@ describe("Subscriber", () => {
     subscriber = relayer.subscriber; //new Subscriber(relayer, logger);
     subscriber.relayer.provider.request = () => Promise.resolve({} as any);
     await subscriber.init();
+  });
+
+  afterEach(async () => {
+    await disconnectSocket(core.relayer);
   });
 
   it("provides the expected `storageKey` format", () => {

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -1,12 +1,11 @@
 import { getSdkError, generateRandomBytes32 } from "@walletconnect/utils";
-import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
+import { expect, describe, it, vi } from "vitest";
 import SignClient from "../../src";
 import {
   initTwoClients,
   testConnectMethod,
   TEST_SIGN_CLIENT_OPTIONS,
   deleteClients,
-  Clients,
   disconnectSocket,
 } from "../shared";
 
@@ -49,6 +48,8 @@ describe("Sign Client Integration", () => {
         const reason = getSdkError("USER_DISCONNECTED");
         await clients.A.disconnect({ topic, reason });
         expect(() => clients.A.pairing.get(topic)).to.throw(`No matching key. pairing: ${topic}`);
+        await disconnectSocket(clients.A.core);
+        await disconnectSocket(clients.B.core);
         const promise = clients.A.ping({ topic });
         await expect(promise).rejects.toThrowError(
           `No matching key. session or pairing topic doesn't exist: ${topic}`,
@@ -64,11 +65,9 @@ describe("Sign Client Integration", () => {
         } = await testConnectMethod(clients);
         const reason = getSdkError("USER_DISCONNECTED");
         await clients.A.disconnect({ topic, reason });
+        await disconnectSocket(clients.A.core);
+        await disconnectSocket(clients.B.core);
         expect(() => clients.A.session.get(topic)).to.throw(`No matching key. session: ${topic}`);
-        const promise = clients.A.ping({ topic });
-        await expect(promise).rejects.toThrowError(
-          `No matching key. session or pairing topic doesn't exist: ${topic}`,
-        );
         await deleteClients(clients);
       });
     });

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -17,6 +17,7 @@ describe("Sign Client Integration", () => {
   it("init", async () => {
     const client = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS);
     expect(client).to.be.exist;
+    await disconnectSocket(client.core);
   });
 
   describe("connect", () => {

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -42,17 +42,14 @@ describe("Sign Client Integration", () => {
   describe("disconnect", () => {
     let clients: Clients;
     beforeEach(async () => {
-      console.log("init clients");
       clients = await initTwoClients();
-      console.log("init clients done");
     });
     afterEach(async () => {
-      console.log("delete clients");
-      // if (!!clients.A && !!clients.B) {
-      await deleteClients(clients);
-
-      console.log("delete clients done");
-      // }
+      if (clients) {
+        await deleteClients(clients);
+      } else {
+        console.warn("clients not initialized");
+      }
     });
     describe("pairing", () => {
       it("deletes the pairing on disconnect", async () => {

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -42,14 +42,20 @@ describe("Sign Client Integration", () => {
   describe("disconnect", () => {
     let clients: Clients;
     beforeEach(async () => {
+      console.log("init clients");
       clients = await initTwoClients();
+      console.log("init clients done");
     });
     afterEach(async () => {
-      console.log(!!clients.A, !!clients.B);
+      console.log("delete clients");
+      // if (!!clients.A && !!clients.B) {
       await deleteClients(clients);
+
+      console.log("delete clients done");
+      // }
     });
     describe("pairing", () => {
-      it("deletes the pairing on disconnect", async () => {
+      it.only("deletes the pairing on disconnect", async () => {
         const {
           pairingA: { topic },
         } = await testConnectMethod(clients);
@@ -63,7 +69,7 @@ describe("Sign Client Integration", () => {
       });
     });
     describe("session", () => {
-      it("deletes the session on disconnect", async () => {
+      it.only("deletes the session on disconnect", async () => {
         const {
           sessionA: { topic },
         } = await testConnectMethod(clients);

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -45,9 +45,6 @@ describe("Sign Client Integration", () => {
       clients = await initTwoClients();
     });
 
-    afterEach(async () => {
-      await deleteClients(clients);
-    });
     afterEach(async (done) => {
       const { result } = done.meta;
       if (result?.state.toString() !== "pass") {
@@ -60,6 +57,9 @@ describe("Sign Client Integration", () => {
             done.meta.name
           } failed with client ids: A:'${await clients.A.core.crypto.getClientId()}';B:'${await clients.B.core.crypto.getClientId()}'`,
         );
+      }
+      if (clients?.A && clients?.B) {
+        await deleteClients(clients);
       }
     });
     describe("pairing", () => {

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -186,14 +186,12 @@ describe("Sign Client Integration", () => {
             sessionA: { topic },
           } = await testConnectMethod(clients);
           await clients.A.ping({ topic });
-          deleteClients(clients);
         });
         it("B pings A", async () => {
           const {
             sessionA: { topic },
           } = await testConnectMethod(clients);
           await clients.B.ping({ topic });
-          deleteClients(clients);
         });
       });
       describe("after restart", () => {

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -70,6 +70,7 @@ describe("Sign Client Integration", () => {
     });
     describe("session", () => {
       it("deletes the session on disconnect", async () => {
+        console.log("disconnect", !!clients);
         const {
           sessionA: { topic },
         } = await testConnectMethod(clients);
@@ -80,6 +81,7 @@ describe("Sign Client Integration", () => {
         await expect(promise).rejects.toThrowError(
           `No matching key. session or pairing topic doesn't exist: ${topic}`,
         );
+        console.log("disconnect done", !!clients);
       });
     });
   });

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -44,23 +44,8 @@ describe("Sign Client Integration", () => {
     beforeEach(async () => {
       clients = await initTwoClients();
     });
-
-    afterEach(async (done) => {
-      const { result } = done.meta;
-      if (result?.state.toString() !== "pass") {
-        if (!clients || !clients.A || !clients.B) {
-          console.log("Clients failed to initialize");
-          return;
-        }
-        console.log(
-          `Test ${
-            done.meta.name
-          } failed with client ids: A:'${await clients.A.core.crypto.getClientId()}';B:'${await clients.B.core.crypto.getClientId()}'`,
-        );
-      }
-      if (clients?.A && clients?.B) {
-        await deleteClients(clients);
-      }
+    afterEach(async () => {
+      await deleteClients(clients);
     });
     describe("pairing", () => {
       it("deletes the pairing on disconnect", async () => {
@@ -105,34 +90,22 @@ describe("Sign Client Integration", () => {
       describe("with existing pairing", () => {
         let clients;
         beforeEach(async () => {
-          if (clients?.A && clients?.B) {
-            await deleteClients(clients);
-          }
           clients = await initTwoClients();
         });
-        afterEach(async (done) => {
-          const { result } = done.meta;
-          if (result?.state.toString() !== "pass") {
-            console.log(
-              `Test ${
-                done.meta.name
-              } failed with client ids: A:'${await clients.A.core.crypto.getClientId()}';B:'${await clients.B.core.crypto.getClientId()}'`,
-            );
-          }
+        afterEach(async () => {
+          await deleteClients(clients);
         });
         it("A pings B", async () => {
           const {
             pairingA: { topic },
           } = await testConnectMethod(clients);
           await clients.A.ping({ topic });
-          await deleteClients(clients);
         });
         it("B pings A", async () => {
           const {
             pairingA: { topic },
           } = await testConnectMethod(clients);
           await clients.B.ping({ topic });
-          await deleteClients(clients);
         });
       });
       describe("after restart", () => {
@@ -141,9 +114,6 @@ describe("Sign Client Integration", () => {
         const db_a = generateClientDbName("client_a");
         const db_b = generateClientDbName("client_b");
         beforeEach(async () => {
-          if (beforeClients?.A && beforeClients?.B) {
-            await deleteClients(beforeClients);
-          }
           beforeClients = await initTwoClients(
             {
               storageOptions: { database: db_a },
@@ -155,29 +125,8 @@ describe("Sign Client Integration", () => {
             },
           );
         });
-        afterEach(async (done) => {
-          const { result } = done.meta;
-          if (result?.state.toString() !== "pass") {
-            if (!beforeClients || !beforeClients.A || !beforeClients.B) {
-              console.log("Clients failed to initialize or removed");
-            } else {
-              console.log(
-                `Test ${
-                  done.meta.name
-                } failed with before client ids: A:'${await beforeClients.A.core.crypto.getClientId()}';B:'${await beforeClients.B.core.crypto.getClientId()}'`,
-              );
-            }
-
-            if (!afterClients || !afterClients.A || !afterClients.B) {
-              console.log("afterClients failed to initialize or removed");
-              return;
-            }
-            console.log(
-              `Test ${
-                done.meta.name
-              } failed with after client ids: A:'${await afterClients.A.core.crypto.getClientId()}';B:'${await afterClients.B.core.crypto.getClientId()}'`,
-            );
-          }
+        afterEach(async () => {
+          await deleteClients(afterClients);
         });
         it("clients can ping each other", async () => {
           const {
@@ -205,9 +154,6 @@ describe("Sign Client Integration", () => {
           ]);
 
           await deleteClients(beforeClients);
-          if (afterClients) {
-            await deleteClients(afterClients);
-          }
 
           // restart
           afterClients = await initTwoClients(
@@ -223,7 +169,6 @@ describe("Sign Client Integration", () => {
           // ping
           await afterClients.A.ping({ topic });
           await afterClients.B.ping({ topic });
-          deleteClients(afterClients);
         });
       });
     });
@@ -231,20 +176,10 @@ describe("Sign Client Integration", () => {
       describe("with existing session", () => {
         let clients: Clients;
         beforeEach(async () => {
-          if (clients?.A && clients?.B) {
-            await deleteClients(clients);
-          }
           clients = await initTwoClients();
         });
-        afterEach(async (done) => {
-          const { result } = done.meta;
-          if (result?.state.toString() !== "pass") {
-            console.log(
-              `Test ${
-                done.meta.name
-              } failed with client ids: A:'${await clients.A.core.crypto.getClientId()}';B:'${await clients.B.core.crypto.getClientId()}'`,
-            );
-          }
+        afterEach(async () => {
+          await deleteClients(clients);
         });
         it("A pings B", async () => {
           const {
@@ -267,9 +202,6 @@ describe("Sign Client Integration", () => {
         const db_a = generateClientDbName("client_a");
         const db_b = generateClientDbName("client_b");
         beforeEach(async () => {
-          if (beforeClients?.A && beforeClients?.B) {
-            await deleteClients(beforeClients);
-          }
           beforeClients = await initTwoClients(
             {
               storageOptions: { database: db_a },
@@ -279,29 +211,8 @@ describe("Sign Client Integration", () => {
             },
           );
         });
-        afterEach(async (done) => {
-          const { result } = done.meta;
-          if (result?.state.toString() !== "pass") {
-            if (!beforeClients || !beforeClients.A || !beforeClients.B) {
-              console.log("Clients failed to initialize or removed");
-            } else {
-              console.log(
-                `Test ${
-                  done.meta.name
-                } failed with before client ids: A:'${await beforeClients.A.core.crypto.getClientId()}';B:'${await beforeClients.B.core.crypto.getClientId()}'`,
-              );
-            }
-
-            if (!afterClients || !afterClients.A || !afterClients.B) {
-              console.log("afterClients failed to initialize or removed");
-              return;
-            }
-            console.log(
-              `Test ${
-                done.meta.name
-              } failed with after client ids: A:'${await afterClients.A.core.crypto.getClientId()}';B:'${await afterClients.B.core.crypto.getClientId()}'`,
-            );
-          }
+        afterEach(async () => {
+          await deleteClients(afterClients);
         }, 50_000);
         it("clients can ping each other", async () => {
           const {
@@ -330,9 +241,7 @@ describe("Sign Client Integration", () => {
 
           // delete
           await deleteClients(beforeClients);
-          if (afterClients) {
-            await deleteClients(afterClients);
-          }
+
           // restart
           afterClients = await initTwoClients(
             {
@@ -346,9 +255,8 @@ describe("Sign Client Integration", () => {
           // ping
           await afterClients.A.ping({ topic });
           await afterClients.B.ping({ topic });
-          await deleteClients(afterClients);
         });
-      }, 50_000);
+      });
     });
   });
 
@@ -389,7 +297,6 @@ describe("Sign Client Integration", () => {
       await deleteClients(clients);
     });
     it("updates session expiry state", async () => {
-      clients = await initTwoClients();
       const {
         sessionA: { topic },
       } = await testConnectMethod(clients);

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -55,7 +55,7 @@ describe("Sign Client Integration", () => {
       // }
     });
     describe("pairing", () => {
-      it.only("deletes the pairing on disconnect", async () => {
+      it("deletes the pairing on disconnect", async () => {
         const {
           pairingA: { topic },
         } = await testConnectMethod(clients);
@@ -69,7 +69,7 @@ describe("Sign Client Integration", () => {
       });
     });
     describe("session", () => {
-      it.only("deletes the session on disconnect", async () => {
+      it("deletes the session on disconnect", async () => {
         const {
           sessionA: { topic },
         } = await testConnectMethod(clients);

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -42,10 +42,11 @@ describe("Sign Client Integration", () => {
   describe("disconnect", () => {
     let clients: Clients;
     beforeEach(async () => {
-      if (clients?.A && clients?.B) {
-        await deleteClients(clients);
-      }
       clients = await initTwoClients();
+    });
+
+    afterEach(async () => {
+      await deleteClients(clients);
     });
     afterEach(async (done) => {
       const { result } = done.meta;
@@ -73,7 +74,6 @@ describe("Sign Client Integration", () => {
         await expect(promise).rejects.toThrowError(
           `No matching key. session or pairing topic doesn't exist: ${topic}`,
         );
-        await deleteClients(clients);
       });
     });
     describe("session", () => {
@@ -88,7 +88,6 @@ describe("Sign Client Integration", () => {
         await expect(promise).rejects.toThrowError(
           `No matching key. session or pairing topic doesn't exist: ${topic}`,
         );
-        await deleteClients(clients);
       });
     });
   });

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -45,6 +45,7 @@ describe("Sign Client Integration", () => {
       clients = await initTwoClients();
     });
     afterEach(async () => {
+      console.log(!!clients.A, !!clients.B);
       await deleteClients(clients);
     });
     describe("pairing", () => {

--- a/packages/sign-client/test/sdk/events.spec.ts
+++ b/packages/sign-client/test/sdk/events.spec.ts
@@ -42,7 +42,7 @@ describe("Sign Client Events Validation", () => {
           `Test ${done.meta.name} failed with client ids: A:'${clientAId}';B:'${clientBId}'`,
         );
       }
-      if (clients) {
+      if (clients?.A && clients?.B) {
         await deleteClients(clients);
       }
     });

--- a/packages/sign-client/test/sdk/events.spec.ts
+++ b/packages/sign-client/test/sdk/events.spec.ts
@@ -99,7 +99,7 @@ describe("Sign Client Events Validation", () => {
             }
           }),
         ]);
-        await deleteClients(clients);
+        await deleteClients({ A, B });
       });
     });
     describe("session_update", () => {
@@ -172,7 +172,7 @@ describe("Sign Client Events Validation", () => {
           ...TEST_EMIT_PARAMS,
         };
 
-        await new Promise<void>((resolve, reject) => {
+        await new Promise<void>(async (resolve, reject) => {
           try {
             clients.B.on("session_event", (event) => {
               expect(TEST_EMIT_PARAMS).to.eql(event.params);
@@ -180,7 +180,7 @@ describe("Sign Client Events Validation", () => {
               resolve();
             });
 
-            clients.A.emit(eventPayload);
+            await clients.A.emit(eventPayload);
           } catch (e) {
             reject(e);
           }
@@ -204,14 +204,14 @@ describe("Sign Client Events Validation", () => {
           ...TEST_EMIT_PARAMS,
         };
 
-        await new Promise<void>((resolve, reject) => {
+        await new Promise<void>(async (resolve, reject) => {
           try {
             clients.B.on("session_delete", (event) => {
               expect(eventPayload.topic).to.eql(event.topic);
               resolve();
             });
 
-            clients.A.disconnect({
+            await clients.A.disconnect({
               topic: sessionA.topic,
               reason: getSdkError("USER_DISCONNECTED"),
             });

--- a/packages/sign-client/test/sdk/events.spec.ts
+++ b/packages/sign-client/test/sdk/events.spec.ts
@@ -21,15 +21,9 @@ describe("Sign Client Events Validation", () => {
   });
 
   describe("session", () => {
-    let clients;
-    beforeEach(async () => {
-      clients = await initTwoClients();
-    });
-    afterEach(async () => {
-      await deleteClients(clients);
-    });
     describe("session_proposal", () => {
       it("emits and handles a valid session_proposal", async () => {
+        const clients = await initTwoClients();
         const { A, B } = clients;
 
         const connectParams: EngineTypes.ConnectParams = {
@@ -105,10 +99,12 @@ describe("Sign Client Events Validation", () => {
             }
           }),
         ]);
+        await deleteClients(clients);
       });
     });
     describe("session_update", () => {
       it("emits and handles a valid session_update", async () => {
+        const clients = await initTwoClients();
         const { sessionA } = await testConnectMethod(clients);
 
         await new Promise<void>(async (resolve, reject) => {
@@ -137,10 +133,12 @@ describe("Sign Client Events Validation", () => {
             reject(e);
           }
         });
+        await deleteClients(clients);
       });
     });
     describe("session_ping", () => {
       it("emits and handles a valid session_ping", async () => {
+        const clients = await initTwoClients();
         const { sessionA } = await testConnectMethod(clients);
 
         await new Promise<void>(async (resolve, reject) => {
@@ -155,10 +153,12 @@ describe("Sign Client Events Validation", () => {
             reject(e);
           }
         });
+        await deleteClients(clients);
       });
     });
     describe("session_event", () => {
       it("emits and handles a valid session_event", async () => {
+        const clients = await initTwoClients();
         const connectParams: EngineTypes.ConnectParams = {
           requiredNamespaces: TEST_REQUIRED_NAMESPACES,
           relays: undefined,
@@ -185,10 +185,12 @@ describe("Sign Client Events Validation", () => {
             reject(e);
           }
         });
+        await deleteClients(clients);
       });
     });
     describe("session_delete", () => {
       it("emits and handles a valid session_delete", async () => {
+        const clients = await initTwoClients();
         const connectParams: EngineTypes.ConnectParams = {
           requiredNamespaces: TEST_REQUIRED_NAMESPACES,
           relays: undefined,
@@ -217,6 +219,7 @@ describe("Sign Client Events Validation", () => {
             reject(e);
           }
         });
+        await deleteClients(clients);
       });
     });
   });

--- a/packages/sign-client/test/sdk/events.spec.ts
+++ b/packages/sign-client/test/sdk/events.spec.ts
@@ -9,6 +9,7 @@ import {
   TEST_NAMESPACES,
   TEST_REQUIRED_NAMESPACES,
   TEST_EMIT_PARAMS,
+  disconnectSocket,
 } from "../shared";
 import { EngineTypes, PairingTypes, SessionTypes } from "@walletconnect/types";
 
@@ -16,6 +17,7 @@ describe("Sign Client Events Validation", () => {
   it("init", async () => {
     const client = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS);
     expect(client).to.be.exist;
+    await disconnectSocket(client.core);
   });
 
   describe("session", () => {

--- a/packages/sign-client/test/sdk/events.spec.ts
+++ b/packages/sign-client/test/sdk/events.spec.ts
@@ -42,7 +42,7 @@ describe("Sign Client Events Validation", () => {
           `Test ${done.meta.name} failed with client ids: A:'${clientAId}';B:'${clientBId}'`,
         );
       }
-      if (clients.A && clients.B) {
+      if (clients) {
         await deleteClients(clients);
       }
     });

--- a/packages/sign-client/test/sdk/events.spec.ts
+++ b/packages/sign-client/test/sdk/events.spec.ts
@@ -42,6 +42,8 @@ describe("Sign Client Events Validation", () => {
           `Test ${done.meta.name} failed with client ids: A:'${clientAId}';B:'${clientBId}'`,
         );
       }
+
+      await deleteClients(clients);
     });
     describe("session_proposal", () => {
       it("emits and handles a valid session_proposal", async () => {
@@ -120,8 +122,6 @@ describe("Sign Client Events Validation", () => {
             }
           }),
         ]);
-
-        deleteClients(clients);
       });
     });
     describe("session_update", () => {
@@ -154,8 +154,6 @@ describe("Sign Client Events Validation", () => {
             reject(e);
           }
         });
-
-        deleteClients(clients);
       });
     });
     describe("session_ping", () => {
@@ -174,8 +172,6 @@ describe("Sign Client Events Validation", () => {
             reject(e);
           }
         });
-
-        deleteClients(clients);
       });
     });
     describe("session_event", () => {
@@ -206,7 +202,6 @@ describe("Sign Client Events Validation", () => {
             reject(e);
           }
         });
-        deleteClients(clients);
       });
     });
     describe("session_delete", () => {
@@ -239,7 +234,6 @@ describe("Sign Client Events Validation", () => {
             reject(e);
           }
         });
-        deleteClients(clients);
       });
     });
   });

--- a/packages/sign-client/test/sdk/events.spec.ts
+++ b/packages/sign-client/test/sdk/events.spec.ts
@@ -25,26 +25,8 @@ describe("Sign Client Events Validation", () => {
     beforeEach(async () => {
       clients = await initTwoClients();
     });
-    afterEach(async (done) => {
-      const { result } = done.meta;
-      if (result?.state.toString() !== "pass") {
-        if (!clients) {
-          console.log("Clients not defined");
-          return;
-        }
-        const clientAId =
-          (clients.A && (await clients.A.core.crypto.getClientId())) ||
-          "not initialized or removed";
-        const clientBId =
-          (clients.B && (await clients.B.core.crypto.getClientId())) ||
-          "not initialized or removed";
-        console.log(
-          `Test ${done.meta.name} failed with client ids: A:'${clientAId}';B:'${clientBId}'`,
-        );
-      }
-      if (clients?.A && clients?.B) {
-        await deleteClients(clients);
-      }
+    afterEach(async () => {
+      await deleteClients(clients);
     });
     describe("session_proposal", () => {
       it("emits and handles a valid session_proposal", async () => {

--- a/packages/sign-client/test/sdk/events.spec.ts
+++ b/packages/sign-client/test/sdk/events.spec.ts
@@ -42,8 +42,9 @@ describe("Sign Client Events Validation", () => {
           `Test ${done.meta.name} failed with client ids: A:'${clientAId}';B:'${clientBId}'`,
         );
       }
-
-      await deleteClients(clients);
+      if (clients.A && clients.B) {
+        await deleteClients(clients);
+      }
     });
     describe("session_proposal", () => {
       it("emits and handles a valid session_proposal", async () => {

--- a/packages/sign-client/test/shared/helpers.ts
+++ b/packages/sign-client/test/shared/helpers.ts
@@ -2,8 +2,8 @@ import SignClient from "../../src";
 import { disconnectSocket } from "./ws";
 
 export async function deleteClients(clients: { A: SignClient; B: SignClient }) {
-  await disconnectSocket(clients.A.core);
-  await disconnectSocket(clients.B.core);
+  await disconnectSocket(clients?.A?.core);
+  await disconnectSocket(clients?.B?.core);
 
   delete clients.A;
   delete clients.B;

--- a/packages/sign-client/test/shared/helpers.ts
+++ b/packages/sign-client/test/shared/helpers.ts
@@ -2,8 +2,8 @@ import SignClient from "../../src";
 import { disconnectSocket } from "./ws";
 
 export async function deleteClients(clients: { A: SignClient; B: SignClient }) {
-  await disconnectSocket(clients?.A?.core);
-  await disconnectSocket(clients?.B?.core);
+  await disconnectSocket(clients.A.core);
+  await disconnectSocket(clients.B.core);
 
   delete clients.A;
   delete clients.B;

--- a/packages/sign-client/test/shared/helpers.ts
+++ b/packages/sign-client/test/shared/helpers.ts
@@ -7,8 +7,6 @@ export async function deleteClients(clients: { A: SignClient; B: SignClient }) {
 
   delete clients.A;
   delete clients.B;
-
-  await throttle(500);
 }
 
 export async function throttle(timeout: number) {

--- a/packages/sign-client/test/shared/init.ts
+++ b/packages/sign-client/test/shared/init.ts
@@ -17,10 +17,14 @@ export async function initTwoClients(
     ...sharedClientOpts,
     ...clientOptsA,
   });
+
+  console.log("client A ", !!A);
   const B = await SignClient.init({
     ...TEST_SIGN_CLIENT_OPTIONS_B,
     ...sharedClientOpts,
     ...clientOptsB,
   });
+
+  console.log("client B ", !!B);
   return { A, B };
 }

--- a/packages/sign-client/test/shared/init.ts
+++ b/packages/sign-client/test/shared/init.ts
@@ -18,13 +18,10 @@ export async function initTwoClients(
     ...clientOptsA,
   });
 
-  console.log("client A ", !!A);
   const B = await SignClient.init({
     ...TEST_SIGN_CLIENT_OPTIONS_B,
     ...sharedClientOpts,
     ...clientOptsB,
   });
-
-  console.log("client B ", !!B);
   return { A, B };
 }

--- a/packages/sign-client/test/shared/ws.ts
+++ b/packages/sign-client/test/shared/ws.ts
@@ -5,6 +5,7 @@ import EventEmitter from "events";
 export async function disconnectSocket(core: ICore) {
   if (core.relayer.connected) {
     core.relayer.provider.events = new EventEmitter();
+    core.relayer.core.heartbeat.events = new EventEmitter();
     core.relayer.provider.connection.on("open", async () => {
       await disconnect(core.relayer.provider.connection);
     });

--- a/packages/sign-client/test/shared/ws.ts
+++ b/packages/sign-client/test/shared/ws.ts
@@ -5,16 +5,12 @@ export async function disconnectSocket(core: ICore) {
   if (core.relayer.connected) {
     core.relayer.provider.connect = () => new Promise<void>((resolve) => resolve);
     core.relayer.provider.connection.on("open", async () => {
-      await disconnectSocket(core);
+      await disconnect(core.relayer.provider.connection);
     });
-    core.relayer.provider.events = new EventEmitter();
-    core.relayer.provider.connection.events = new EventEmitter();
     await disconnect(core.relayer.provider.connection);
   }
 }
 
 async function disconnect(socket: any) {
-  if (socket.connected) {
-    await socket.close();
-  }
+  await socket.close();
 }

--- a/packages/sign-client/test/shared/ws.ts
+++ b/packages/sign-client/test/shared/ws.ts
@@ -3,8 +3,18 @@ import EventEmitter from "events";
 
 export async function disconnectSocket(core: ICore) {
   if (core.relayer.connected) {
-    // override the events to disable reconnection
+    core.relayer.provider.connect = () => new Promise<void>((resolve) => resolve);
+    core.relayer.provider.connection.on("open", async () => {
+      await disconnectSocket(core);
+    });
     core.relayer.provider.events = new EventEmitter();
-    await core.relayer.provider.connection.close();
+    core.relayer.provider.connection.events = new EventEmitter();
+    await disconnect(core.relayer.provider.connection);
+  }
+}
+
+async function disconnect(socket: any) {
+  if (socket.connected) {
+    await socket.close();
   }
 }

--- a/packages/sign-client/test/shared/ws.ts
+++ b/packages/sign-client/test/shared/ws.ts
@@ -1,15 +1,10 @@
 import { ICore } from "@walletconnect/types";
+import EventEmitter from "events";
 
 export async function disconnectSocket(core: ICore) {
   if (core.relayer.connected) {
-    core.relayer.provider.connect = () => new Promise<void>((resolve) => resolve);
-    core.relayer.provider.connection.on("open", async () => await disconnectSocket(core));
-    await disconnect(core.relayer.provider.connection);
-  }
-}
-
-async function disconnect(socket: any) {
-  if (socket.connected) {
-    await socket.close();
+    // override the events to disable reconnection
+    core.relayer.provider.events = new EventEmitter();
+    await core.relayer.provider.connection.close();
   }
 }

--- a/packages/sign-client/test/shared/ws.ts
+++ b/packages/sign-client/test/shared/ws.ts
@@ -3,6 +3,16 @@ import { ICore } from "@walletconnect/types";
 export async function disconnectSocket(core: ICore) {
   if (core.relayer.connected) {
     core.relayer.provider.connect = () => new Promise<void>((resolve) => resolve);
-    await core.relayer.provider.connection.close();
+    core.relayer.provider.connection.on(
+      "open",
+      async () => await disconnect(core.relayer.provider.connection),
+    );
+    await disconnect(core.relayer.provider.connection);
+  }
+}
+
+async function disconnect(socket: any) {
+  if (socket.connected) {
+    await socket.close();
   }
 }

--- a/packages/sign-client/test/shared/ws.ts
+++ b/packages/sign-client/test/shared/ws.ts
@@ -1,9 +1,10 @@
+import { IJsonRpcConnection } from "@walletconnect/jsonrpc-utils";
 import { ICore } from "@walletconnect/types";
 import EventEmitter from "events";
 
 export async function disconnectSocket(core: ICore) {
   if (core.relayer.connected) {
-    core.relayer.provider.connect = () => new Promise<void>((resolve) => resolve);
+    core.relayer.provider.events = new EventEmitter();
     core.relayer.provider.connection.on("open", async () => {
       await disconnect(core.relayer.provider.connection);
     });
@@ -11,6 +12,6 @@ export async function disconnectSocket(core: ICore) {
   }
 }
 
-async function disconnect(socket: any) {
-  await socket.close();
+function disconnect(socket: IJsonRpcConnection) {
+  return socket.close();
 }

--- a/packages/sign-client/test/shared/ws.ts
+++ b/packages/sign-client/test/shared/ws.ts
@@ -3,10 +3,7 @@ import { ICore } from "@walletconnect/types";
 export async function disconnectSocket(core: ICore) {
   if (core.relayer.connected) {
     core.relayer.provider.connect = () => new Promise<void>((resolve) => resolve);
-    core.relayer.provider.connection.on(
-      "open",
-      async () => await disconnect(core.relayer.provider.connection),
-    );
+    core.relayer.provider.connection.on("open", async () => await disconnectSocket(core));
     await disconnect(core.relayer.provider.connection);
   }
 }


### PR DESCRIPTION
# Description
When running the tests in `core` & `sign-client` we have faced intermittent 'socket hang up' errors. After investigation, it became apparent that we're not disconnecting relay connections thus resulting web sockets remaining open long after the test has been completed.

This PR aims to resolve the issue by explicitly disconnecting web sockets after each test where necessary  
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves # ([browse](https://github.com/WalletConnect/walletconnect-monorepo/issues) or [create](https://github.com/WalletConnect/walletconnect-monorepo/issues/new/choose))

## How Has This Been Tested?
Issue & solution confirmed by a network monitoring tool
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
