### PR TITLE
fix: websocket cleanup in tests

### DIFF
--- a/packages/sign-client/test/sdk/integration/integration.spec.ts
+++ b/packages/sign-client/test/sdk/integration/integration.spec.ts
@@ -87,6 +87,7 @@ describe("Sign Client Integration", () => {
       const updatedExpiry = clients.A.session.get(topic).expiry;
       expect(updatedExpiry).to.be.greaterThan(prevExpiry);
       vi.useRealTimers();
+      await deleteClients(clients);
     });
   });
   describe("disconnect", () => {

--- a/packages/sign-client/test/sdk/integration/push.spec.ts
+++ b/packages/sign-client/test/sdk/integration/push.spec.ts
@@ -70,6 +70,6 @@ describe("Push", () => {
       }),
     ]);
 
-    deleteClients(clients);
+    await deleteClients(clients);
   });
 });

--- a/packages/sign-client/test/shared/helpers.ts
+++ b/packages/sign-client/test/shared/helpers.ts
@@ -16,6 +16,7 @@ export async function deleteClients(clients: {
     client.core.relayer.provider.connection.events.removeAllListeners();
     client.events.removeAllListeners();
     await disconnectSocket(client.core);
+    await throttle(100);
   }
   delete clients.A;
   delete clients.B;


### PR DESCRIPTION
# Description
Socket disposal in tests

- two sockets were left connected in the integration tests
- added await to `deleteClients` in push tests
- added 100ms delay to allow for connections to disconnect before moving to the next test / proper fix in PR review stage in utils repo

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves # ([browse](https://github.com/WalletConnect/walletconnect-monorepo/issues) or [create](https://github.com/WalletConnect/walletconnect-monorepo/issues/new/choose))

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
