### PR TITLE
fix: allow `showQrModal` to be `false`

### DIFF
--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -283,7 +283,7 @@ export class EthereumProvider implements IEthereumProvider {
       methods: opts?.methods || signerMethods,
       events: opts?.events || signerEvents,
       rpcMap: opts?.rpcMap || this.buildRpcMap(opts.chains, opts.projectId),
-      showQrModal: opts?.showQrModal || true,
+      showQrModal: opts?.showQrModal ?? true,
       projectId: opts.projectId,
       metadata: opts.metadata,
     };


### PR DESCRIPTION
# Description

If `showQrModal` was set to `false`, it would be overwritten to `true`. It is now possible to set it to `false` and the setting remain.

## How Has This Been Tested?

Calling `EthereumProvider.init` with a `showQrModal` value returns `rpc.showQrModal` as specified.

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
