### PR TITLE
feat: transport lifecycle 

### DIFF
--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -136,8 +136,8 @@ export class Relayer extends IRelayer {
     await this.provider.connection.close();
   }
 
-  public async transportOpen(relayUrl: string = RELAYER_DEFAULT_RELAY_URL) {
-    this.relayUrl = relayUrl;
+  public async transportOpen(relayUrl?: string) {
+    this.relayUrl = relayUrl || this.relayUrl;
     this.provider = await this.createProvider();
     this.transportExplicitlyClosed = false;
   }

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -53,12 +53,12 @@ export class Relayer extends IRelayer {
   public subscriber: ISubscriber;
   public publisher: IPublisher;
   public name = RELAYER_CONTEXT;
+  public transportExplicitlyClosed = false;
 
   private initialized = false;
 
   private relayUrl: string;
   private projectId: string | undefined;
-  public transportExplicitlyClosed = false;
 
   constructor(opts: RelayerOptions) {
     super(opts);

--- a/packages/core/src/controllers/subscriber.ts
+++ b/packages/core/src/controllers/subscriber.ts
@@ -344,6 +344,9 @@ export class Subscriber extends ISubscriber {
   }
 
   private checkPending() {
+    if (this.relayer.transportExplicitlyClosed) {
+      return;
+    }
     this.pending.forEach(async (params) => {
       const id = await this.rpcSubscribe(params.topic, params.relay);
       this.onSubscribe(id, params);

--- a/packages/types/src/core/relayer.ts
+++ b/packages/types/src/core/relayer.ts
@@ -75,6 +75,8 @@ export abstract class IRelayer extends IEvents {
 
   public abstract name: string;
 
+  public abstract transportExplicitlyClosed: boolean;
+
   public abstract readonly context: string;
 
   public abstract readonly connected: boolean;
@@ -99,4 +101,6 @@ export abstract class IRelayer extends IEvents {
   public abstract subscribe(topic: string, opts?: RelayerTypes.SubscribeOptions): Promise<string>;
 
   public abstract unsubscribe(topic: string, opts?: RelayerTypes.UnsubscribeOptions): Promise<void>;
+  public abstract transportClose(): Promise<void>;
+  public abstract transportOpen(relayUrl?: string): Promise<void>;
 }


### PR DESCRIPTION
# Description
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves # [1507](https://github.com/WalletConnect/walletconnect-monorepo/issues/1507)

Added two new methods in `relayer` to explicitely stop/start WebSocket connection
-  `public abstract transportClose(): Promise<void>;`
-  `public abstract transportOpen(relayUrl?: string): Promise<void>;`

`transportOpen` takes an optional relay URL parameter, else it uses the one provided during the core's initialization

# Notable behavior
To preserve backward compatibility and avoid introducing breaking changes, calling `relayer.provider.request(args)` will restart the WebSocket connection automatically without needing to call `transportOpen()` beforehand 

## How Has This Been Tested?
Tested locally.
Tests can be created to validate relay URL update but that would require making `relayer.relayUrl` property public
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
