### PR TITLE
fix: unsubscribe `transport_closed` listener

### DIFF
--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { EventEmitter } from "events";
 import pino from "pino";
 import { JsonRpcProvider } from "@walletconnect/jsonrpc-provider";


### PR DESCRIPTION
# Description
Moved `transport_closed` listener rejection in own named function so we could unsubscribe the event listener
This change fixes the possible `maxEventListeners` warnings
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?
dogfooding
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
