### PR TITLE
feat: re-enable webhook tests

### DIFF
--- a/packages/sign-client/test/sdk/push.spec.ts
+++ b/packages/sign-client/test/sdk/push.spec.ts
@@ -23,7 +23,11 @@ describe("Push", () => {
   });
   it("receives a prompt webhook", async () => {
     await throttle(200); // Allow to propagate routing table
-    console.log('emitting', await clients.A.core.crypto.getClientId(), await clients.B.core.crypto.getClientId());
+    console.log(
+      "emitting",
+      await clients.A.core.crypto.getClientId(),
+      await clients.B.core.crypto.getClientId(),
+    );
     // Send a message which triggers the webhook to be invoked
     const eventPayload: any = {
       topic: sessionA.topic,
@@ -35,7 +39,10 @@ describe("Push", () => {
     // Extend some time to relay to process it
     await throttle(1000);
 
-    const url = `${TEST_WEBHOOK_ENDPOINT}/${await clients.B.core.crypto.getClientId()}`.replace('did:key:', '');
+    const url = `${TEST_WEBHOOK_ENDPOINT}/${await clients.B.core.crypto.getClientId()}`.replace(
+      "did:key:",
+      "",
+    );
 
     // Validate webhook was called
     const res = await axios.get(url);

--- a/packages/sign-client/test/sdk/push.spec.ts
+++ b/packages/sign-client/test/sdk/push.spec.ts
@@ -5,29 +5,25 @@ import {
   testConnectMethod,
   deleteClients,
   TEST_EMIT_PARAMS,
-  TEST_RELAY_URL,
   TEST_WEBHOOK_ENDPOINT,
   throttle,
 } from "../shared";
+import { TEST_RELAY_URL } from "./../shared/values";
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 
-describe.skip("Push", () => {
+describe("Push", () => {
   let clients;
   let sessionA;
   beforeEach(async () => {
     clients = await initTwoClients();
+    console.log(
+      `Clients initialized (relay '${TEST_RELAY_URL}'), client ids: A:'${await clients.A.core.crypto.getClientId()}';B:'${await clients.B.core.crypto.getClientId()}'`,
+    );
     sessionA = (await testConnectMethod(clients)).sessionA;
   });
-  it("receives a prompt webhook", async () => {
-    // Register Webhook for topic
-    await axios.post(
-      `${TEST_RELAY_URL.replace("ws", "http")}/subscribe`,
-      { webhook: TEST_WEBHOOK_ENDPOINT, topic: sessionA.topic },
-      {
-        headers: { "content-type": "application/json" },
-      },
-    );
-
+  it.only("receives a prompt webhook", async () => {
+    await throttle(5000);
+    console.log('emitting', await clients.A.core.crypto.getClientId(), await clients.B.core.crypto.getClientId());
     // Send a message which triggers the webhook to be invoked
     const eventPayload: any = {
       topic: sessionA.topic,
@@ -37,7 +33,9 @@ describe.skip("Push", () => {
 
     // Relay processes webhooks in background
     // Extend some time to relay to process it
-    await throttle(500);
+    await throttle(5000);
+
+    console.log('emitted');
 
     // Validate webhook was called
     const res = await axios.get(`${TEST_WEBHOOK_ENDPOINT}/${sessionA.topic}`);

--- a/packages/sign-client/test/sdk/push.spec.ts
+++ b/packages/sign-client/test/sdk/push.spec.ts
@@ -21,8 +21,8 @@ describe("Push", () => {
     );
     sessionA = (await testConnectMethod(clients)).sessionA;
   });
-  it.only("receives a prompt webhook", async () => {
-    await throttle(5000);
+  it("receives a prompt webhook", async () => {
+    await throttle(200); // Allow to propagate routing table
     console.log('emitting', await clients.A.core.crypto.getClientId(), await clients.B.core.crypto.getClientId());
     // Send a message which triggers the webhook to be invoked
     const eventPayload: any = {
@@ -33,12 +33,12 @@ describe("Push", () => {
 
     // Relay processes webhooks in background
     // Extend some time to relay to process it
-    await throttle(5000);
+    await throttle(1000);
 
-    console.log('emitted');
+    const url = `${TEST_WEBHOOK_ENDPOINT}/${await clients.B.core.crypto.getClientId()}`.replace('did:key:', '');
 
     // Validate webhook was called
-    const res = await axios.get(`${TEST_WEBHOOK_ENDPOINT}/${sessionA.topic}`);
+    const res = await axios.get(url);
     expect(res.status).to.eql(200);
   });
   afterEach(async () => {


### PR DESCRIPTION
# Description

We used to test by topic. Now by client id. This updates the tests accordingy.

Resolves https://github.com/WalletConnect/rs-relay/issues/652

## How Has This Been Tested?

Ran the tests locally.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
