### PR TITLE
chore: adds universal-provider to workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "packages/sign-client",
         "packages/react-native-compat",
         "providers/signer-connection",
-        "providers/ethereum-provider"
+        "providers/ethereum-provider",
+        "providers/universal-provider"
       ],
       "devDependencies": {
         "@rollup/plugin-commonjs": "22.0.2",
@@ -6652,6 +6653,10 @@
     },
     "node_modules/@walletconnect/types": {
       "resolved": "packages/types",
+      "link": true
+    },
+    "node_modules/@walletconnect/universal-provider": {
+      "resolved": "providers/universal-provider",
       "link": true
     },
     "node_modules/@walletconnect/utils": {
@@ -25533,6 +25538,806 @@
         "pino-pretty": "4.3.0",
         "uint8arrays": "3.1.0"
       }
+    },
+    "providers/universal-provider": {
+      "version": "2.0.0-rc.4",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@walletconnect/jsonrpc-http-connection": "1.0.3",
+        "@walletconnect/jsonrpc-provider": "1.0.5",
+        "@walletconnect/jsonrpc-types": "1.0.1",
+        "@walletconnect/jsonrpc-utils": "1.0.3",
+        "@walletconnect/sign-client": "2.0.0-rc.4",
+        "@walletconnect/types": "2.0.0-rc.4",
+        "@walletconnect/utils": "2.0.0-rc.4",
+        "eip1193-provider": "1.0.1",
+        "pino": "6.7.0"
+      },
+      "devDependencies": {
+        "ethereum-test-network": "0.1.6",
+        "ethers": "5.7.0",
+        "uint8arrays": "3.0.0",
+        "web3": "1.7.5"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/abi": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+      "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/abstract-provider": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/abstract-signer": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/address": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/base64": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/basex": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+      "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/bignumber": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "bn.js": "^5.2.1"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/bytes": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/constants": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/contracts": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/hash": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/hdnode": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/json-wallets": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "aes-js": "3.0.0",
+        "scrypt-js": "3.0.1"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/keccak256": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "js-sha3": "0.8.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/logger": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ]
+    },
+    "providers/universal-provider/node_modules/@ethersproject/networks": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.0.tgz",
+      "integrity": "sha512-MG6oHSQHd4ebvJrleEQQ4HhVu8Ichr0RDYEfHzsVAVjHNM+w36x9wp9r+hf1JstMXtseXDtkiVoARAG6M959AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/pbkdf2": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/properties": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+      "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/providers": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.0.tgz",
+      "integrity": "sha512-+TTrrINMzZ0aXtlwO/95uhAggKm4USLm1PbeCBR/3XZ7+Oey+3pMyddzZEyRhizHpy1HXV0FRWRMI1O3EGYibA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0",
+        "bech32": "1.1.4",
+        "ws": "7.4.6"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/random": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+      "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/rlp": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/sha2": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+      "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "hash.js": "1.1.7"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/signing-key": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "bn.js": "^5.2.1",
+        "elliptic": "6.5.4",
+        "hash.js": "1.1.7"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/solidity": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
+      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/strings": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/transactions": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/units": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
+      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/wallet": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/json-wallets": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/web": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.0.tgz",
+      "integrity": "sha512-ApHcbbj+muRASVDSCl/tgxaH2LBkRMEYfLOLVa0COipx0+nlu0QKet7U2lEg0vdkh8XRSLf2nd1f1Uk9SrVSGA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/@ethersproject/wordlists": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/ethers": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.0.tgz",
+      "integrity": "sha512-5Xhzp2ZQRi0Em+0OkOcRHxPzCfoBfgtOQA+RUylSkuHbhTEaQklnYi2hsWbRgs3ztJsXVXd9VKBcO1ScWL8YfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.0",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.0",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.0",
+        "@ethersproject/wordlists": "5.7.0"
+      }
+    },
+    "providers/universal-provider/node_modules/uint8arrays": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
+      "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
+    "providers/universal-provider/node_modules/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   },
   "dependencies": {
@@ -30628,6 +31433,481 @@
         "@walletconnect/heartbeat": "1.0.0",
         "@walletconnect/jsonrpc-types": "1.0.1",
         "@walletconnect/keyvaluestorage": "1.0.0"
+      }
+    },
+    "@walletconnect/universal-provider": {
+      "version": "file:providers/universal-provider",
+      "requires": {
+        "@walletconnect/jsonrpc-http-connection": "1.0.3",
+        "@walletconnect/jsonrpc-provider": "1.0.5",
+        "@walletconnect/jsonrpc-types": "1.0.1",
+        "@walletconnect/jsonrpc-utils": "1.0.3",
+        "@walletconnect/sign-client": "2.0.0-rc.4",
+        "@walletconnect/types": "2.0.0-rc.4",
+        "@walletconnect/utils": "2.0.0-rc.4",
+        "eip1193-provider": "1.0.1",
+        "ethereum-test-network": "0.1.6",
+        "ethers": "5.7.0",
+        "pino": "6.7.0",
+        "uint8arrays": "3.0.0",
+        "web3": "1.7.5"
+      },
+      "dependencies": {
+        "@ethersproject/abi": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+          "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/hash": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "@ethersproject/abstract-provider": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+          "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/networks": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0",
+            "@ethersproject/web": "^5.7.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+          "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+          "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/rlp": "^5.7.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+          "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0"
+          }
+        },
+        "@ethersproject/basex": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+          "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+          "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "bn.js": "^5.2.1"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+          "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+          "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0"
+          }
+        },
+        "@ethersproject/contracts": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+          "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abi": "^5.7.0",
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+          "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/base64": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "@ethersproject/hdnode": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+          "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/basex": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/pbkdf2": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/sha2": "^5.7.0",
+            "@ethersproject/signing-key": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0",
+            "@ethersproject/wordlists": "^5.7.0"
+          }
+        },
+        "@ethersproject/json-wallets": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+          "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/hdnode": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/pbkdf2": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/random": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0",
+            "aes-js": "3.0.0",
+            "scrypt-js": "3.0.1"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+          "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "js-sha3": "0.8.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+          "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
+          "dev": true
+        },
+        "@ethersproject/networks": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.0.tgz",
+          "integrity": "sha512-MG6oHSQHd4ebvJrleEQQ4HhVu8Ichr0RDYEfHzsVAVjHNM+w36x9wp9r+hf1JstMXtseXDtkiVoARAG6M959AA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/pbkdf2": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+          "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/sha2": "^5.7.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+          "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/providers": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.0.tgz",
+          "integrity": "sha512-+TTrrINMzZ0aXtlwO/95uhAggKm4USLm1PbeCBR/3XZ7+Oey+3pMyddzZEyRhizHpy1HXV0FRWRMI1O3EGYibA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/base64": "^5.7.0",
+            "@ethersproject/basex": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/hash": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/networks": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/random": "^5.7.0",
+            "@ethersproject/rlp": "^5.7.0",
+            "@ethersproject/sha2": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0",
+            "@ethersproject/web": "^5.7.0",
+            "bech32": "1.1.4",
+            "ws": "7.4.6"
+          }
+        },
+        "@ethersproject/random": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+          "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+          "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/sha2": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+          "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+          "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "bn.js": "^5.2.1",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/solidity": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
+          "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/sha2": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+          "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+          "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/rlp": "^5.7.0",
+            "@ethersproject/signing-key": "^5.7.0"
+          }
+        },
+        "@ethersproject/units": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
+          "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/wallet": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+          "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/hash": "^5.7.0",
+            "@ethersproject/hdnode": "^5.7.0",
+            "@ethersproject/json-wallets": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/random": "^5.7.0",
+            "@ethersproject/signing-key": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0",
+            "@ethersproject/wordlists": "^5.7.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.0.tgz",
+          "integrity": "sha512-ApHcbbj+muRASVDSCl/tgxaH2LBkRMEYfLOLVa0COipx0+nlu0QKet7U2lEg0vdkh8XRSLf2nd1f1Uk9SrVSGA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/base64": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "@ethersproject/wordlists": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+          "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/hash": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "ethers": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.0.tgz",
+          "integrity": "sha512-5Xhzp2ZQRi0Em+0OkOcRHxPzCfoBfgtOQA+RUylSkuHbhTEaQklnYi2hsWbRgs3ztJsXVXd9VKBcO1ScWL8YfA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abi": "5.7.0",
+            "@ethersproject/abstract-provider": "5.7.0",
+            "@ethersproject/abstract-signer": "5.7.0",
+            "@ethersproject/address": "5.7.0",
+            "@ethersproject/base64": "5.7.0",
+            "@ethersproject/basex": "5.7.0",
+            "@ethersproject/bignumber": "5.7.0",
+            "@ethersproject/bytes": "5.7.0",
+            "@ethersproject/constants": "5.7.0",
+            "@ethersproject/contracts": "5.7.0",
+            "@ethersproject/hash": "5.7.0",
+            "@ethersproject/hdnode": "5.7.0",
+            "@ethersproject/json-wallets": "5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/logger": "5.7.0",
+            "@ethersproject/networks": "5.7.0",
+            "@ethersproject/pbkdf2": "5.7.0",
+            "@ethersproject/properties": "5.7.0",
+            "@ethersproject/providers": "5.7.0",
+            "@ethersproject/random": "5.7.0",
+            "@ethersproject/rlp": "5.7.0",
+            "@ethersproject/sha2": "5.7.0",
+            "@ethersproject/signing-key": "5.7.0",
+            "@ethersproject/solidity": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "@ethersproject/transactions": "5.7.0",
+            "@ethersproject/units": "5.7.0",
+            "@ethersproject/wallet": "5.7.0",
+            "@ethersproject/web": "5.7.0",
+            "@ethersproject/wordlists": "5.7.0"
+          }
+        },
+        "uint8arrays": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
+          "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+          "dev": true,
+          "requires": {
+            "multiformats": "^9.4.2"
+          }
+        },
+        "ws": {
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+          "dev": true,
+          "requires": {}
+        }
       }
     },
     "@walletconnect/utils": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "packages/sign-client",
     "packages/react-native-compat",
     "providers/signer-connection",
-    "providers/ethereum-provider"
+    "providers/ethereum-provider",
+    "providers/universal-provider"
   ],
   "scripts": {
     "clean": "npm run clean --workspaces --if-present",

--- a/providers/universal-provider/package.json
+++ b/providers/universal-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/universal-provider",
   "description": "Universal Provider for WalletConnect Protocol",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.4",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {
@@ -36,9 +36,9 @@
     "@walletconnect/jsonrpc-provider": "1.0.5",
     "@walletconnect/jsonrpc-types": "1.0.1",
     "@walletconnect/jsonrpc-utils": "1.0.3",
-    "@walletconnect/sign-client": "2.0.0-rc.2",
-    "@walletconnect/types": "2.0.0-rc.2",
-    "@walletconnect/utils": "2.0.0-rc.2",
+    "@walletconnect/sign-client": "2.0.0-rc.4",
+    "@walletconnect/types": "2.0.0-rc.4",
+    "@walletconnect/utils": "2.0.0-rc.4",
     "eip1193-provider": "1.0.1",
     "pino": "6.7.0"
   },

--- a/providers/universal-provider/src/types/misc.ts
+++ b/providers/universal-provider/src/types/misc.ts
@@ -12,7 +12,7 @@ export interface UniversalProviderOpts {
   relayUrl?: string;
 }
 
-export type Metadata = SignClientTypes.Metadata
+export type Metadata = SignClientTypes.Metadata;
 
 export interface RpcProvidersMap {
   [provider: string]: JsonRpcProvider;


### PR DESCRIPTION
# Description
Added the `universal provider` package to workspaces so its version is bumped along the rest of the packages
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves # ([browse](https://github.com/WalletConnect/walletconnect-monorepo/issues) or [create](https://github.com/WalletConnect/walletconnect-monorepo/issues/new/choose))

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
