### PR TITLE
fix: check if relay event is related to a pairing topic

### DIFF
--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -252,6 +252,8 @@ export class Pairing implements IPairing {
     const { topic, payload } = event;
     const reqMethod = payload.method as PairingJsonRpcTypes.WcMethod;
 
+    if (!this.pairings.keys.includes(topic)) return;
+
     switch (reqMethod) {
       case "wc_pairingPing":
         return this.onPairingPingRequest(topic, payload);
@@ -266,6 +268,8 @@ export class Pairing implements IPairing {
     const { topic, payload } = event;
     const record = await this.core.history.get(topic, payload.id);
     const resMethod = record.request.method as PairingJsonRpcTypes.WcMethod;
+
+    if (!this.pairings.keys.includes(topic)) return;
 
     switch (resMethod) {
       case "wc_pairingPing":


### PR DESCRIPTION
# Description

Currently if you use Core API without registering with the Pairing API you will get an error regarding History even if the incoming payload was not targeting a pairing topic.

For example, I'm using a random symKey and topic to message between two clients and you can see in the screenshot below that I'm using a method `wc_syncSet` and the Pairing controller is automatically rejecting it.\

<img width="818" alt="Screenshot 2023-01-05 at 18 22 06" src="https://user-images.githubusercontent.com/10136079/210842075-1f6b2c00-e720-4758-8a00-7ce5bd5ab2df.png">

However I get an error message that JsonRpcHistory controller is not matching any keys to this request and this happens on `onRelayEventResponse` when the Pairing controller tries to reject with `unknown method`

<img width="1027" alt="Screenshot 2023-01-05 at 18 22 13" src="https://user-images.githubusercontent.com/10136079/210842080-49c801be-3f08-4aa4-9123-3c50fc81c7a4.png">

## How Has This Been Tested?

I'm creating a prototype for the Sync API on this repo: https://github.com/WalletConnect/sync-api-testing

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
