### PR TITLE
feat: empty required namespaces

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -868,11 +868,7 @@ export class Engine extends IEngine {
     if (!isUndefined(pairingTopic)) await this.isValidPairingTopic(pairingTopic);
 
     // validate required namespaces only if they are defined
-    if (
-      typeof requiredNamespaces === "object" &&
-      !Array.isArray(requiredNamespaces) &&
-      !Object.keys(requiredNamespaces).length
-    ) {
+    if (isValidObject(requiredNamespaces) === 0) {
       return;
     }
 

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -868,7 +868,7 @@ export class Engine extends IEngine {
     if (!isUndefined(pairingTopic)) await this.isValidPairingTopic(pairingTopic);
 
     // validate required namespaces only if they are defined
-    if (isValidObject(requiredNamespaces) === 0) {
+    if (!isUndefined(requiredNamespaces) && isValidObject(requiredNamespaces) === 0) {
       return;
     }
 

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -49,8 +49,9 @@ import {
   isConformingNamespaces,
   isValidController,
   TYPE_1,
+  getRequiredNamespacesFromNamespaces,
+  isValidObject,
 } from "@walletconnect/utils";
-
 import { SESSION_EXPIRY, ENGINE_CONTEXT, ENGINE_RPC_OPTS } from "../constants";
 
 export class Engine extends IEngine {
@@ -113,7 +114,7 @@ export class Engine extends IEngine {
         if (error) reject(error);
         else if (session) {
           session.self.publicKey = publicKey;
-          const completeSession = { ...session, requiredNamespaces };
+          const completeSession = { ...session, requiredNamespaces: session.requiredNamespaces };
           await this.client.session.set(session.topic, completeSession);
           await this.setExpiry(session.topic, session.expiry);
           if (topic) {
@@ -146,9 +147,17 @@ export class Engine extends IEngine {
 
   public approve: IEngine["approve"] = async (params) => {
     this.isInitialized();
-    await this.isValidApprove(params);
     const { id, relayProtocol, namespaces } = params;
-    const { pairingTopic, proposer, requiredNamespaces } = this.client.proposal.get(id);
+    const proposal = this.client.proposal.get(id);
+    let { pairingTopic, proposer, requiredNamespaces } = proposal;
+
+    if (!isValidObject(requiredNamespaces)) {
+      const required = getRequiredNamespacesFromNamespaces(namespaces, "approve()");
+      requiredNamespaces = required;
+      // update the proposal with the new required namespaces
+      this.client.proposal.set(id, { ...proposal, requiredNamespaces });
+    }
+    await this.isValidApprove(params);
 
     const selfPublicKey = await this.client.core.crypto.generateKeyPair();
     const peerPublicKey = proposer.publicKey;
@@ -570,13 +579,14 @@ export class Engine extends IEngine {
     const { id, params } = payload;
     try {
       this.isValidSessionSettleRequest(params);
-      const { relay, controller, expiry, namespaces } = payload.params;
+      const { relay, controller, expiry, namespaces, requiredNamespaces } = payload.params;
       const session = {
         topic,
         relay,
         expiry,
         namespaces,
         acknowledged: true,
+        requiredNamespaces,
         controller: controller.publicKey,
         self: {
           publicKey: "",
@@ -856,6 +866,10 @@ export class Engine extends IEngine {
     }
     const { pairingTopic, requiredNamespaces, relays } = params;
     if (!isUndefined(pairingTopic)) await this.isValidPairingTopic(pairingTopic);
+
+    // validate required namespaces only if they are defined
+    if (!Object.keys(requiredNamespaces).length) return;
+
     const validRequiredNamespacesError = isValidRequiredNamespaces(requiredNamespaces, "connect()");
     if (validRequiredNamespacesError) throw new Error(validRequiredNamespacesError.message);
     if (!isValidRelays(relays, true)) {

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -51,7 +51,6 @@ import {
   TYPE_1,
   getRequiredNamespacesFromNamespaces,
   isValidObject,
-  isValidArray,
 } from "@walletconnect/utils";
 import { SESSION_EXPIRY, ENGINE_CONTEXT, ENGINE_RPC_OPTS } from "../constants";
 

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -8,9 +8,9 @@ import {
   TEST_SIGN_CLIENT_OPTIONS,
   deleteClients,
   throttle,
-  TEST_ETHEREUM_ACCOUNT,
-  TEST_ETHEREUM_CHAIN,
   TEST_REQUEST_PARAMS,
+  TEST_NAMESPACES,
+  TEST_REQUIRED_NAMESPACES,
 } from "../shared";
 
 describe("Sign Client Integration", () => {
@@ -207,6 +207,23 @@ describe("Sign Client Integration", () => {
       const updatedExpiry = clients.A.session.get(topic).expiry;
       expect(updatedExpiry).to.be.greaterThan(prevExpiry);
       vi.useRealTimers();
+      await deleteClients(clients);
+    });
+  });
+  describe("namespaces", () => {
+    it("should pair with empty namespaces", async () => {
+      const clients = await initTwoClients();
+      const requiredNamespaces = {};
+      const { sessionA } = await testConnectMethod(clients, {
+        requiredNamespaces,
+        namespaces: TEST_NAMESPACES,
+      });
+      expect(requiredNamespaces).toMatchObject({});
+      // requiredNamespaces are built internally from the namespaces during approve()
+      expect(sessionA.requiredNamespaces).toMatchObject(TEST_REQUIRED_NAMESPACES);
+      expect(sessionA.requiredNamespaces).toMatchObject(
+        clients.B.session.get(sessionA.topic).requiredNamespaces,
+      );
       await deleteClients(clients);
     });
   });

--- a/packages/sign-client/test/sdk/validation.spec.ts
+++ b/packages/sign-client/test/sdk/validation.spec.ts
@@ -63,17 +63,13 @@ describe("Sign Client Validation", () => {
       ).rejects.toThrowError("No matching key. pairing topic doesn't exist: none");
     });
 
-    it("throws when empty requiredNamespaces are provided", async () => {
-      await expect(
-        clients.A.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, requiredNamespaces: {} }),
-      ).rejects.toThrowError(
-        "Missing or invalid. connect(), requiredNamespaces should be an object with data",
-      );
-    });
-
     it("throws when invalid requiredNamespaces are provided", async () => {
       await expect(
-        clients.A.connect({ ...TEST_CONNECT_PARAMS, pairingTopic, requiredNamespaces: [] }),
+        clients.A.connect({
+          ...TEST_CONNECT_PARAMS,
+          pairingTopic,
+          requiredNamespaces: [],
+        }),
       ).rejects.toThrowError(
         "Missing or invalid. connect(), requiredNamespaces should be an object with data",
       );

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -27,7 +27,7 @@ export declare namespace EngineTypes {
   interface EventArguments {
     session_connect: {
       error?: ErrorResponse;
-      session?: Omit<SessionTypes.Struct, "requiredNamespaces">;
+      session?: SessionTypes.Struct;
     };
     session_approve: { error?: ErrorResponse };
     session_update: { error?: ErrorResponse };

--- a/packages/types/src/sign-client/jsonrpc.ts
+++ b/packages/types/src/sign-client/jsonrpc.ts
@@ -37,6 +37,7 @@ export declare namespace JsonRpcTypes {
     wc_sessionSettle: {
       relay: RelayerTypes.ProtocolOptions;
       namespaces: SessionTypes.Namespaces;
+      requiredNamespaces: ProposalTypes.RequiredNamespaces;
       expiry: number;
       controller: {
         publicKey: string;

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -1,4 +1,5 @@
-import { SessionTypes } from "@walletconnect/types";
+import { ProposalTypes, SessionTypes } from "@walletconnect/types";
+import { isValidNamespaces } from "./validators";
 
 export function getAccountsChains(accounts: SessionTypes.Namespace["accounts"]) {
   const chains: string[] = [];
@@ -60,4 +61,22 @@ export function getNamespacesEventsForChainId(
   });
 
   return events;
+}
+
+export function getRequiredNamespacesFromNamespaces(
+  namespaces: SessionTypes.Namespaces,
+  caller: string,
+): ProposalTypes.RequiredNamespaces {
+  const validNamespacesError = isValidNamespaces(namespaces, caller);
+  if (validNamespacesError) throw new Error(validNamespacesError.message);
+
+  const required = {};
+  for (const [namespace, values] of Object.entries(namespaces)) {
+    required[namespace] = {
+      methods: values.methods,
+      events: values.events,
+      chains: values.accounts.map((account) => `${account.split(":")[0]}:${account.split(":")[1]}`),
+    };
+  }
+  return required;
 }


### PR DESCRIPTION
# Description
Empty `requiredNamespaces` as per spec https://github.com/WalletConnect/walletconnect-docs/blob/a14e99fe3e42447ce892da34cc32b57b0e289bb8/docs/specs/clients/sign/session-namespaces.md#110-proposal-namespaces-may-be-empty

When a dapp does not provide `requiredNamespaces`, it will use the namespaces provided by the wallet when session is initiated  

The PR includes empty `requiredNamespaces` handling + test

- Canary `2.1.5-rc-135e5e70`
- Dapp example https://react-dapp-v2-4k4jtajfd-walletconnect1.vercel.app/
- Wallet example https://react-wallet-v2-oyxqd89lh-walletconnect1.vercel.app/

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?
npm run test
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
