### PR TITLE
Fix/w3m universal provider

### DIFF
--- a/providers/universal-provider/package.json
+++ b/providers/universal-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/universal-provider",
   "description": "Universal Provider for WalletConnect Protocol",
-  "version": "2.3.2-858d3960",
+  "version": "2.3.2",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {

--- a/providers/universal-provider/package.json
+++ b/providers/universal-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/universal-provider",
   "description": "Universal Provider for WalletConnect Protocol",
-  "version": "2.3.2",
+  "version": "2.3.2-858d3960",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -345,7 +345,6 @@ export class UniversalProvider implements IUniversalProvider {
 
   private async cleanup() {
     this.session = undefined;
-    this.rpcProviders = {};
     await this.cleanupPendingPairings({ deletePairings: true });
   }
 }


### PR DESCRIPTION
# Description

Fixes issue where in some cases (wagmi) a `setDefaultChain` function needs to be called before `connect`. `setDefaultChain` call will fail if it was called after `disconnect` due to rpc object being cleaed up (which we don't need to do).

## How Has This Been Tested?
Tested within wagmi walletconnect connector.

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
