### PR TITLE
feat: pending pairigs cleanup

### DIFF
--- a/providers/universal-provider/package.json
+++ b/providers/universal-provider/package.json
@@ -27,7 +27,8 @@
     "build:types": "tsc",
     "build:source": "rollup --config rollup.config.js",
     "build": "npm run build:pre; npm run build:source; npm run build:types",
-    "test": "vitest run --dir test",
+    "test:pre": "rm -rf ./test/tmp && mkdir ./test/tmp",
+    "test": "npm run test:pre; vitest run --dir test",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -151,13 +151,13 @@ export class UniversalProvider implements IUniversalProvider {
     this.logger.info("Cleaning up inactive pairings...");
     const inactivePairings = this.client.pairing.getAll({ active: false });
 
-    if (!isValidArray(invactivePairings)) return;
+    if (!isValidArray(inactivePairings)) return;
 
-    invactivePairings.forEach((pairing) => {
+    inactivePairings.forEach((pairing) => {
       this.client.pairing.delete(pairing.topic, getSdkError("USER_DISCONNECTED"));
     });
 
-    this.logger.info(`Inactive pairings cleared: ${invactivePairings.length}`);
+    this.logger.info(`Inactive pairings cleared: ${inactivePairings.length}`);
   }
 
   // ---------- Private ----------------------------------------------- //

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -149,7 +149,7 @@ export class UniversalProvider implements IUniversalProvider {
 
   public cleanupPendingPairings(): void {
     this.logger.info("Cleaning up inactive pairings...");
-    const invactivePairings = this.client.pairing.getAll({ active: false });
+    const inactivePairings = this.client.pairing.getAll({ active: false });
 
     if (!isValidArray(invactivePairings)) return;
 

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -2,7 +2,7 @@ import pino from "pino";
 import SignClient from "@walletconnect/sign-client";
 import { ProviderAccounts } from "eip1193-provider";
 import { SessionTypes } from "@walletconnect/types";
-import { getSdkError } from "@walletconnect/utils";
+import { getSdkError, isValidArray } from "@walletconnect/utils";
 import { getDefaultLoggerOptions, Logger } from "@walletconnect/logger";
 import Eip155Provider from "./providers/eip155";
 import SolanaProvider from "./providers/solana";
@@ -96,6 +96,7 @@ export class UniversalProvider implements IUniversalProvider {
 
     this.setNamespaces(opts.namespaces);
     this.createProviders();
+    this.cleanupPendingPairings();
 
     return opts.skipPairing === true ? undefined : await this.pair(opts.pairingTopic);
   }
@@ -144,6 +145,19 @@ export class UniversalProvider implements IUniversalProvider {
       // ignore the error if the fx is used prematurely before namespaces are set
       if (!/Please call connect/.test((error as Error).message)) throw error;
     }
+  }
+
+  public cleanupPendingPairings(): void {
+    this.logger.info("Cleaning up inactive pairings...");
+    const invactivePairings = this.client.pairing.getAll({ active: false });
+
+    if (!isValidArray(invactivePairings)) return;
+
+    invactivePairings.forEach((pairing) => {
+      this.client.pairing.delete(pairing.topic, getSdkError("USER_DISCONNECTED"));
+    });
+
+    this.logger.info(`Inactive pairings cleared: ${invactivePairings.length}`);
   }
 
   // ---------- Private ----------------------------------------------- //

--- a/providers/universal-provider/src/types/providers.ts
+++ b/providers/universal-provider/src/types/providers.ts
@@ -38,4 +38,5 @@ export interface IUniversalProvider extends IEthereumProvider {
   pair: (pairingTopic: string | undefined) => Promise<SessionTypes.Struct>;
   connect: (opts: ConnectParams) => Promise<SessionTypes.Struct | undefined>;
   disconnect: () => void;
+  cleanupPendingPairings: () => void;
 }

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -7,7 +7,7 @@ import {
   _abi,
   _bytecode,
 } from "ethereum-test-network/lib/utils/ERC20Token__factory";
-import { deleteProviders, testConnectMethod, WalletClient } from "./shared";
+import { deleteProviders, disconnectSocket, testConnectMethod, WalletClient } from "./shared";
 import UniversalProvider from "../src";
 import {
   CHAIN_ID,
@@ -19,6 +19,7 @@ import {
   TEST_ETH_TRANSFER,
   TEST_SIGN_TRANSACTION,
   CHAIN_ID_B,
+  TEST_REQUIRED_NAMESPACES,
 } from "./shared/constants";
 
 describe("UniversalProvider", function () {
@@ -334,6 +335,30 @@ describe("UniversalProvider", function () {
         ethers = new providers.Web3Provider(afterDapp);
         const afterAccounts = await ethers.listAccounts();
         expect(accounts).to.toMatchObject(afterAccounts);
+      });
+    });
+    describe("pairings", () => {
+      it("should clean up inactive pairings", async () => {
+        const PAIRINGS_TO_CREATE = 5;
+        const dapp = await UniversalProvider.init({
+          ...TEST_PROVIDER_OPTS,
+          name: "dapp",
+        });
+
+        for (let i = 0; i < PAIRINGS_TO_CREATE; i++) {
+          const { uri } = await dapp.client.connect({
+            requiredNamespaces: TEST_REQUIRED_NAMESPACES,
+          });
+
+          expect(!!uri).to.be.true;
+          expect(uri).to.be.a("string");
+          expect(dapp.client.pairing.getAll({ active: false }).length).to.eql(i + 1);
+        }
+        dapp.cleanupPendingPairings();
+        expect(dapp.client.pairing.getAll({ active: false }).length).to.eql(0);
+
+        // disconnect
+        await disconnectSocket(dapp.client.core);
       });
     });
   });


### PR DESCRIPTION
# Description

Pending pairings have a current lifetime of 5 minutes. Rapid creation of multiple pairings in a short period of time (before the expirer kick in) might lead to degraded performance, especially during development, thus an update is required to clean-up pending pairings when a new one is initiated.

- added auto clean-up when `connect()` is called
- added public API `cleanupPendingPairings` clean-up
- integration test

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->
npm run test
dogfooding in demo apps

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
