### PR TITLE
feat(scripts): auto-update RELAYER_SDK_VERSION as part of `new-version`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:ignoreUnhandled": "npm run test:ignoreUnhandled --workspaces --if-present",
     "check": "npm run lint; npm run build; npm run test",
     "reset": "npm run clean; npm run check",
-    "new-version": "lerna version --no-git-tag-version --exact",
+    "new-version": "lerna version --no-git-tag-version --exact && ./scripts/update_relayer_sdk_version.sh",
     "pre-publish": "npm run new-version; npm run reset",
     "npm-publish:rc": "lerna exec -- npm publish --access public --tag rc",
     "npm-publish:latest": "lerna exec -- npm publish --access public --tag latest",

--- a/packages/core/src/constants/relayer.ts
+++ b/packages/core/src/constants/relayer.ts
@@ -30,6 +30,5 @@ export const RELAYER_STORAGE_OPTIONS = {
   database: ":memory:",
 };
 
-// FIXME: Always manually change this after each release (hardcoded from package.json)
-// ... this will be temporarily hardcoded until we refactor our build chain!
+// Updated automatically via `new-version` npm script.
 export const RELAYER_SDK_VERSION = "2.1.3";

--- a/scripts/update_relayer_sdk_version.sh
+++ b/scripts/update_relayer_sdk_version.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+file_location="packages/core/src/constants/relayer.ts"
+regex="RELAYER_SDK_VERSION = \".*\""
+
+# Get the next version from user input.
+echo "Enter new Relayer SDK version (should match the packages): "
+read next_version
+
+# Define the replace value
+new_value="RELAYER_SDK_VERSION = \"$next_version\""
+
+echo "[SCRIPT] Updating RELAYER_SDK_VERSION to $next_version in $file_location..."
+
+# Use sed to update the value in the file
+sed -i '' "s/${regex}/${new_value}/g" $file_location
+
+echo "[SCRIPT] ...Done!"


### PR DESCRIPTION
# Description

No more manually updating finally 🤞 

## How Has This Been Tested?

- [x] Locally
- [x] Do a fresh clone of the repo and ensure the script runs out of the box as expected

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
