### PR TITLE
fix(core): fixes missing `isInitialized` check on `store.getAll`

### DIFF
--- a/packages/core/src/controllers/store.ts
+++ b/packages/core/src/controllers/store.ts
@@ -108,6 +108,7 @@ export class Store<Key, Data extends Record<string, any>> extends IStore<Key, Da
   };
 
   public getAll: IStore<Key, Data>["getAll"] = (filter) => {
+    this.isInitialized();
     if (!filter) return this.values;
 
     return this.values.filter((value) =>


### PR DESCRIPTION
# Description

* While working on pairing API refactoring, I noticed that I can call `store.getAll()` without first initialising the store.
* Adds missing `isInitialized` check

## How Has This Been Tested?

- Unit tests locally
- CI run

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
