### PR TITLE
chore(deps): update jsonrpc-ws-connection to fix various WS issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6738,9 +6738,9 @@
       }
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.3.tgz",
-      "integrity": "sha512-+tKT3y8HvSdwXZkvF3+6FwnT9MYVdR7rxr1/x/hCPCB4DCLl4ZfDm8rP4doXbDaMJHaMrGn2JNT3RPABlOXSnw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.4.tgz",
+      "integrity": "sha512-5eHlE2lYmc6gZYtFRhw15uI7K/LdQ3/gRdIbpJZLaW1JhX3yHyGHuVp7mwpgpIRQZcixzzqTXOdpJsoJfwBJ/g==",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.3",
         "@walletconnect/safe-json": "^1.0.0",
@@ -25317,7 +25317,7 @@
         "@walletconnect/heartbeat": "1.0.0",
         "@walletconnect/jsonrpc-provider": "1.0.5",
         "@walletconnect/jsonrpc-utils": "1.0.3",
-        "@walletconnect/jsonrpc-ws-connection": "1.0.3",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.4",
         "@walletconnect/keyvaluestorage": "1.0.1-rc.2",
         "@walletconnect/logger": "2.0.0",
         "@walletconnect/relay-api": "1.0.6",
@@ -25371,7 +25371,7 @@
         "pino": "7.11.0"
       },
       "devDependencies": {
-        "@walletconnect/jsonrpc-ws-connection": "1.0.3",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.4",
         "@walletconnect/relay-api": "1.0.6",
         "aws-sdk": "2.1194.0",
         "lokijs": "^1.5.12"
@@ -31228,7 +31228,7 @@
         "@walletconnect/heartbeat": "1.0.0",
         "@walletconnect/jsonrpc-provider": "1.0.5",
         "@walletconnect/jsonrpc-utils": "1.0.3",
-        "@walletconnect/jsonrpc-ws-connection": "1.0.3",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.4",
         "@walletconnect/keyvaluestorage": "1.0.1-rc.2",
         "@walletconnect/logger": "2.0.0",
         "@walletconnect/relay-api": "1.0.6",
@@ -31319,9 +31319,9 @@
       }
     },
     "@walletconnect/jsonrpc-ws-connection": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.3.tgz",
-      "integrity": "sha512-+tKT3y8HvSdwXZkvF3+6FwnT9MYVdR7rxr1/x/hCPCB4DCLl4ZfDm8rP4doXbDaMJHaMrGn2JNT3RPABlOXSnw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.4.tgz",
+      "integrity": "sha512-5eHlE2lYmc6gZYtFRhw15uI7K/LdQ3/gRdIbpJZLaW1JhX3yHyGHuVp7mwpgpIRQZcixzzqTXOdpJsoJfwBJ/g==",
       "requires": {
         "@walletconnect/jsonrpc-utils": "^1.0.3",
         "@walletconnect/safe-json": "^1.0.0",
@@ -31390,7 +31390,7 @@
         "@walletconnect/heartbeat": "1.0.0",
         "@walletconnect/jsonrpc-provider": "1.0.5",
         "@walletconnect/jsonrpc-utils": "1.0.3",
-        "@walletconnect/jsonrpc-ws-connection": "1.0.3",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.4",
         "@walletconnect/logger": "2.0.0",
         "@walletconnect/relay-api": "1.0.6",
         "@walletconnect/time": "1.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "@walletconnect/heartbeat": "1.0.0",
     "@walletconnect/jsonrpc-provider": "1.0.5",
     "@walletconnect/jsonrpc-utils": "1.0.3",
-    "@walletconnect/jsonrpc-ws-connection": "1.0.3",
+    "@walletconnect/jsonrpc-ws-connection": "1.0.4",
     "@walletconnect/keyvaluestorage": "1.0.1-rc.2",
     "@walletconnect/logger": "2.0.0",
     "@walletconnect/relay-api": "1.0.6",

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -48,7 +48,7 @@
     "pino": "7.11.0"
   },
   "devDependencies": {
-    "@walletconnect/jsonrpc-ws-connection": "1.0.3",
+    "@walletconnect/jsonrpc-ws-connection": "1.0.4",
     "@walletconnect/relay-api": "1.0.6",
     "aws-sdk": "2.1194.0",
     "lokijs": "^1.5.12"


### PR DESCRIPTION
# Description

- Update `core` and `sign-client` to `jsonrpc-ws-connection@1.0.4`
- Fixes WS connection failing with opaque `Cannot read property 'message' of undefined` message, providing an explicit error instead 
	- via https://github.com/WalletConnect/walletconnect-utils/pull/38
- Fixes the unguarded `global` reference raised in #1299 
	- via https://github.com/WalletConnect/walletconnect-utils/pull/36)

### TODO

- We still have to resolve the unguarded `global` reference in the external `localStorage` dependency raised in #1658

## How Has This Been Tested?

- Unit tests
- CI
- Dogfooding with a canary

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
