### PR TITLE
feat(o11y): integrate with statuspage

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -5,6 +5,7 @@ import {
   deleteClients,
   uploadCanaryResultsToCloudWatch,
   throttle,
+  publishToStatusPage,
 } from "../shared";
 import { TEST_RELAY_URL } from "./../shared/values";
 import { describe, it, expect, afterEach } from "vitest";
@@ -74,6 +75,10 @@ describe("Canary", () => {
             { pingLatency: pingLatencyMs },
           ],
         );
+      }
+
+      if (environment === 'prod') {
+        await publishToStatusPage(latencyMs);
       }
 
       const clientDisconnect = new Promise<void>((resolve, reject) => {

--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -77,7 +77,7 @@ describe("Canary", () => {
         );
       }
 
-      if (environment === 'prod') {
+      if (environment === "prod") {
         await publishToStatusPage(latencyMs);
       }
 

--- a/packages/sign-client/test/shared/index.ts
+++ b/packages/sign-client/test/shared/index.ts
@@ -4,4 +4,5 @@ export * from "./mock";
 export * from "./values";
 export * from "./helpers";
 export * from "./metrics";
+export * from "./status";
 export * from "./ws";

--- a/packages/sign-client/test/shared/status.ts
+++ b/packages/sign-client/test/shared/status.ts
@@ -13,7 +13,6 @@ export const publishToStatusPage = (latencyMs: number) => {
   const timestampEpichSeconds = new Date().getTime() / 1000;
   const data = { data: {} };
   data.data[latencyMetricId] = [{ timestamp: timestampEpichSeconds, value: latencyMs / 1000 }];
-  console.log(JSON.stringify(data));
 
   return new Promise((resolve, reject) => {
     const request = https.request(url, options, function (res) {

--- a/packages/sign-client/test/shared/status.ts
+++ b/packages/sign-client/test/shared/status.ts
@@ -1,20 +1,20 @@
-import http from 'http';
- 
+import http from "http";
+
 // The following 4 are the actual values that pertain to your account and this specific metric.
 const apiKey = process.env.STATUSPAGE_API_KEY;
-const pageId = '0z72kp3p7j8h';
-const latencyMetricId = 'dzjbt55mfxks';
-const apiBase = 'https://api.statuspage.io/v1';
- 
-const url = apiBase + '/pages/' + pageId + '/metrics/';
-const authHeader = { 'Authorization': 'OAuth ' + apiKey };
-const options = { method: 'POST', headers: authHeader };
- 
+const pageId = "0z72kp3p7j8h";
+const latencyMetricId = "dzjbt55mfxks";
+const apiBase = "https://api.statuspage.io/v1";
+
+const url = apiBase + "/pages/" + pageId + "/metrics/";
+const authHeader = { Authorization: "OAuth " + apiKey };
+const options = { method: "POST", headers: authHeader };
+
 export const publishToStatusPage = (latencyMs: number) => {
   const timestampEpichSeconds = new Date().getTime() / 1000;
   const data = { data: {} };
   data.data[latencyMetricId] = [timestampEpichSeconds, latencyMs];
- 
+
   return new Promise((resolve, reject) => {
     const request = http.request(url, options, function (res) {
       if (res.statusMessage === "Unauthorized") {
@@ -29,4 +29,4 @@ export const publishToStatusPage = (latencyMs: number) => {
     });
     request.end(JSON.stringify({ data: data }));
   });
-}
+};

--- a/packages/sign-client/test/shared/status.ts
+++ b/packages/sign-client/test/shared/status.ts
@@ -12,7 +12,7 @@ const options = { method: "POST", headers: headers };
 export const publishToStatusPage = (latencyMs: number) => {
   const timestampEpichSeconds = new Date().getTime() / 1000;
   const data = { data: {} };
-  data.data[latencyMetricId] = [{timestamp: timestampEpichSeconds, value: latencyMs / 1000}];
+  data.data[latencyMetricId] = [{ timestamp: timestampEpichSeconds, value: latencyMs / 1000 }];
   console.log(JSON.stringify(data));
 
   return new Promise((resolve, reject) => {
@@ -21,12 +21,14 @@ export const publishToStatusPage = (latencyMs: number) => {
       if (res.statusMessage === "Unauthorized") {
         return reject(new Error("Unauthorized"));
       }
-      res.setEncoding('utf8');
+      res.setEncoding("utf8");
       const responseParts: string[] = [];
       res.on("end", function () {
         const response = responseParts.join("");
         if (res.statusCode! >= 300) {
-            return reject(new Error(`Call failed with status code ${res.statusCode} and response ${response}`));
+          return reject(
+            new Error(`Call failed with status code ${res.statusCode} and response ${response}`),
+          );
         }
         return resolve(true);
       });

--- a/packages/sign-client/test/shared/status.ts
+++ b/packages/sign-client/test/shared/status.ts
@@ -1,0 +1,32 @@
+import http from 'http';
+ 
+// The following 4 are the actual values that pertain to your account and this specific metric.
+const apiKey = process.env.STATUSPAGE_API_KEY;
+const pageId = '0z72kp3p7j8h';
+const latencyMetricId = 'dzjbt55mfxks';
+const apiBase = 'https://api.statuspage.io/v1';
+ 
+const url = apiBase + '/pages/' + pageId + '/metrics/';
+const authHeader = { 'Authorization': 'OAuth ' + apiKey };
+const options = { method: 'POST', headers: authHeader };
+ 
+export const publishToStatusPage = (latencyMs: number) => {
+  const timestampEpichSeconds = new Date().getTime() / 1000;
+  const data = { data: {} };
+  data.data[latencyMetricId] = [timestampEpichSeconds, latencyMs];
+ 
+  return new Promise((resolve, reject) => {
+    const request = http.request(url, options, function (res) {
+      if (res.statusMessage === "Unauthorized") {
+        return reject(new Error("Unauthorized"));
+      }
+      res.on("end", function () {
+        return resolve(true);
+      });
+      res.on("error", (error) => {
+        return reject(error);
+      });
+    });
+    request.end(JSON.stringify({ data: data }));
+  });
+}


### PR DESCRIPTION
# Description

Integrates the Canary with Atlassian status page.
http://status.walletconnect.com/

Through this feature we will see latency/availability blips (if no data reported for 5 mins then it shows a gap).

## How Has This Been Tested?

Not yet tested as I don't have an API key.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
