### PR TITLE
fix(utils): ensures matching units in `isExpired`, adds tests for expiry calcs

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -210,16 +210,6 @@ export function capitalize(str: string) {
     .join(EMPTY_SPACE);
 }
 
-// -- time ------------------------------------------------- //
-
-export function calcExpiry(ttl: number, now?: number): number {
-  return fromMiliseconds((now || Date.now()) + toMiliseconds(ttl));
-}
-
-export function isExpired(expiry: number) {
-  return fromMiliseconds(Date.now()) >= toMiliseconds(expiry);
-}
-
 // -- promises --------------------------------------------- //
 export function createDelayedPromise<T>(expiry?: number | undefined) {
   const timeout = toMiliseconds(expiry || FIVE_MINUTES);
@@ -298,6 +288,14 @@ export function parseExpirerTarget(target: string) {
   }
 
   return parsed;
+}
+
+export function calcExpiry(ttl: number, now?: number): number {
+  return fromMiliseconds((now || Date.now()) + toMiliseconds(ttl));
+}
+
+export function isExpired(expiry: number) {
+  return Date.now() >= toMiliseconds(expiry);
 }
 
 // -- events ---------------------------------------------- //


### PR DESCRIPTION
# Description

* Fixes unit conversion bug in `isExpiry`
* Sets up sub-suite in `misc.spec.ts` for expiry-related utils.
* Minor cleanup

## How Has This Been Tested?

- Unit tests, by adding failing test first and validating the fix by seeing it pass.

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
