### PR TITLE
fix(deps): ensure pino import resolves at runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25327,6 +25327,7 @@
         "@walletconnect/types": "2.1.2",
         "@walletconnect/utils": "2.1.2",
         "lodash.isequal": "4.5.0",
+        "pino": "7.11.0",
         "uint8arrays": "3.1.0"
       },
       "devDependencies": {
@@ -25366,7 +25367,8 @@
         "@walletconnect/logger": "2.0.0",
         "@walletconnect/time": "1.0.1",
         "@walletconnect/types": "2.1.2",
-        "@walletconnect/utils": "2.1.2"
+        "@walletconnect/utils": "2.1.2",
+        "pino": "7.11.0"
       },
       "devDependencies": {
         "@walletconnect/jsonrpc-ws-connection": "1.0.3",
@@ -25458,7 +25460,8 @@
         "@walletconnect/sign-client": "2.1.2",
         "@walletconnect/types": "2.1.2",
         "@walletconnect/utils": "2.1.2",
-        "eip1193-provider": "1.0.1"
+        "eip1193-provider": "1.0.1",
+        "pino": "7.11.0"
       },
       "devDependencies": {
         "ethereum-test-network": "0.1.6",
@@ -31235,6 +31238,7 @@
         "@walletconnect/types": "2.1.2",
         "@walletconnect/utils": "2.1.2",
         "lodash.isequal": "4.5.0",
+        "pino": "7.11.0",
         "uint8arrays": "3.1.0"
       }
     },
@@ -31393,7 +31397,8 @@
         "@walletconnect/types": "2.1.2",
         "@walletconnect/utils": "2.1.2",
         "aws-sdk": "2.1194.0",
-        "lokijs": "^1.5.12"
+        "lokijs": "^1.5.12",
+        "pino": "7.11.0"
       }
     },
     "@walletconnect/signer-connection": {
@@ -31436,6 +31441,7 @@
         "eip1193-provider": "1.0.1",
         "ethereum-test-network": "0.1.6",
         "ethers": "5.7.0",
+        "pino": "7.11.0",
         "uint8arrays": "3.0.0",
         "web3": "1.7.5"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,7 @@
     "@walletconnect/types": "2.1.2",
     "@walletconnect/utils": "2.1.2",
     "lodash.isequal": "4.5.0",
+    "pino": "7.11.0",
     "uint8arrays": "3.1.0"
   },
   "devDependencies": {

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "events";
+import pino from "pino";
 import { JsonRpcProvider } from "@walletconnect/jsonrpc-provider";
 import {
   formatJsonRpcResult,
@@ -13,7 +14,6 @@ import {
   getDefaultLoggerOptions,
   getLoggerContext,
   Logger,
-  pino,
 } from "@walletconnect/logger";
 import { RelayJsonRpc } from "@walletconnect/relay-api";
 import { toMiliseconds } from "@walletconnect/time";

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "events";
+import pino from "pino";
 
 import KeyValueStorage from "@walletconnect/keyvaluestorage";
 import { HeartBeat } from "@walletconnect/heartbeat";
@@ -6,7 +7,6 @@ import {
   generateChildLogger,
   getDefaultLoggerOptions,
   getLoggerContext,
-  pino,
 } from "@walletconnect/logger";
 import { CoreTypes, ICore } from "@walletconnect/types";
 

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -44,7 +44,8 @@
     "@walletconnect/logger": "2.0.0",
     "@walletconnect/time": "1.0.1",
     "@walletconnect/types": "2.1.2",
-    "@walletconnect/utils": "2.1.2"
+    "@walletconnect/utils": "2.1.2",
+    "pino": "7.11.0"
   },
   "devDependencies": {
     "@walletconnect/jsonrpc-ws-connection": "1.0.3",

--- a/packages/sign-client/src/client.ts
+++ b/packages/sign-client/src/client.ts
@@ -1,9 +1,9 @@
+import pino from "pino";
 import { Core } from "@walletconnect/core";
 import {
   generateChildLogger,
   getDefaultLoggerOptions,
   getLoggerContext,
-  pino,
 } from "@walletconnect/logger";
 import { SignClientTypes, ISignClient, ISignClientEvents, EngineTypes } from "@walletconnect/types";
 import { getAppMetadata } from "@walletconnect/utils";

--- a/providers/universal-provider/package.json
+++ b/providers/universal-provider/package.json
@@ -40,7 +40,8 @@
     "@walletconnect/sign-client": "2.1.2",
     "@walletconnect/types": "2.1.2",
     "@walletconnect/utils": "2.1.2",
-    "eip1193-provider": "1.0.1"
+    "eip1193-provider": "1.0.1",
+    "pino": "7.11.0"
   },
   "devDependencies": {
     "ethereum-test-network": "0.1.6",

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -1,8 +1,9 @@
+import pino from "pino";
 import SignClient from "@walletconnect/sign-client";
 import { ProviderAccounts } from "eip1193-provider";
 import { SessionTypes } from "@walletconnect/types";
 import { getSdkError } from "@walletconnect/utils";
-import { getDefaultLoggerOptions, Logger, pino } from "@walletconnect/logger";
+import { getDefaultLoggerOptions, Logger } from "@walletconnect/logger";
 import Eip155Provider from "./providers/eip155";
 import SolanaProvider from "./providers/solana";
 import { getChainFromNamespaces } from "./utils";


### PR DESCRIPTION
# Description

- Import `pino` from its own dep as before until the issue with using the re-exported approach is resolved.
- Followup to fix runtime import issues caused by #1616
- Fixes #1634 


## How Has This Been Tested?

- Tested against example dapp/wallet via canary `2.1.2-eaa4818c`

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
