### PR TITLE
Add deeplink redirects for rpc requests

### DIFF
--- a/providers/universal-provider/package.json
+++ b/providers/universal-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/universal-provider",
   "description": "Universal Provider for WalletConnect Protocol",
-  "version": "2.3.3",
+  "version": "2.3.4-7690b8b7",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {

--- a/providers/universal-provider/src/providers/cardano.ts
+++ b/providers/universal-provider/src/providers/cardano.ts
@@ -10,7 +10,8 @@ import {
   SessionNamespace,
   SubProviderOpts,
 } from "../types";
-import { getRpcUrl } from "../utils";
+import { getRpcUrl, deeplinkRedirect } from "../utils";
+import { RELAYER_EVENTS } from "@walletconnect/core";
 
 class CardanoProvider implements IProvider {
   public name = "cip34";
@@ -70,6 +71,7 @@ class CardanoProvider implements IProvider {
 
   public request<T = unknown>(args: RequestParams): Promise<T> {
     if (this.namespace.methods.includes(args.request.method)) {
+      this.client.core.relayer.once(RELAYER_EVENTS.publish, deeplinkRedirect);
       return this.client.request(args as EngineTypes.RequestParams);
     }
     return this.getHttpProvider().request(args.request);

--- a/providers/universal-provider/src/providers/cosmos.ts
+++ b/providers/universal-provider/src/providers/cosmos.ts
@@ -10,7 +10,8 @@ import {
   SessionNamespace,
   SubProviderOpts,
 } from "../types";
-import { getRpcUrl } from "../utils";
+import { getRpcUrl, deeplinkRedirect } from "../utils";
+import { RELAYER_EVENTS } from "@walletconnect/core";
 
 class CosmosProvider implements IProvider {
   public name = "cosmos";
@@ -70,6 +71,7 @@ class CosmosProvider implements IProvider {
 
   public request<T = unknown>(args: RequestParams): Promise<T> {
     if (this.namespace.methods.includes(args.request.method)) {
+      this.client.core.relayer.once(RELAYER_EVENTS.publish, deeplinkRedirect);
       return this.client.request(args as EngineTypes.RequestParams);
     }
     return this.getHttpProvider().request(args.request);

--- a/providers/universal-provider/src/providers/eip155.ts
+++ b/providers/universal-provider/src/providers/eip155.ts
@@ -11,8 +11,9 @@ import {
   SessionNamespace,
 } from "../types";
 
-import { getRpcUrl } from "../utils";
+import { getRpcUrl, deeplinkRedirect } from "../utils";
 import EventEmitter from "events";
+import { RELAYER_EVENTS } from "@walletconnect/core";
 
 class Eip155Provider implements IProvider {
   public name = "eip155";
@@ -48,6 +49,7 @@ class Eip155Provider implements IProvider {
         break;
     }
     if (this.namespace.methods.includes(args.request.method)) {
+      this.client.core.relayer.once(RELAYER_EVENTS.publish, deeplinkRedirect);
       return await this.client.request(args as EngineTypes.RequestParams);
     }
     return this.getHttpProvider().request(args.request);

--- a/providers/universal-provider/src/providers/solana.ts
+++ b/providers/universal-provider/src/providers/solana.ts
@@ -10,7 +10,8 @@ import {
   SessionNamespace,
   SubProviderOpts,
 } from "../types";
-import { getRpcUrl } from "../utils";
+import { getRpcUrl, deeplinkRedirect } from "../utils";
+import { RELAYER_EVENTS } from "@walletconnect/core";
 
 class SolanaProvider implements IProvider {
   public name = "solana";
@@ -70,6 +71,7 @@ class SolanaProvider implements IProvider {
 
   public request<T = unknown>(args: RequestParams): Promise<T> {
     if (this.namespace.methods.includes(args.request.method)) {
+      this.client.core.relayer.once(RELAYER_EVENTS.publish, deeplinkRedirect);
       return this.client.request(args as EngineTypes.RequestParams);
     }
     return this.getHttpProvider().request(args.request);

--- a/providers/universal-provider/src/utils/misc.ts
+++ b/providers/universal-provider/src/utils/misc.ts
@@ -16,3 +16,19 @@ export function getRpcUrl(chainId: string, rpc: Namespace): string | undefined {
 export function getChainId(chains: string[]): number {
   return Number(chains[0].split(":")[1]);
 }
+
+export function deeplinkRedirect() {
+  if (typeof window !== "undefined") {
+    try {
+      const item = window.localStorage.getItem("WALLETCONNECT_DEEPLINK_CHOICE");
+      if (item) {
+        const json = JSON.parse(item);
+        window.open(json.href, "_self", "noreferrer noopener");
+      }
+    } catch (err) {
+      // Silent error, just log in console
+      // eslint-disable-next-line no-console
+      console.error(err);
+    }
+  }
+}


### PR DESCRIPTION
# Description

Client side libraries like web3modal / rainbowkit and connectkit set localstorage entry with deeplink or universal href for connected mobile wallets. We need to redirect to these during rpc requests (if such entry exists in localStorage)

## How Has This Been Tested?

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
