### PR TITLE
refactor: disconnect pairings in universal-provider

### DIFF
--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -165,20 +165,6 @@ export class UniversalProvider implements IUniversalProvider {
     this.logger.info(`Inactive pairings cleared: ${inactivePairings.length}`);
   }
 
-  public cleanupProposals(): void {
-    this.logger.info("Cleaning up proposals...");
-    const proposals = this.client.proposal.getAll();
-
-    if (!isValidArray(proposals)) return;
-    proposals.forEach((proposal) => {
-      const id = proposal.id;
-      this.client.proposal.delete(id, getSdkError("USER_DISCONNECTED"));
-      this.client.core.expirer.del(id);
-    });
-
-    this.logger.info(`Proposals cleared: ${proposals.length}`);
-  }
-
   // ---------- Private ----------------------------------------------- //
 
   private async checkStorage() {

--- a/providers/universal-provider/src/types/misc.ts
+++ b/providers/universal-provider/src/types/misc.ts
@@ -70,7 +70,9 @@ export interface RequestArguments {
 }
 
 export interface CleanupOpts {
-  pairings?: {
-    active?: boolean;
-  };
+  pairings?: CleanupPairingsOpts;
+}
+
+export interface CleanupPairingsOpts {
+  active?: boolean;
 }

--- a/providers/universal-provider/src/types/misc.ts
+++ b/providers/universal-provider/src/types/misc.ts
@@ -68,11 +68,3 @@ export interface RequestArguments {
   method: string;
   params?: unknown[] | Record<string, unknown> | object | undefined;
 }
-
-export interface CleanupOpts {
-  pairings?: CleanupPairingsOpts;
-}
-
-export interface CleanupPairingsOpts {
-  active?: boolean;
-}

--- a/providers/universal-provider/src/types/misc.ts
+++ b/providers/universal-provider/src/types/misc.ts
@@ -68,3 +68,9 @@ export interface RequestArguments {
   method: string;
   params?: unknown[] | Record<string, unknown> | object | undefined;
 }
+
+export interface CleanupOpts {
+  pairings?: {
+    active?: boolean;
+  };
+}

--- a/providers/universal-provider/src/types/providers.ts
+++ b/providers/universal-provider/src/types/providers.ts
@@ -27,7 +27,7 @@ export interface IUniversalProvider extends IEthereumProvider {
   client?: SignClient;
   namespaces?: NamespaceConfig;
   rpcProviders: RpcProviderMap;
-  session: SessionTypes.Struct;
+  session?: SessionTypes.Struct;
   uri: string | undefined;
 
   request: <T = unknown>(args: RequestArguments, chain?: string) => Promise<T>;

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -393,6 +393,7 @@ describe("UniversalProvider", function () {
     });
     describe("pairings", () => {
       it("should clean up inactive pairings", async () => {
+        const SUBS_ON_START = provider.client.core.relayer.subscriber.subscriptions.size;
         const PAIRINGS_TO_CREATE = 5;
         for (let i = 0; i < PAIRINGS_TO_CREATE; i++) {
           const { uri } = await provider.client.connect({
@@ -403,8 +404,12 @@ describe("UniversalProvider", function () {
           expect(uri).to.be.a("string");
           expect(provider.client.pairing.getAll({ active: false }).length).to.eql(i + 1);
         }
+        const EXPECTED_SUBS = PAIRINGS_TO_CREATE + SUBS_ON_START;
+        expect(provider.client.core.relayer.subscriber.subscriptions.size).to.eql(EXPECTED_SUBS);
         await provider.cleanupPendingPairings();
-        expect(provider.client.pairing.getAll({ active: false }).length).to.eql(0);
+        expect(provider.client.core.relayer.subscriber.subscriptions.size).to.eql(
+          EXPECTED_SUBS - PAIRINGS_TO_CREATE,
+        );
       });
     });
   });

--- a/providers/universal-provider/test/shared/connect.ts
+++ b/providers/universal-provider/test/shared/connect.ts
@@ -145,26 +145,7 @@ export async function testConnectMethod(
   expect(sessionA.self.metadata).to.eql(sessionB.peer.metadata);
   expect(sessionB.self.metadata).to.eql(sessionA.peer.metadata);
 
-  if (!pairingA) throw new Error("expect pairing A to be defined");
-  if (!pairingB) throw new Error("expect pairing B to be defined");
-
-  // update pairing state beforehand
-  pairingA = dappClient.pairing.get(pairingA.topic);
-  pairingB = walletClient.pairing.get(pairingB.topic);
-
-  // topic
-  expect(pairingA.topic).to.eql(pairingB.topic);
-  // relay
-  expect(pairingA.relay).to.eql(TEST_RELAY_OPTIONS);
-  expect(pairingA.relay).to.eql(pairingB.relay);
-  // active
-  expect(pairingA.active).to.eql(true);
-  expect(pairingA.active).to.eql(pairingB.active);
-  // metadata
-  expect(pairingA.peerMetadata).to.eql(sessionA.peer.metadata);
-  expect(pairingB.peerMetadata).to.eql(sessionB.peer.metadata);
-
-  return { pairingA, sessionA, clientAConnectLatencyMs, settlePairingLatencyMs };
+  return { sessionA, clientAConnectLatencyMs, settlePairingLatencyMs };
 }
 
 export function batchArray(array: any[], size: number) {


### PR DESCRIPTION
# Description
Reworked the pending pairings cleanup to unsubscribe the pairings instead of deleting them to avoid disruption of internal `SignClient/Core` flows
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?
integration tests
dogfooding
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
