### PR TITLE
chore(templates): adds sub-section for link to docs issue/PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,8 +18,9 @@ Please:
 
 <!-- If valid for smoke test on feature add screenshots -->
 
-## Due Dilligence
+## Due Diligence
 
-* [ ] Breaking change
-* [ ] Requires a documentation update
-* [ ] Requires a e2e/integration test update
+- [ ] Breaking change
+- [ ] Requires a documentation update
+  - [ ] Related docs issue/PR (if docs are not included in this PR):
+- [ ] Requires a e2e/integration test update


### PR DESCRIPTION
## Description

* Updates the monorepo PR template to include a sub-section where a follow-up docs issue/PR can be linked if documentation needs to changed
* Intended as an additional waypoint to avoid us forgetting docs updates, not following up with docs changes where needed.
