### PR TITLE
fix: expirer pending requests

### DIFF
--- a/packages/core/src/controllers/expirer.ts
+++ b/packages/core/src/controllers/expirer.ts
@@ -89,9 +89,9 @@ export class Expirer extends IExpirer {
 
   public del: IExpirer["del"] = (key) => {
     this.isInitialized();
-    const target = this.formatTarget(key);
-    const exists = this.has(target);
+    const exists = this.has(key);
     if (exists) {
+      const target = this.formatTarget(key);
       const expiration = this.getExpiration(target);
       this.expirations.delete(target);
       this.events.emit(EXPIRER_EVENTS.deleted, {

--- a/packages/core/test/expirer.spec.ts
+++ b/packages/core/test/expirer.spec.ts
@@ -23,7 +23,6 @@ describe("Expirer", () => {
         resolve();
       });
     });
-    // core.expirer.set("test")
     await disconnectSocket(core.relayer);
   });
 });

--- a/packages/core/test/expirer.spec.ts
+++ b/packages/core/test/expirer.spec.ts
@@ -1,0 +1,29 @@
+import { expect, describe, it } from "vitest";
+import { calcExpiry, formatExpirerTarget } from "@walletconnect/utils";
+
+import { Core, EXPIRER_EVENTS } from "../src";
+import { disconnectSocket, TEST_CORE_OPTIONS } from "./shared";
+
+describe("Expirer", () => {
+  it("should expire payload", async () => {
+    const core = new Core(TEST_CORE_OPTIONS);
+    await core.start();
+    // confirm the expirer is empty
+    expect(core.expirer.length).to.eq(0);
+    // set a payload
+    const topic = "test";
+    core.expirer.set(topic, calcExpiry(1));
+    // confirm the expirer is not empty
+    expect(core.expirer.length).to.eq(1);
+    await new Promise<void>((resolve) => {
+      core.expirer.on(EXPIRER_EVENTS.expired, (payload: any) => {
+        expect(payload.target).to.eq(formatExpirerTarget("topic", topic));
+        // confirm the expirer is empty again
+        expect(core.expirer.length).to.eq(0);
+        resolve();
+      });
+    });
+    // core.expirer.set("test")
+    await disconnectSocket(core.relayer);
+  });
+});

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -381,7 +381,7 @@ export class Engine extends IEngine {
       topic,
       params,
     });
-    if (expiry) this.client.core.expirer.set(id, expiry);
+    if (expiry) this.client.core.expirer.set(id, calcExpiry(expiry));
   };
 
   private sendRequest: EnginePrivate["sendRequest"] = async (topic, method, params) => {
@@ -754,8 +754,7 @@ export class Engine extends IEngine {
   private registerExpirerEvents() {
     this.client.core.expirer.on(EXPIRER_EVENTS.expired, async (event: ExpirerTypes.Expiration) => {
       const { topic, id } = parseExpirerTarget(event.target);
-
-      if (id && this.getPendingSessionRequests()[id]) {
+      if (id && this.client.pendingRequest.keys.includes(id)) {
         return await this.deletePendingSessionRequest(id, getInternalError("EXPIRED"), true);
       }
 


### PR DESCRIPTION
# Description

An issue was identified with pending requests where on approving/rejecting a request was logging`{context: 'core'} {context: 'core/expirer'} 'No matching key. expirer: topic:id:1672999835033891'`.
The problem was caused by `formatTarget` being called twice on the same key in `expirer.del` flow thus prepending the `topic:..` & `id:...` to the key

Additionally, the expiration calculation was incorrect for pending requests and is also resolved in the PR


## How Has This Been Tested?
dogfooding
additional test for the expirer
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
