### PR TITLE
chore: a comment to explain why await is ommited

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -400,6 +400,9 @@ export class Engine extends IEngine {
     const message = await this.client.core.crypto.encode(topic, payload);
     const opts = ENGINE_RPC_OPTS[method].req;
     this.client.history.set(topic, payload);
+
+    // await is intentionally ommited here because of a possible race condition
+    // where a response is received before the publish call is resolved
     this.client.core.relayer.publish(topic, message, opts);
     return payload.id;
   };

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -401,7 +401,7 @@ export class Engine extends IEngine {
     const opts = ENGINE_RPC_OPTS[method].req;
     this.client.history.set(topic, payload);
 
-    // await is intentionally ommited here because of a possible race condition
+    // await is intentionally omitted here because of a possible race condition
     // where a response is received before the publish call is resolved
     this.client.core.relayer.publish(topic, message, opts);
     return payload.id;


### PR DESCRIPTION
# Description
Added a comment to explain why the `await` was omitted for the publish call to avoid being unintentionally `fixed` in the future
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves # ([browse](https://github.com/WalletConnect/walletconnect-monorepo/issues) or [create](https://github.com/WalletConnect/walletconnect-monorepo/issues/new/choose))

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
