### PR TITLE
fix: socket transport manual start/stop

### DIFF
--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -206,18 +206,23 @@ export class Relayer extends IRelayer {
       this.events.emit(RELAYER_EVENTS.connect);
     });
     this.provider.on(RELAYER_PROVIDER_EVENTS.disconnect, () => {
-      if (this.transportExplicitlyClosed) {
-        return;
-      }
       this.events.emit(RELAYER_EVENTS.disconnect);
-      // Attempt reconnection after one second.
-      setTimeout(() => {
-        this.provider.connect();
-      }, toMiliseconds(RELAYER_RECONNECT_TIMEOUT));
+
+      this.attemptToReconnect();
     });
     this.provider.on(RELAYER_PROVIDER_EVENTS.error, (err: unknown) =>
       this.events.emit(RELAYER_EVENTS.error, err),
     );
+  }
+
+  private attemptToReconnect() {
+    if (this.transportExplicitlyClosed) {
+      return;
+    }
+    // Attempt reconnection after one second.
+    setTimeout(() => {
+      this.provider.connect();
+    }, toMiliseconds(RELAYER_RECONNECT_TIMEOUT));
   }
 
   private isInitialized() {

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -134,13 +134,13 @@ export class Relayer extends IRelayer {
   public async transportClose() {
     this.transportExplicitlyClosed = true;
     await this.provider.disconnect();
+    this.events.emit(RELAYER_EVENTS.disconnect);
   }
 
   public async transportOpen(relayUrl?: string) {
     this.relayUrl = relayUrl || this.relayUrl;
-    await this.provider.connect();
-    await this.subscriber.init();
     this.transportExplicitlyClosed = false;
+    await this.provider.connect();
   }
   // ---------- Private ----------------------------------------------- //
 
@@ -204,7 +204,6 @@ export class Relayer extends IRelayer {
       this.onProviderPayload(payload),
     );
     this.provider.on(RELAYER_PROVIDER_EVENTS.connect, () => {
-      this.transportExplicitlyClosed = false;
       this.events.emit(RELAYER_EVENTS.connect);
     });
     this.provider.on(RELAYER_PROVIDER_EVENTS.disconnect, () => {

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -133,12 +133,13 @@ export class Relayer extends IRelayer {
 
   public async transportClose() {
     this.transportExplicitlyClosed = true;
-    await this.provider.connection.close();
+    await this.provider.disconnect();
   }
 
   public async transportOpen(relayUrl?: string) {
     this.relayUrl = relayUrl || this.relayUrl;
-    this.provider = await this.createProvider();
+    await this.provider.connect();
+    await this.subscriber.init();
     this.transportExplicitlyClosed = false;
   }
   // ---------- Private ----------------------------------------------- //

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -134,7 +134,6 @@ export class Relayer extends IRelayer {
   public async transportClose() {
     this.transportExplicitlyClosed = true;
     await this.provider.disconnect();
-    this.events.emit(RELAYER_EVENTS.disconnect);
   }
 
   public async transportOpen(relayUrl?: string) {

--- a/packages/core/src/controllers/subscriber.ts
+++ b/packages/core/src/controllers/subscriber.ts
@@ -24,7 +24,7 @@ import {
   SUBSCRIBER_EVENTS,
   SUBSCRIBER_STORAGE_VERSION,
   PENDING_SUB_RESOLUTION_TIMEOUT,
-  RELAYER_EVENTS,
+  RELAYER_PROVIDER_EVENTS,
 } from "../constants";
 import { SubscriberTopicMap } from "./topicmap";
 
@@ -361,10 +361,10 @@ export class Subscriber extends ISubscriber {
     this.relayer.core.heartbeat.on(HEARTBEAT_EVENTS.pulse, () => {
       this.checkPending();
     });
-    this.relayer.on(RELAYER_EVENTS.connect, async () => {
+    this.relayer.provider.on(RELAYER_PROVIDER_EVENTS.connect, async () => {
       await this.onConnect();
     });
-    this.relayer.on(RELAYER_EVENTS.disconnect, () => {
+    this.relayer.provider.on(RELAYER_PROVIDER_EVENTS.disconnect, () => {
       this.onDisconnect();
     });
     this.events.on(SUBSCRIBER_EVENTS.created, async (createdEvent: SubscriberEvents.Created) => {

--- a/packages/core/src/controllers/subscriber.ts
+++ b/packages/core/src/controllers/subscriber.ts
@@ -335,6 +335,7 @@ export class Subscriber extends ISubscriber {
   }
 
   private async onConnect() {
+    if (this.relayer.transportExplicitlyClosed) return;
     await this.reset();
     this.onEnable();
   }

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -287,4 +287,37 @@ describe("Sign Client Integration", () => {
       await deleteClients(clients);
     }, 50_000);
   });
+  describe("transport", () => {
+    it("should disconnect & reestablish socket transport", async () => {
+      const clients = await initTwoClients();
+      const {
+        sessionA: { topic },
+      } = await testConnectMethod(clients);
+
+      await clients.A.core.relayer.transportClose();
+      await clients.A.core.relayer.transportOpen();
+
+      await clients.B.core.relayer.transportClose();
+      await clients.B.core.relayer.transportOpen();
+
+      await Promise.all([
+        new Promise((resolve) => {
+          clients.B.on("session_ping", (event: any) => {
+            resolve(event);
+          });
+        }),
+        new Promise((resolve) => {
+          clients.A.on("session_ping", (event: any) => {
+            resolve(event);
+          });
+        }),
+        new Promise(async (resolve) => {
+          await clients.A.ping({ topic });
+          await clients.B.ping({ topic });
+          resolve(true);
+        }),
+      ]);
+      await deleteClients(clients);
+    });
+  });
 });

--- a/providers/universal-provider/src/types/providers.ts
+++ b/providers/universal-provider/src/types/providers.ts
@@ -9,7 +9,6 @@ import {
   RequestArguments,
   SessionNamespace,
   NamespaceConfig,
-  ConnectParams,
 } from "./misc";
 
 export interface IProvider {
@@ -36,6 +35,4 @@ export interface IUniversalProvider extends IEthereumProvider {
     chain?: string,
   ) => void;
   pair: (pairingTopic: string | undefined) => Promise<SessionTypes.Struct>;
-  connect: (opts: ConnectParams) => Promise<SessionTypes.Struct | undefined>;
-  disconnect: () => void;
 }

--- a/providers/universal-provider/src/types/providers.ts
+++ b/providers/universal-provider/src/types/providers.ts
@@ -9,6 +9,7 @@ import {
   RequestArguments,
   SessionNamespace,
   NamespaceConfig,
+  ConnectParams,
 } from "./misc";
 
 export interface IProvider {
@@ -35,4 +36,6 @@ export interface IUniversalProvider extends IEthereumProvider {
     chain?: string,
   ) => void;
   pair: (pairingTopic: string | undefined) => Promise<SessionTypes.Struct>;
+  connect: (opts: ConnectParams) => Promise<SessionTypes.Struct | undefined>;
+  disconnect: () => void;
 }


### PR DESCRIPTION
# Description
With the addition of the `transportClose` & `transportOpen` a bug was introduced where after the socket was restarted, incoming relay messages were ignored.
This was due to the `core/subscriber` clearing its in memory cache/data while the socket was being closed and this caused the sequential `subscription topic` checks to fail

This PR adds a restart mechanism where when the socket is reconnected & the subscriber will resubscribe to the topics in its storage.
Also added tests to simulate transport open/close usage  
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves https://github.com/WalletConnect/walletconnect-monorepo/issues/1578

## How Has This Been Tested?
npm run test
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
