### PR TITLE
fix: validate set default chain

### DIFF
--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -264,7 +264,9 @@ export class UniversalProvider implements IUniversalProvider {
     // validate namespace
     if (namespace) {
       if (!Object.keys(this.namespaces).includes(namespace)) {
-        throw new Error(`Invalid namespace: ${namespace}`);
+        throw new Error(
+          `Namespace '${namespace}' is not configured. Please call connect() first with namespace config.`,
+        );
       }
     }
 

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -149,9 +149,8 @@ export class UniversalProvider implements IUniversalProvider {
   // ---------- Private ----------------------------------------------- //
 
   private async checkStorage() {
-    this.namespaces = (await this.client.core.storage.getItem(
-      `${STORAGE}/namespaces`,
-    )) as NamespaceConfig;
+    this.namespaces =
+      ((await this.client.core.storage.getItem(`${STORAGE}/namespaces`)) as NamespaceConfig) || {};
     if (this.namespaces) {
       this.createProviders();
     }

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -137,8 +137,13 @@ export class UniversalProvider implements IUniversalProvider {
   }
 
   public setDefaultChain(chain: string, rpcUrl?: string | undefined) {
-    const [namespace, chainId] = this.validateChain(chain);
-    this.getProvider(namespace).setDefaultChain(chainId, rpcUrl);
+    try {
+      const [namespace, chainId] = this.validateChain(chain);
+      this.getProvider(namespace).setDefaultChain(chainId, rpcUrl);
+    } catch (error) {
+      // ignore the error if the fx is used prematurely before namespaces are set
+      if (!/Please call connect/.test((error as Error).message)) throw error;
+    }
   }
 
   // ---------- Private ----------------------------------------------- //

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -337,4 +337,11 @@ describe("UniversalProvider", function () {
       });
     });
   });
+
+  describe("validation", () => {
+    it("should not throw exception when setDefaultChain is called prematurely", async () => {
+      const provider = await UniversalProvider.init(TEST_PROVIDER_OPTS);
+      provider.setDefaultChain("eip155:1");
+    });
+  });
 });


### PR DESCRIPTION
# Description

When `setDefaultChain` is called before `connect()` in the `universal-provider` unnecessary exception is thrown.
Additionally, I've added more descriptive error message for chain validation + test

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves # ([browse](https://github.com/WalletConnect/walletconnect-monorepo/issues) or [create](https://github.com/WalletConnect/walletconnect-monorepo/issues/new/choose))

## How Has This Been Tested?
npm run test
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
