### PR TITLE
fix: Skip Push Tests in v2

### DIFF
--- a/packages/sign-client/test/sdk/push.spec.ts
+++ b/packages/sign-client/test/sdk/push.spec.ts
@@ -11,7 +11,7 @@ import {
 } from "../shared";
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 
-describe("Push", () => {
+describe.skip("Push", () => {
   let clients;
   let sessionA;
   beforeEach(async () => {


### PR DESCRIPTION
# Description
Skips push tests because of API Deprecation, blocks: https://github.com/WalletConnect/rs-relay/pull/493

## How Has This Been Tested?
N/a

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
