### PR TITLE
fix: avoid expirer events when connection is down

### DIFF
--- a/packages/core/src/controllers/expirer.ts
+++ b/packages/core/src/controllers/expirer.ts
@@ -187,6 +187,8 @@ export class Expirer extends IExpirer {
   }
 
   private checkExpirations(): void {
+    // avoid auto expiring if the relayer is not connected
+    if (!this.core.relayer.connected) return;
     this.expirations.forEach((expiration, target) => this.checkExpiry(target, expiration));
   }
 


### PR DESCRIPTION
# Description

Another case of `subscriber. not initialized` issue happens when the expirer tries to unsubscribe a topic when the socket is down due to explicit `transportClose` or random connection drops. On the next tick, the subscriber will check again the network status emit only when the connection is enabled.


## How Has This Been Tested?
dogfooding
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
