### PR TITLE
chore(tests): log client id for constantly failing test

### DIFF
--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -1,5 +1,5 @@
 import { getSdkError, generateRandomBytes32 } from "@walletconnect/utils";
-import { expect, describe, it, vi } from "vitest";
+import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
 import SignClient from "../../src";
 import {
   initTwoClients,
@@ -58,8 +58,22 @@ describe("Sign Client Integration", () => {
       });
     });
     describe("session", () => {
+      let clients;
+      beforeEach(async () => {
+        clients = await initTwoClients();
+      });
+      afterEach(async (done) => {
+        const { result } = done.meta;
+        if (result?.state.toString() !== "pass") {
+          console.log(
+            `Test ${
+              done.meta.name
+            } failed with client ids: A:'${await clients.A.core.crypto.getClientId()}';B:'${await clients.B.core.crypto.getClientId()}'`,
+          );
+        }
+      });
       it("deletes the session on disconnect", async () => {
-        const clients = await initTwoClients();
+        await initTwoClients();
         const {
           sessionA: { topic },
         } = await testConnectMethod(clients);


### PR DESCRIPTION
# Description

This test failed the past 4 pipeline runs. I cannot repro locally. Let's see what's going on by logging the client ids when it fails.

## How Has This Been Tested?

Ran locally.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
