### PR TITLE
feat: optional request expiry

### DIFF
--- a/packages/core/src/constants/relayer.ts
+++ b/packages/core/src/constants/relayer.ts
@@ -15,6 +15,7 @@ export const RELAYER_EVENTS = {
   error: "relayer_error",
   connection_stalled: "relayer_connection_stalled",
   transport_closed: "relayer_transport_closed",
+  publish: "relayer_publish",
 };
 
 export const RELAYER_SUBSCRIBER_SUFFIX = "_subscription";

--- a/packages/core/src/controllers/publisher.ts
+++ b/packages/core/src/controllers/publisher.ts
@@ -47,6 +47,7 @@ export class Publisher extends IPublisher {
           this.publishTimeout,
         );
         await publish;
+        this.relayer.events.emit(RELAYER_EVENTS.publish, params);
       } catch (err) {
         this.logger.debug(`Publishing Payload stalled`);
         this.relayer.events.emit(RELAYER_EVENTS.connection_stalled);

--- a/packages/sign-client/src/constants/engine.ts
+++ b/packages/sign-client/src/constants/engine.ts
@@ -1,4 +1,4 @@
-import { FIVE_MINUTES, ONE_DAY, THIRTY_SECONDS } from "@walletconnect/time";
+import { FIVE_MINUTES, ONE_DAY, SEVEN_DAYS, THIRTY_SECONDS } from "@walletconnect/time";
 import { EngineTypes } from "@walletconnect/types";
 
 export const ENGINE_CONTEXT = "engine";
@@ -104,6 +104,6 @@ export const ENGINE_RPC_OPTS: EngineTypes.RpcOptsMap = {
 };
 
 export const SESSION_REQUEST_EXPIRY_BOUNDARIES = {
-  min: 300,
-  max: 604800,
+  min: FIVE_MINUTES,
+  max: SEVEN_DAYS,
 };

--- a/packages/sign-client/src/constants/engine.ts
+++ b/packages/sign-client/src/constants/engine.ts
@@ -102,3 +102,8 @@ export const ENGINE_RPC_OPTS: EngineTypes.RpcOptsMap = {
     },
   },
 };
+
+export const SESSION_REQUEST_EXPIRY_BOUNDARIES = {
+  min: 300,
+  max: 604800,
+};

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -1011,7 +1011,7 @@ export class Engine extends IEngine {
     if (expiry && !isValidRequestExpiry(expiry, SESSION_REQUEST_EXPIRY_BOUNDARIES)) {
       const { message } = getInternalError(
         "MISSING_OR_INVALID",
-        `request() expiry: ${expiry}. Expiry must be a number between ${SESSION_REQUEST_EXPIRY_BOUNDARIES.min} and ${SESSION_REQUEST_EXPIRY_BOUNDARIES.max}`,
+        `request() expiry: ${expiry}. Expiry must be a number (in seconds) between ${SESSION_REQUEST_EXPIRY_BOUNDARIES.min} and ${SESSION_REQUEST_EXPIRY_BOUNDARIES.max}`,
       );
       throw new Error(message);
     }

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -266,7 +266,7 @@ export class Engine extends IEngine {
     await this.isValidRequest(params);
     const { chainId, request, topic, expiry } = params;
     const id = await this.sendRequest(topic, "wc_sessionRequest", { request, chainId }, expiry);
-    const { done, resolve, reject } = createDelayedPromise<T>();
+    const { done, resolve, reject } = createDelayedPromise<T>(expiry);
     this.events.once<"session_request">(engineEvent("session_request", id), ({ error, result }) => {
       if (error) reject(error);
       else resolve(result);

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -241,7 +241,7 @@ describe("Sign Client Integration", () => {
 
       await Promise.all([
         new Promise<void>((resolve) => {
-          clients.A.core.relayer.on(
+          clients.A.core.relayer.once(
             RELAYER_EVENTS.publish,
             (payload: RelayerTypes.PublishPayload) => {
               // ttl of the request should match the expiry

--- a/packages/sign-client/test/sdk/validation.spec.ts
+++ b/packages/sign-client/test/sdk/validation.spec.ts
@@ -540,6 +540,14 @@ describe("Sign Client Validation", () => {
         clients.A.request({ ...TEST_REQUEST_PARAMS, topic, request: { method: "unknown" } }),
       ).rejects.toThrowError("Missing or invalid. request() method: unknown");
     });
+
+    it("throws when invalid expiry is provider", async () => {
+      await expect(
+        clients.A.request({ ...TEST_REQUEST_PARAMS, topic, expiry: 10 }),
+      ).rejects.toThrowError(
+        "Missing or invalid. request() expiry: 10. Expiry must be a number between 300 and 604800",
+      );
+    });
   });
 
   describe("respond", () => {

--- a/packages/sign-client/test/sdk/validation.spec.ts
+++ b/packages/sign-client/test/sdk/validation.spec.ts
@@ -545,7 +545,7 @@ describe("Sign Client Validation", () => {
       await expect(
         clients.A.request({ ...TEST_REQUEST_PARAMS, topic, expiry: 10 }),
       ).rejects.toThrowError(
-        "Missing or invalid. request() expiry: 10. Expiry must be a number between 300 and 604800",
+        "Missing or invalid. request() expiry: 10. Expiry must be a number (in seconds) between 300 and 604800",
       );
     });
   });

--- a/packages/types/src/core/relayer.ts
+++ b/packages/types/src/core/relayer.ts
@@ -31,6 +31,11 @@ export declare namespace RelayerTypes {
 
   export type RequestOptions = PublishOptions | SubscribeOptions | UnsubscribeOptions;
 
+  export interface PublishPayload {
+    topic: string;
+    message: string;
+    opts?: RelayerTypes.PublishOptions;
+  }
   export interface MessageEvent {
     topic: string;
     message: string;

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -87,6 +87,7 @@ export declare namespace EngineTypes {
       params: any;
     };
     chainId: string;
+    expiry?: number;
   }
 
   interface RespondParams {
@@ -149,6 +150,7 @@ export interface EnginePrivate {
     topic: string,
     method: M,
     params: JsonRpcTypes.RequestParams[M],
+    expiry?: number,
   ): Promise<number>;
 
   sendResult<M extends JsonRpcTypes.WcMethod>(

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -221,8 +221,8 @@ export function isExpired(expiry: number) {
 }
 
 // -- promises --------------------------------------------- //
-export function createDelayedPromise<T>() {
-  const timeout = toMiliseconds(FIVE_MINUTES);
+export function createDelayedPromise<T>(expiry?: number | undefined) {
+  const timeout = toMiliseconds(expiry || FIVE_MINUTES);
   let cacheResolve: undefined | ((value: T | PromiseLike<T>) => void);
   let cacheReject: undefined | ((value?: ErrorResponse) => void);
   let cacheTimeout: undefined | NodeJS.Timeout;

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -489,3 +489,7 @@ export function isConformingNamespaces(
 
   return error;
 }
+
+export function isValidRequestExpiry(expiry: number, boudaries: { min: number; max: number }) {
+  return isValidNumber(expiry, false) && expiry <= boudaries.max && expiry >= boudaries.min;
+}

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -490,6 +490,6 @@ export function isConformingNamespaces(
   return error;
 }
 
-export function isValidRequestExpiry(expiry: number, boudaries: { min: number; max: number }) {
-  return isValidNumber(expiry, false) && expiry <= boudaries.max && expiry >= boudaries.min;
+export function isValidRequestExpiry(expiry: number, boundaries: { min: number; max: number }) {
+  return isValidNumber(expiry, false) && expiry <= boundaries.max && expiry >= boundaries.min;
 }


### PR DESCRIPTION
# Description

Relates to #1739 

Added an optional `expiry` parameter to session requests where a number between `300` & `604800` seconds (5 minutes min - 7 days max) can be specified to extend a request timeout 
## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->
new validation + integration tests
## Due Dilligence

* [ ] Breaking change
* [x] Requires a documentation update
* [ ] Requires a e2e/integration test update
