### PR TITLE
fix: removes pairing delete response

### DIFF
--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -314,8 +314,6 @@ export class Pairing implements IPairing {
     const { id } = payload;
     try {
       this.isValidDisconnect({ topic });
-      // RPC request needs to happen before deletion as it utilises pairing encryption
-      await this.sendResult<"wc_pairingDelete">(id, topic, true);
       await this.deletePairing(topic);
       this.events.emit("pairing_delete", { id, topic });
     } catch (err: any) {


### PR DESCRIPTION
# Description
Small bug where Pairing API is responding to `wc_pairingDelete` but there is no handler for that response thus resulting `method unsupported` exception. To align with the session delete flow, I've removed the response

## How Has This Been Tested?
dogfooding
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
