### PR TITLE
refactor: chainChanged in hex

### DIFF
--- a/providers/ethereum-provider/src/types.ts
+++ b/providers/ethereum-provider/src/types.ts
@@ -1,7 +1,7 @@
 import { SignClientTypes } from "@walletconnect/types";
 import EventEmitter from "events";
 
-export interface ProviderRpcError extends Error {
+export interface ProviderRpcError {
   message: string;
   code: number;
   data?: unknown;
@@ -21,7 +21,7 @@ export interface RequestArguments {
   params?: unknown[] | object;
 }
 
-export type ProviderChainId = string;
+export type ProviderChainId = ProviderInfo["chainId"];
 
 export type ProviderAccounts = string[];
 
@@ -72,6 +72,11 @@ export interface IEthereumProviderEvents extends EventEmitter {
   removeListener: <E extends IProviderEvents.Event>(
     event: E,
     listener: (args: IProviderEvents.EventArguments[E]) => any,
+  ) => any;
+
+  emit: <E extends IProviderEvents.Event>(
+    event: E,
+    payload: IProviderEvents.EventArguments[E],
   ) => any;
 }
 

--- a/providers/ethereum-provider/test/index.spec.ts
+++ b/providers/ethereum-provider/test/index.spec.ts
@@ -74,9 +74,9 @@ describe("EthereumProvider", function () {
       }),
 
       new Promise<void>((resolve, reject) => {
-        provider.on("chainChanged", (chainId: number) => {
+        provider.on("chainChanged", (chainId) => {
           try {
-            expect(chainId).to.eql(42);
+            expect(parseInt(chainId, 16)).to.eql(42);
             resolve();
           } catch (e) {
             reject(e);
@@ -96,9 +96,9 @@ describe("EthereumProvider", function () {
       }),
 
       new Promise<void>((resolve, reject) => {
-        provider.on("chainChanged", (chainId: number) => {
+        provider.on("chainChanged", (chainId) => {
           try {
-            expect(chainId).to.eql(CHAIN_ID);
+            expect(parseInt(chainId, 16)).to.eql(CHAIN_ID);
             resolve();
           } catch (e) {
             reject(e);
@@ -143,7 +143,7 @@ describe("EthereumProvider", function () {
       }),
 
       new Promise<void>((resolve, reject) => {
-        provider.on("accountsChanged", (accounts: string) => {
+        provider.on("accountsChanged", (accounts) => {
           try {
             expect(accounts[0]).to.eql(ACCOUNTS.a.address);
             resolve();


### PR DESCRIPTION
# Description
Updated `ethereum-provider` to emit `chainChanged` in hex instead of integer to be 1193 compliant.
Also mapped emit to proper event types
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?
integration tests
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
