### PR TITLE
fix(scripts): differentiate `sed` command by platform

### DIFF
--- a/scripts/update_relayer_sdk_version.sh
+++ b/scripts/update_relayer_sdk_version.sh
@@ -13,6 +13,12 @@ new_value="RELAYER_SDK_VERSION = \"$next_version\""
 echo "[SCRIPT] Updating RELAYER_SDK_VERSION to $next_version in $file_location..."
 
 # Use sed to update the value in the file
-sed -i '' "s/${regex}/${new_value}/g" $file_location
+if [ "$(uname)" == "Darwin" ]; then
+  # MacOS requires an empty string as the second argument to -i
+  sed -i "" "s/${regex}/${new_value}/g" $file_location
+else
+  sed -i "s/${regex}/${new_value}/g" $file_location
+fi
+
 
 echo "[SCRIPT] ...Done!"

--- a/scripts/update_relayer_sdk_version.sh
+++ b/scripts/update_relayer_sdk_version.sh
@@ -13,7 +13,7 @@ new_value="RELAYER_SDK_VERSION = \"$next_version\""
 echo "[SCRIPT] Updating RELAYER_SDK_VERSION to $next_version in $file_location..."
 
 # Use sed to update the value in the file
-if [ "$(uname)" == "Darwin" ]; then
+if [ "$(uname)" = "Darwin" ]; then
   # MacOS requires an empty string as the second argument to -i
   sed -i "" "s/${regex}/${new_value}/g" $file_location
 else


### PR DESCRIPTION
# Description

- The empty string `""` parameter for `sed` in the `update_relayer_sdk_version.sh` script seems to be macOS/BSD specific.
- Adds control flow to call on macOS with extra parameter, without by default.

## How Has This Been Tested?

- Tested on macOS via parallel GNU `sed` installation.

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
