### PR TITLE
Fix providers not initialized correctly

### DIFF
--- a/providers/universal-provider/src/providers/solana.ts
+++ b/providers/universal-provider/src/providers/solana.ts
@@ -15,11 +15,11 @@ class SolanaProvider implements IProvider {
   public chainId: string;
 
   constructor(opts: SubProviderOpts) {
-    this.httpProviders = this.createHttpProviders();
     this.namespace = opts.namespace;
     this.events = opts.events;
     this.client = opts.client;
     this.chainId = this.getDefaultChainId();
+    this.httpProviders = this.createHttpProviders();
   }
 
   public updateNamespace(namespace: SessionTypes.Namespace) {


### PR DESCRIPTION
# Description

Solana providers were not initialized correctly due to not initializing
namespaces first.

## How Has This Been Tested?

tested by integrating it into `react-dapp-v2`

## Due Dilligence

* [x] Breaking change
* [x] Requires a documentation update
* [x] Requires a e2e/integration test update
