### PR TITLE
fix: ignoring messages handled by external SDKs

### DIFF
--- a/packages/core/src/controllers/crypto.ts
+++ b/packages/core/src/controllers/crypto.ts
@@ -14,6 +14,8 @@ import {
   validateEncoding,
   validateDecoding,
   isTypeOneEnvelope,
+  deserialize,
+  decodeTypeByte,
 } from "@walletconnect/utils";
 import { Logger } from "pino";
 import { CRYPTO_CONTEXT, CRYPTO_CLIENT_SEED, CRYPTO_JWT_TTL } from "../constants";
@@ -128,6 +130,10 @@ export class Crypto implements ICrypto {
     return payload;
   };
 
+  public getPayloadType(encoded: string): number {
+    const deserialized = deserialize(encoded);
+    return decodeTypeByte(deserialized.type);
+  }
   // ---------- Private ----------------------------------------------- //
 
   private async setPrivateKey(publicKey: string, privateKey: string): Promise<string> {

--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -57,7 +57,7 @@ export class Pairing implements IPairing {
 
   private initialized = false;
   private storagePrefix = CORE_STORAGE_PREFIX;
-  private messageTypesToIgnore = [TYPE_1];
+  private ignoredPayloadTypes = [TYPE_1];
 
   constructor(public core: ICore, public logger: Logger) {
     this.core = core;

--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -223,7 +223,7 @@ export class Pairing implements IPairing {
       const { topic, message } = event;
 
       // messages of certain types should be ignored as they are handled by their respective SDKs
-      if (this.messageTypesToIgnore.includes(this.core.crypto.getPayloadType(message))) {
+      if (this.ignoredPayloadTypes.includes(this.core.crypto.getPayloadType(message))) {
         return;
       }
 

--- a/packages/types/src/core/crypto.ts
+++ b/packages/types/src/core/crypto.ts
@@ -103,4 +103,5 @@ export abstract class ICrypto {
   ): Promise<JsonRpcPayload>;
 
   public abstract signJWT(aud: string): Promise<string>;
+  public abstract getPayloadType(encoded: string): number;
 }

--- a/packages/utils/src/crypto.ts
+++ b/packages/utils/src/crypto.ts
@@ -134,8 +134,18 @@ export function validateDecoding(
 }
 
 export function validateEncoding(opts?: CryptoTypes.EncodeOptions): CryptoTypes.EncodingValidation {
+  const type = opts?.type || TYPE_0;
+  if (type === TYPE_1) {
+    if (typeof opts?.senderPublicKey === "undefined") {
+      throw new Error("missing sender public key");
+    }
+    if (typeof opts?.receiverPublicKey === "undefined") {
+      throw new Error("missing receiver public key");
+    }
+  }
+
   return {
-    type: opts?.type || TYPE_0,
+    type,
     senderPublicKey: opts?.senderPublicKey,
     receiverPublicKey: opts?.receiverPublicKey,
   };

--- a/packages/utils/src/crypto.ts
+++ b/packages/utils/src/crypto.ts
@@ -134,17 +134,8 @@ export function validateDecoding(
 }
 
 export function validateEncoding(opts?: CryptoTypes.EncodeOptions): CryptoTypes.EncodingValidation {
-  const type = opts?.type || TYPE_0;
-  if (type === TYPE_1) {
-    if (typeof opts?.senderPublicKey === "undefined") {
-      throw new Error("missing sender public key");
-    }
-    if (typeof opts?.receiverPublicKey === "undefined") {
-      throw new Error("missing receiver public key");
-    }
-  }
   return {
-    type,
+    type: opts?.type || TYPE_0,
     senderPublicKey: opts?.senderPublicKey,
     receiverPublicKey: opts?.receiverPublicKey,
   };

--- a/packages/utils/src/crypto.ts
+++ b/packages/utils/src/crypto.ts
@@ -143,7 +143,6 @@ export function validateEncoding(opts?: CryptoTypes.EncodeOptions): CryptoTypes.
       throw new Error("missing receiver public key");
     }
   }
-
   return {
     type,
     senderPublicKey: opts?.senderPublicKey,


### PR DESCRIPTION
Added the possibility to define messages types that would be ignored by the `pairing`. 
This functionality is required as some SDKs such as `Auth` require custom/additional data when processing messages.

# Description

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves # ([browse](https://github.com/WalletConnect/walletconnect-monorepo/issues) or [create](https://github.com/WalletConnect/walletconnect-monorepo/issues/new/choose))

## How Has This Been Tested?
npm run test

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
