### PR TITLE
fix: x region tests transport disconnnect

### DIFF
--- a/packages/sign-client/test/lifecycle/lifecycle.spec.ts
+++ b/packages/sign-client/test/lifecycle/lifecycle.spec.ts
@@ -102,7 +102,7 @@ describe("Lifecycle", () => {
       });
       await clientDisconnect;
       log("Clients disconnected");
-      deleteClients(clients);
+      await deleteClients(clients);
       log("Clients deleted");
     }, 70000_000);
   });

--- a/packages/sign-client/test/xregion/xregion.spec.ts
+++ b/packages/sign-client/test/xregion/xregion.spec.ts
@@ -12,51 +12,10 @@ import {
   TEST_PROJECT_ID,
   testConnectMethod,
   throttle,
+  deleteClients,
 } from "../shared";
 
 describe("X Region", () => {
-  it("init", async () => {
-    const client = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS);
-    expect(client).to.be.exist;
-  });
-
-  describe("connect", () => {
-    it("connect with default region: ", async () => {
-      const client = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS);
-      const defaultRelayerRegion = await client.opts?.relayUrl;
-      expect(defaultRelayerRegion).to.be.equal(TEST_RELAY_URL);
-    });
-    it("connect with default region, then switch to USA", async () => {
-      const defaultRelayerClient = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS);
-      await defaultRelayerClient.disconnect;
-      const usRelayerClient = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS_USA);
-      const usRelayerRegion = await usRelayerClient.opts?.relayUrl;
-      expect(usRelayerRegion).to.be.equal(TEST_RELAY_URL_US);
-    });
-    it("connect with default region, then switch to EU", async () => {
-      const defaultRelayerClient = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS);
-      await defaultRelayerClient.disconnect;
-      const usRelayerClient = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS_EU);
-      const usRelayerRegion = await usRelayerClient.opts?.relayUrl;
-      expect(usRelayerRegion).to.be.equal(TEST_RELAY_URL_EU);
-    });
-    it("connect with default region, then switch to AP", async () => {
-      const defaultRelayerClient = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS);
-      await defaultRelayerClient.disconnect;
-      const usRelayerClient = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS_AP);
-      const usRelayerRegion = await usRelayerClient.opts?.relayUrl;
-      expect(usRelayerRegion).to.be.equal(TEST_RELAY_URL_AP);
-    });
-    it("connect with default region, switch to US, then back to default", async () => {
-      const defaultRelayerClient = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS);
-      await defaultRelayerClient.disconnect;
-      const usRelayerClient = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS_AP);
-      await usRelayerClient.disconnect;
-      const defaultRelayerClientTwo = await SignClient.init(TEST_SIGN_CLIENT_OPTIONS);
-      const defaultRelayerRegion = await defaultRelayerClientTwo.opts?.relayUrl;
-      expect(defaultRelayerRegion).to.be.equal(TEST_RELAY_URL);
-    });
-  });
   describe("pairing+ping", () => {
     it.each(regionEndpointPermutations)(
       "pairs client in '%s' with client in '%s'",
@@ -104,6 +63,7 @@ describe("X Region", () => {
             reject(e);
           }
         });
+        await deleteClients({ A, B });
       },
     );
   });


### PR DESCRIPTION
# Description
Sockets were not properly disconnected from two test files

- x region tests
- lifecycle tests

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves # ([browse](https://github.com/WalletConnect/walletconnect-monorepo/issues) or [create](https://github.com/WalletConnect/walletconnect-monorepo/issues/new/choose))

## How Has This Been Tested?
npm run test
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
