### PR TITLE
chore: use pino from logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25378,7 +25378,6 @@
         "@walletconnect/utils": "2.4.0",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
-        "pino": "7.11.0",
         "uint8arrays": "3.1.0"
       },
       "devDependencies": {
@@ -25412,8 +25411,7 @@
         "@walletconnect/time": "^1.0.2",
         "@walletconnect/types": "2.4.0",
         "@walletconnect/utils": "2.4.0",
-        "events": "^3.3.0",
-        "pino": "7.11.0"
+        "events": "^3.3.0"
       },
       "devDependencies": {
         "@walletconnect/jsonrpc-ws-connection": "^1.0.7",
@@ -25500,64 +25498,6 @@
         "ethers": "5.6.9",
         "uint8arrays": "3.1.0",
         "web3": "1.7.5"
-      }
-    },
-    "providers/ethereum-provider/node_modules/@walletconnect/core": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.3.3.tgz",
-      "integrity": "sha512-pkPG3f0Mb9WcWMeLtRS8+RSV9gpnAGrU0y291LNXjggDupg5H7I1hFtcj5HI0kmpk4suAS4RKqYAxPzy4MgFRQ==",
-      "dependencies": {
-        "@walletconnect/heartbeat": "1.2.0",
-        "@walletconnect/jsonrpc-provider": "^1.0.6",
-        "@walletconnect/jsonrpc-utils": "^1.0.4",
-        "@walletconnect/jsonrpc-ws-connection": "^1.0.6",
-        "@walletconnect/keyvaluestorage": "^1.0.2",
-        "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/relay-api": "^1.0.7",
-        "@walletconnect/relay-auth": "^1.0.4",
-        "@walletconnect/safe-json": "^1.0.1",
-        "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.3.3",
-        "@walletconnect/utils": "2.3.3",
-        "events": "^3.3.0",
-        "lodash.isequal": "4.5.0",
-        "pino": "7.11.0",
-        "uint8arrays": "3.1.0"
-      }
-    },
-    "providers/ethereum-provider/node_modules/@walletconnect/core/node_modules/@walletconnect/types": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.3.3.tgz",
-      "integrity": "sha512-g2x27MloGElcRTwYM9Md/1E2RQ5ifYBCFZ/sfnpQrZPVxK3NzSMHJlcV6qrQm9ST82i+UrLEce9RkDgvjKk7+w==",
-      "dependencies": {
-        "@walletconnect/events": "^1.0.1",
-        "@walletconnect/heartbeat": "1.2.0",
-        "@walletconnect/jsonrpc-types": "^1.0.2",
-        "@walletconnect/keyvaluestorage": "^1.0.2",
-        "@walletconnect/logger": "^2.0.1",
-        "events": "^3.3.0"
-      }
-    },
-    "providers/ethereum-provider/node_modules/@walletconnect/core/node_modules/@walletconnect/utils": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.3.3.tgz",
-      "integrity": "sha512-wS9ptLlT30c7m7zme3/y3cNjKXztZeKIulqBD1K/VxSxWEA4mK9mmXEACdmahjiX4EHZWtdHvEIu2rLDhkrrvQ==",
-      "dependencies": {
-        "@stablelib/chacha20poly1305": "1.0.1",
-        "@stablelib/hkdf": "1.0.1",
-        "@stablelib/random": "^1.0.2",
-        "@stablelib/sha256": "1.0.1",
-        "@stablelib/x25519": "^1.0.3",
-        "@walletconnect/jsonrpc-utils": "^1.0.4",
-        "@walletconnect/relay-api": "^1.0.7",
-        "@walletconnect/safe-json": "^1.0.1",
-        "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.3.3",
-        "@walletconnect/window-getters": "^1.0.1",
-        "@walletconnect/window-metadata": "^1.0.1",
-        "detect-browser": "5.3.0",
-        "query-string": "7.1.1",
-        "uint8arrays": "3.1.0"
       }
     },
     "providers/signer-connection": {
@@ -30368,7 +30308,6 @@
         "@walletconnect/utils": "2.4.0",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
-        "pino": "7.11.0",
         "uint8arrays": "3.1.0"
       }
     },
@@ -30401,67 +30340,6 @@
         "events": "^3.3.0",
         "uint8arrays": "3.1.0",
         "web3": "1.7.5"
-      },
-      "dependencies": {
-        "@walletconnect/core": {
-          "version": "https://registry.npmjs.org/@walletconnect/core/-/core-2.3.3.tgz",
-          "integrity": "sha512-pkPG3f0Mb9WcWMeLtRS8+RSV9gpnAGrU0y291LNXjggDupg5H7I1hFtcj5HI0kmpk4suAS4RKqYAxPzy4MgFRQ==",
-          "requires": {
-            "@walletconnect/heartbeat": "1.2.0",
-            "@walletconnect/jsonrpc-provider": "^1.0.6",
-            "@walletconnect/jsonrpc-utils": "^1.0.4",
-            "@walletconnect/jsonrpc-ws-connection": "^1.0.6",
-            "@walletconnect/keyvaluestorage": "^1.0.2",
-            "@walletconnect/logger": "^2.0.1",
-            "@walletconnect/relay-api": "^1.0.7",
-            "@walletconnect/relay-auth": "^1.0.4",
-            "@walletconnect/safe-json": "^1.0.1",
-            "@walletconnect/time": "^1.0.2",
-            "@walletconnect/types": "2.3.3",
-            "@walletconnect/utils": "2.3.3",
-            "events": "^3.3.0",
-            "lodash.isequal": "4.5.0",
-            "pino": "7.11.0",
-            "uint8arrays": "3.1.0"
-          },
-          "dependencies": {
-            "@walletconnect/types": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.3.3.tgz",
-              "integrity": "sha512-g2x27MloGElcRTwYM9Md/1E2RQ5ifYBCFZ/sfnpQrZPVxK3NzSMHJlcV6qrQm9ST82i+UrLEce9RkDgvjKk7+w==",
-              "requires": {
-                "@walletconnect/events": "^1.0.1",
-                "@walletconnect/heartbeat": "1.2.0",
-                "@walletconnect/jsonrpc-types": "^1.0.2",
-                "@walletconnect/keyvaluestorage": "^1.0.2",
-                "@walletconnect/logger": "^2.0.1",
-                "events": "^3.3.0"
-              }
-            },
-            "@walletconnect/utils": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.3.3.tgz",
-              "integrity": "sha512-wS9ptLlT30c7m7zme3/y3cNjKXztZeKIulqBD1K/VxSxWEA4mK9mmXEACdmahjiX4EHZWtdHvEIu2rLDhkrrvQ==",
-              "requires": {
-                "@stablelib/chacha20poly1305": "1.0.1",
-                "@stablelib/hkdf": "1.0.1",
-                "@stablelib/random": "^1.0.2",
-                "@stablelib/sha256": "1.0.1",
-                "@stablelib/x25519": "^1.0.3",
-                "@walletconnect/jsonrpc-utils": "^1.0.4",
-                "@walletconnect/relay-api": "^1.0.7",
-                "@walletconnect/safe-json": "^1.0.1",
-                "@walletconnect/time": "^1.0.2",
-                "@walletconnect/types": "2.3.3",
-                "@walletconnect/window-getters": "^1.0.1",
-                "@walletconnect/window-metadata": "^1.0.1",
-                "detect-browser": "5.3.0",
-                "query-string": "7.1.1",
-                "uint8arrays": "3.1.0"
-              }
-            }
-          }
-        }
       }
     },
     "@walletconnect/events": {
@@ -30642,8 +30520,7 @@
         "@walletconnect/utils": "2.4.0",
         "aws-sdk": "2.1194.0",
         "events": "^3.3.0",
-        "lokijs": "^1.5.12",
-        "pino": "7.11.0"
+        "lokijs": "^1.5.12"
       }
     },
     "@walletconnect/signer-connection": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,7 +44,6 @@
     "@walletconnect/utils": "2.4.0",
     "events": "^3.3.0",
     "lodash.isequal": "4.5.0",
-    "pino": "7.11.0",
     "uint8arrays": "3.1.0"
   },
   "devDependencies": {

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from "events";
-import pino from "pino";
 import { JsonRpcProvider } from "@walletconnect/jsonrpc-provider";
 import {
   formatJsonRpcResult,
@@ -13,6 +12,7 @@ import {
   generateChildLogger,
   getDefaultLoggerOptions,
   getLoggerContext,
+  pino,
   Logger,
 } from "@walletconnect/logger";
 import { RelayJsonRpc } from "@walletconnect/relay-api";

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from "events";
-import pino from "pino";
 
 import KeyValueStorage from "@walletconnect/keyvaluestorage";
 import { HeartBeat } from "@walletconnect/heartbeat";
@@ -7,6 +6,7 @@ import {
   generateChildLogger,
   getDefaultLoggerOptions,
   getLoggerContext,
+  pino,
 } from "@walletconnect/logger";
 import { CoreTypes, ICore } from "@walletconnect/types";
 

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -46,8 +46,7 @@
     "@walletconnect/time": "^1.0.2",
     "@walletconnect/types": "2.4.0",
     "@walletconnect/utils": "2.4.0",
-    "events": "^3.3.0",
-    "pino": "7.11.0"
+    "events": "^3.3.0"
   },
   "devDependencies": {
     "@walletconnect/jsonrpc-ws-connection": "^1.0.7",

--- a/packages/sign-client/src/client.ts
+++ b/packages/sign-client/src/client.ts
@@ -1,9 +1,9 @@
-import pino from "pino";
 import { Core } from "@walletconnect/core";
 import {
   generateChildLogger,
   getDefaultLoggerOptions,
   getLoggerContext,
+  pino,
 } from "@walletconnect/logger";
 import { SignClientTypes, ISignClient, ISignClientEvents, EngineTypes } from "@walletconnect/types";
 import { getAppMetadata } from "@walletconnect/utils";


### PR DESCRIPTION
`@walletconnect/logger` re-exports pino here: https://github.com/WalletConnect/walletconnect-utils/blob/master/misc/logger/src/index.ts#L6

To avoid having multiple points of pino dep specification, this PR re-uses pino from the logger.

This way, a version bump in a single place would be needed to update the `pino` dep, not 3 synchronous ones.