### PR TITLE
fix: universal provider persistance

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -33,6 +33,7 @@ jobs:
             packages/utils/dist
             providers/ethereum-provider/dist
             providers/signer-connection/dist
+            providers/universal-provider/dist
 
   code_style:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -65,6 +65,7 @@ jobs:
           - packages/sign-client
           - packages/core
           - packages/utils
+          - providers/universal-provider
     env:
       TEST_RELAY_URL: ${{ secrets.TEST_RELAY_URL }}
       TEST_PROJECT_ID: ${{ secrets.TEST_PROJECT_ID }}

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -154,6 +154,7 @@ export class UniversalProvider implements IUniversalProvider {
     if (this.client.session.length) {
       const lastKeyIndex = this.client.session.keys.length - 1;
       this.session = this.client.session.get(this.client.session.keys[lastKeyIndex]);
+      this.onSessionUpdate();
     }
   }
 
@@ -172,6 +173,8 @@ export class UniversalProvider implements IUniversalProvider {
         relayUrl: this.providerOpts.relayUrl || RELAY_URL,
         projectId: this.providerOpts.projectId,
         metadata: this.providerOpts.metadata, // fetch metadata automatically if not provided?
+        storageOptions: this.providerOpts.storageOptions,
+        name: this.providerOpts.name,
       }));
 
     this.logger.trace(`SignClient Initialized`);

--- a/providers/universal-provider/src/types/misc.ts
+++ b/providers/universal-provider/src/types/misc.ts
@@ -1,6 +1,7 @@
 import SignClient from "@walletconnect/sign-client";
 import { SignClientTypes, ProposalTypes } from "@walletconnect/types";
 import { JsonRpcProvider } from "@walletconnect/jsonrpc-provider";
+import { KeyValueStorageOptions } from "@walletconnect/keyvaluestorage";
 import { IProvider } from "./providers";
 import EventEmitter from "events";
 
@@ -10,6 +11,8 @@ export interface UniversalProviderOpts {
   logger?: string;
   client?: SignClient;
   relayUrl?: string;
+  storageOptions?: KeyValueStorageOptions;
+  name?: string;
 }
 
 export type Metadata = SignClientTypes.Metadata;

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -297,6 +297,44 @@ describe("UniversalProvider", function () {
         // delete
         await deleteProviders({ A: afterDapp, B: afterWallet });
       });
+
+      it("should reload provider data after restart", async () => {
+        const dapp = await UniversalProvider.init({
+          ...TEST_PROVIDER_OPTS,
+          name: "dapp",
+          storageOptions: { database: "/tmp/dappDB" },
+        });
+        const wallet = await UniversalProvider.init({
+          ...TEST_PROVIDER_OPTS,
+          name: "wallet",
+          storageOptions: { database: "/tmp/walletDB" },
+        });
+
+        const {
+          sessionA: { topic },
+        } = await testConnectMethod({ dapp, wallet });
+
+        expect(!!topic).to.be.true;
+
+        let ethers = new providers.Web3Provider(dapp);
+        const accounts = await ethers.listAccounts();
+        expect(!!accounts).to.be.true;
+
+        // delete
+        await deleteProviders({ A: dapp, B: wallet });
+
+        // restart
+        const afterDapp = await UniversalProvider.init({
+          ...TEST_PROVIDER_OPTS,
+          name: "dapp",
+          storageOptions: { database: "/tmp/dappDB" },
+        });
+
+        // load the provider in ethers without new pairing
+        ethers = new providers.Web3Provider(afterDapp);
+        const afterAccounts = await ethers.listAccounts();
+        expect(accounts).to.toMatchObject(afterAccounts);
+      });
     });
   });
 });

--- a/providers/universal-provider/test/shared/connect.ts
+++ b/providers/universal-provider/test/shared/connect.ts
@@ -1,0 +1,179 @@
+import { parseUri } from "@walletconnect/utils";
+import {
+  EngineTypes,
+  PairingTypes,
+  RelayerTypes,
+  ProposalTypes,
+  SessionTypes,
+  ISignClient,
+} from "@walletconnect/types";
+import { throttle } from "./../shared";
+import { TEST_RELAY_OPTIONS, TEST_NAMESPACES, TEST_REQUIRED_NAMESPACES } from "./constants";
+import { expect } from "vitest";
+import UniversalProvider from "../../src/UniversalProvider";
+
+export interface TestConnectParams {
+  requiredNamespaces?: ProposalTypes.RequiredNamespaces;
+  namespaces?: SessionTypes.Namespaces;
+  relays?: RelayerTypes.ProtocolOptions[];
+  pairingTopic?: string;
+  qrCodeScanLatencyMs?: number;
+}
+
+export async function testConnectMethod(
+  providers: { dapp: UniversalProvider; wallet: UniversalProvider },
+  params?: TestConnectParams,
+) {
+  const start = Date.now();
+  const { dapp, wallet } = providers;
+  const dappClient = dapp.client;
+  const walletClient = wallet.client;
+
+  const connectParams: EngineTypes.ConnectParams = {
+    requiredNamespaces: params?.requiredNamespaces || TEST_REQUIRED_NAMESPACES,
+    relays: params?.relays || undefined,
+    pairingTopic: params?.pairingTopic || undefined,
+  };
+
+  const approveParams: Omit<EngineTypes.ApproveParams, "id"> = {
+    namespaces: params?.namespaces || TEST_NAMESPACES,
+  };
+
+  // We need to kick off the promise that binds the listener for `session_proposal` before `A.connect()`
+  // is called, to avoid race conditions.
+  const resolveSessionProposal = new Promise<void>((resolve, reject) => {
+    walletClient.once("session_proposal", async (proposal) => {
+      try {
+        expect(proposal.params.requiredNamespaces).to.eql(connectParams.requiredNamespaces);
+
+        const { acknowledged } = await walletClient.approve({
+          id: proposal.id,
+          ...approveParams,
+        });
+        if (!sessionB) {
+          sessionB = await acknowledged();
+        }
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
+
+  const clientAConnectLatencyMs = Date.now() - start;
+
+  let pairingA: PairingTypes.Struct | undefined;
+  let pairingB: PairingTypes.Struct | undefined;
+
+  let sessionA: SessionTypes.Struct | undefined;
+  let sessionB: SessionTypes.Struct | undefined;
+
+  const pair: (uri: string) => Promise<PairingTypes.Struct> = (uri: string) =>
+    new Promise(async function (resolve, reject) {
+      const pairTimeoutMs = 15_000;
+      const timeout = setTimeout(() => {
+        return reject(new Error(`Pair timed out after ${pairTimeoutMs}ms`));
+      }, pairTimeoutMs);
+      const result = await walletClient.pair({ uri });
+      clearTimeout(timeout);
+      return resolve(result);
+    });
+
+  await Promise.all([
+    resolveSessionProposal,
+    new Promise<void>(async (resolve, reject) => {
+      try {
+        dapp.on("display_uri", async (uri: string) => {
+          const uriParams = parseUri(uri);
+
+          pairingA = dappClient.pairing.get(uriParams.topic);
+          expect(pairingA.topic).to.eql(uriParams.topic);
+          expect(pairingA.relay).to.eql(uriParams.relay);
+
+          if (uri) {
+            pairingB = await pair(uri);
+
+            if (!pairingA) throw new Error("expect pairing A to be defined");
+            expect(pairingB.topic).to.eql(pairingA.topic);
+            expect(pairingB.relay).to.eql(pairingA.relay);
+
+            resolve();
+          } else {
+            reject(new Error("missing uri"));
+          }
+        });
+      } catch (error) {
+        reject(error);
+      }
+    }),
+    new Promise<void>(async (resolve, reject) => {
+      try {
+        const session = await dapp.connect({ namespaces: TEST_REQUIRED_NAMESPACES });
+        if (!session) throw new Error();
+        const lastKeyIndex = dapp.client.session.keys.length - 1;
+        sessionA = dapp.client.session.get(dapp.client.session.keys[lastKeyIndex]);
+        resolve();
+      } catch (error) {
+        reject(error);
+      }
+    }),
+  ]);
+
+  const settlePairingLatencyMs = Date.now() - start - (params?.qrCodeScanLatencyMs || 0);
+
+  if (!sessionA) throw new Error("expect session A to be defined");
+  if (!sessionB) throw new Error("expect session B to be defined");
+
+  // topic
+  expect(sessionA.topic).to.eql(sessionB.topic);
+  // relay
+  expect(sessionA.relay).to.eql(TEST_RELAY_OPTIONS);
+  expect(sessionA.relay).to.eql(sessionB.relay);
+  // namespaces
+  expect(sessionA.namespaces).to.eql(approveParams.namespaces);
+  expect(sessionA.namespaces).to.eql(sessionB.namespaces);
+  // expiry
+  expect(Math.abs(sessionA.expiry - sessionB.expiry)).to.be.lessThan(5);
+  // acknowledged
+  expect(sessionA.acknowledged).to.eql(sessionB.acknowledged);
+  // participants
+  expect(sessionA.self).to.eql(sessionB.peer);
+  expect(sessionA.peer).to.eql(sessionB.self);
+  // controller
+  expect(sessionA.controller).to.eql(sessionB.controller);
+  expect(sessionA.controller).to.eql(sessionA.peer.publicKey);
+  expect(sessionB.controller).to.eql(sessionB.self.publicKey);
+  // metadata
+  expect(sessionA.self.metadata).to.eql(sessionB.peer.metadata);
+  expect(sessionB.self.metadata).to.eql(sessionA.peer.metadata);
+
+  if (!pairingA) throw new Error("expect pairing A to be defined");
+  if (!pairingB) throw new Error("expect pairing B to be defined");
+
+  // update pairing state beforehand
+  pairingA = dappClient.pairing.get(pairingA.topic);
+  pairingB = walletClient.pairing.get(pairingB.topic);
+
+  // topic
+  expect(pairingA.topic).to.eql(pairingB.topic);
+  // relay
+  expect(pairingA.relay).to.eql(TEST_RELAY_OPTIONS);
+  expect(pairingA.relay).to.eql(pairingB.relay);
+  // active
+  expect(pairingA.active).to.eql(true);
+  expect(pairingA.active).to.eql(pairingB.active);
+  // metadata
+  expect(pairingA.peerMetadata).to.eql(sessionA.peer.metadata);
+  expect(pairingB.peerMetadata).to.eql(sessionB.peer.metadata);
+
+  return { pairingA, sessionA, clientAConnectLatencyMs, settlePairingLatencyMs };
+}
+
+export function batchArray(array: any[], size: number) {
+  const result: any[] = [];
+  for (let i = 0; i < array.length; i += size) {
+    const batch: any = array.slice(i, i + size);
+    result.push(batch);
+  }
+  return result;
+}

--- a/providers/universal-provider/test/shared/constants.ts
+++ b/providers/universal-provider/test/shared/constants.ts
@@ -1,3 +1,4 @@
+import { RelayerTypes } from "@walletconnect/types";
 import { utils } from "ethers";
 
 export const CHAIN_ID = 123;
@@ -91,4 +92,45 @@ export const TEST_SIGN_TRANSACTION = {
   to: "0xF0109fC8DF283027b6285cc889F5aA624EaC1F55",
   value: "1000000000",
   gas: 2000000,
+};
+
+export const TEST_EVENTS = ["chainChanged", "accountsChanged"];
+
+export const TEST_ETHEREUM_ADDRESS = "0x3c582121909DE92Dc89A36898633C1aE4790382b";
+
+export const TEST_ETHEREUM_CHAIN = "eip155:1";
+
+export const TEST_ETHEREUM_ACCOUNT = `${TEST_ETHEREUM_CHAIN}:${TEST_ETHEREUM_ADDRESS}`;
+
+export const TEST_CHAINS = [TEST_ETHEREUM_CHAIN];
+
+export const TEST_ACCOUNTS = [TEST_ETHEREUM_ACCOUNT];
+
+export const TEST_RELAY_PROTOCOL = "irn";
+
+export const TEST_RELAY_OPTIONS: RelayerTypes.ProtocolOptions = {
+  protocol: TEST_RELAY_PROTOCOL,
+};
+
+export const TEST_METHODS = [
+  "eth_sendTransaction",
+  "eth_signTransaction",
+  "personal_sign",
+  "eth_signTypedData",
+];
+
+export const TEST_REQUIRED_NAMESPACES = {
+  eip155: {
+    methods: TEST_METHODS,
+    chains: TEST_CHAINS,
+    events: TEST_EVENTS,
+  },
+};
+
+export const TEST_NAMESPACES = {
+  eip155: {
+    methods: TEST_METHODS,
+    accounts: TEST_ACCOUNTS,
+    events: TEST_EVENTS,
+  },
 };

--- a/providers/universal-provider/test/shared/helpers.ts
+++ b/providers/universal-provider/test/shared/helpers.ts
@@ -1,0 +1,25 @@
+import { SignClient } from "@walletconnect/sign-client/dist/types/client";
+import UniversalProvider from "../../src";
+import { disconnectSocket } from "./index";
+
+export async function deleteProviders(providers: { A: UniversalProvider; B: UniversalProvider }) {
+  await deleteClients({ A: providers.A.client, B: providers.B.client });
+  delete providers.A;
+  delete providers.B;
+}
+
+export async function deleteClients(clients: { A: SignClient; B: SignClient }) {
+  await disconnectSocket(clients.A.core);
+  await disconnectSocket(clients.B.core);
+
+  delete clients.A;
+  delete clients.B;
+}
+
+export async function throttle(timeout: number) {
+  return await new Promise<void>((resolve) =>
+    setTimeout(() => {
+      resolve();
+    }, timeout),
+  );
+}

--- a/providers/universal-provider/test/shared/index.ts
+++ b/providers/universal-provider/test/shared/index.ts
@@ -1,1 +1,5 @@
 export * from "./WalletClient";
+export * from "./ws";
+export * from "./connect";
+export * from "./helpers";
+export * from "./constants";

--- a/providers/universal-provider/test/shared/ws.ts
+++ b/providers/universal-provider/test/shared/ws.ts
@@ -1,0 +1,18 @@
+import { IJsonRpcConnection } from "@walletconnect/jsonrpc-utils";
+import { ICore } from "@walletconnect/types";
+import EventEmitter from "events";
+
+export async function disconnectSocket(core: ICore) {
+  if (core.relayer.connected) {
+    core.relayer.provider.events = new EventEmitter();
+    core.relayer.core.heartbeat.events = new EventEmitter();
+    core.relayer.provider.connection.on("open", async () => {
+      await disconnect(core.relayer.provider.connection);
+    });
+    await disconnect(core.relayer.provider.connection);
+  }
+}
+
+function disconnect(socket: IJsonRpcConnection) {
+  return socket.close();
+}


### PR DESCRIPTION
# Description
While using the `universal-provider` in our example apps I discovered issues with storage persistence where on page reload the `universal-provider` couldn't restore completely its state

This update includes

- bug fix to the cache reloading
- addition constructor parameters such as  `storageOptions` so persisted storage is available 
- tests to cover persisted storage usage

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?
npm run test
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
