### PR TITLE
fix: `ProviderRpcError` type to extend `Error`

### DIFF
--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -354,6 +354,7 @@ export class EthereumProvider implements IEthereumProvider {
         this.events.emit("disconnect", {
           ...getSdkError("USER_DISCONNECTED"),
           data: payload.topic,
+          name: "USER_DISCONNECTED",
         });
       },
     );
@@ -446,7 +447,10 @@ export class EthereumProvider implements IEthereumProvider {
   private async initialize(opts: EthereumProviderOptions) {
     this.rpc = this.getRpcConfig(opts);
     this.chainId = getEthereumChainId(this.rpc.chains);
-    this.signer = await UniversalProvider.init({ projectId: this.rpc.projectId, metadata: this.rpc.metadata });
+    this.signer = await UniversalProvider.init({
+      projectId: this.rpc.projectId,
+      metadata: this.rpc.metadata,
+    });
     this.registerEventListeners();
     await this.loadPersistedSession();
     if (this.rpc.showQrModal) {

--- a/providers/ethereum-provider/src/types.ts
+++ b/providers/ethereum-provider/src/types.ts
@@ -1,7 +1,7 @@
 import { SignClientTypes } from "@walletconnect/types";
 import EventEmitter from "events";
 
-export interface ProviderRpcError {
+export interface ProviderRpcError extends Error {
   message: string;
   code: number;
   data?: unknown;


### PR DESCRIPTION
# Description
`ProviderRpcError` type to extend `Error` as per spec https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md#rpc-errors
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
