### PR TITLE
fix: resubscribing after transport is reopened

### DIFF
--- a/packages/core/src/constants/subscriber.ts
+++ b/packages/core/src/constants/subscriber.ts
@@ -6,6 +6,7 @@ export const SUBSCRIBER_EVENTS = {
   expired: "subscription_expired",
   disabled: "subscription_disabled",
   sync: "subscription_sync",
+  resubscribed: "subscription_resubscribed",
 };
 
 export const SUBSCRIBER_DEFAULT_TTL = THIRTY_DAYS;

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -142,9 +142,9 @@ export class Relayer extends IRelayer {
     this.relayUrl = relayUrl || this.relayUrl;
     this.transportExplicitlyClosed = false;
     await this.provider.connect();
-    // wait the subscriber to finish resubscribing to its topics
+    // wait for the subscriber to finish resubscribing to its topics
     await new Promise<void>((resolve) => {
-      this.subscriber.on(SUBSCRIBER_EVENTS.resubscribed, () => {
+      this.subscriber.once(SUBSCRIBER_EVENTS.resubscribed, () => {
         resolve();
       });
     });

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -37,6 +37,7 @@ import {
   RELAYER_RECONNECT_TIMEOUT,
   RELAYER_SUBSCRIBER_SUFFIX,
   RELAYER_DEFAULT_RELAY_URL,
+  SUBSCRIBER_EVENTS,
 } from "../constants";
 import { MessageTracker } from "./messages";
 import { Publisher } from "./publisher";
@@ -141,6 +142,12 @@ export class Relayer extends IRelayer {
     this.relayUrl = relayUrl || this.relayUrl;
     this.transportExplicitlyClosed = false;
     await this.provider.connect();
+    // wait the subscriber to finish resubscribing to its topics
+    await new Promise<void>((resolve) => {
+      this.subscriber.on(SUBSCRIBER_EVENTS.resubscribed, () => {
+        resolve();
+      });
+    });
   }
   // ---------- Private ----------------------------------------------- //
 

--- a/packages/core/src/controllers/subscriber.ts
+++ b/packages/core/src/controllers/subscriber.ts
@@ -302,10 +302,12 @@ export class Subscriber extends ISubscriber {
   }
 
   private async reset() {
-    if (!this.cached.length) return;
-    await Promise.all(
-      this.cached.map(async (subscription) => await this.resubscribe(subscription)),
-    );
+    if (this.cached.length) {
+      await Promise.all(
+        this.cached.map(async (subscription) => await this.resubscribe(subscription)),
+      );
+    }
+    this.events.emit(SUBSCRIBER_EVENTS.resubscribed);
   }
 
   private async restore() {


### PR DESCRIPTION
PR to address the possible race condition where `transportOpen` resolves before the client is in a ready state to receive messages. This happens because the client needs to resubscribe to its cached topics. 
Any messages sent to a topic the client has not yet resubscribed will not be received

# Description

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?

- `npm run test`
- transport tests

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
