### PR TITLE
fix(engine): adds missing emit for `proposal_expire`

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -772,6 +772,7 @@ export class Engine extends IEngine {
         }
       } else if (id) {
         await this.deleteProposal(id, true);
+        this.client.events.emit("proposal_expire", { id });
       }
     });
   }


### PR DESCRIPTION
# Description

- `proposal_expire` is defined as one of our Sign events but is currently not being emitted as expected
- Emit `proposal_expire` when the expirer removes a pending proposal.

## How Has This Been Tested?

- Canary/dogfooding

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
