### PR TITLE
fix: universal provider required test params 

### DIFF
--- a/providers/universal-provider/test/shared/constants.ts
+++ b/providers/universal-provider/test/shared/constants.ts
@@ -48,6 +48,7 @@ export const TEST_PROVIDER_OPTS = {
   logger: "error",
   relayUrl: TEST_RELAY_URL,
   metadata: TEST_APP_METADATA,
+  projectId: process.env.TEST_PROJECT_ID,
 };
 
 export const TEST_WALLET_CLIENT_OPTS = {
@@ -56,6 +57,7 @@ export const TEST_WALLET_CLIENT_OPTS = {
   privateKey: ACCOUNTS.a.privateKey,
   relayUrl: TEST_RELAY_URL,
   metadata: TEST_WALLET_METADATA,
+  projectId: process.env.TEST_PROJECT_ID,
 };
 
 export const TEST_NAMESPACES_CONFIG = {


### PR DESCRIPTION
# Description
Added the possibility to configure `projectId` via the env parameter `TEST_PROJECT_ID` when running the `@walletconnect/universal-provider` test suit
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?
npm run test
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
