### PR TITLE
fix: pass dapp metadata to UniversalProvider

### DIFF
--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -446,7 +446,7 @@ export class EthereumProvider implements IEthereumProvider {
   private async initialize(opts: EthereumProviderOptions) {
     this.rpc = this.getRpcConfig(opts);
     this.chainId = getEthereumChainId(this.rpc.chains);
-    this.signer = await UniversalProvider.init({ projectId: this.rpc.projectId });
+    this.signer = await UniversalProvider.init({ projectId: this.rpc.projectId, metadata: opts.metadata });
     this.registerEventListeners();
     await this.loadPersistedSession();
     if (this.rpc.showQrModal) {

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -446,7 +446,7 @@ export class EthereumProvider implements IEthereumProvider {
   private async initialize(opts: EthereumProviderOptions) {
     this.rpc = this.getRpcConfig(opts);
     this.chainId = getEthereumChainId(this.rpc.chains);
-    this.signer = await UniversalProvider.init({ projectId: this.rpc.projectId, metadata: opts.metadata });
+    this.signer = await UniversalProvider.init({ projectId: this.rpc.projectId, metadata: this.rpc.metadata });
     this.registerEventListeners();
     await this.loadPersistedSession();
     if (this.rpc.showQrModal) {


### PR DESCRIPTION
# Description
We need to pass the dapp metadata to the UniversalProvider. In React Native, we'd like to be able to show the dapp's name and url. Also, some wallets do not work without a name and url when connecting to them (namely: TrustWallet)

Resolves #2028

## How Has This Been Tested?
Used the new version in a small RN app to verify dapp metadata was being correctly pass through to the Universal Provider

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
