### PR TITLE
refactor: provider full cleanup on disconnect

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -709,8 +709,10 @@ export class Engine extends IEngine {
     try {
       this.isValidDisconnect({ topic, reason: payload.params });
       // RPC request needs to happen before deletion as it utalises session encryption
+      this.client.core.relayer.once(RELAYER_EVENTS.publish, async () => {
+        await this.deleteSession(topic);
+      });
       await this.sendResult<"wc_sessionDelete">(id, topic, true);
-      await this.deleteSession(topic);
       this.client.events.emit("session_delete", { id, topic });
     } catch (err: any) {
       await this.sendError(id, topic, err);

--- a/providers/universal-provider/src/types/misc.ts
+++ b/providers/universal-provider/src/types/misc.ts
@@ -68,3 +68,6 @@ export interface RequestArguments {
   method: string;
   params?: unknown[] | Record<string, unknown> | object | undefined;
 }
+export interface PairingsCleanupOpts {
+  deletePairings?: boolean;
+}

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -407,9 +407,7 @@ describe("UniversalProvider", function () {
         const EXPECTED_SUBS = PAIRINGS_TO_CREATE + SUBS_ON_START;
         expect(provider.client.core.relayer.subscriber.subscriptions.size).to.eql(EXPECTED_SUBS);
         await provider.cleanupPendingPairings();
-        expect(provider.client.core.relayer.subscriber.subscriptions.size).to.eql(
-          EXPECTED_SUBS - PAIRINGS_TO_CREATE,
-        );
+        expect(provider.client.core.relayer.subscriber.subscriptions.size).to.eql(1);
       });
     });
   });


### PR DESCRIPTION
# Description

To allow easier/more fluent usage of the `universal-provider` all cached data is removed when a session is disconnected. This allows for brand new connection flow the next time a pairing is initiated.

Also resolves an intermittent issue where `keyring` pairing key might get deleted before publishing a `disconnect` response thus causing `Error: No matching key. keychain:` error

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?
integration tests
dogfooding
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
