### PR TITLE
feat: pending proposal expiry

### DIFF
--- a/packages/sign-client/src/constants/proposal.ts
+++ b/packages/sign-client/src/constants/proposal.ts
@@ -3,3 +3,5 @@ import { THIRTY_DAYS } from "@walletconnect/time";
 export const PROPOSAL_CONTEXT = "proposal";
 
 export const PROPOSAL_EXPIRY = THIRTY_DAYS;
+
+export const PROPOSAL_EXPIRY_MESSAGE = "Proposal expired";

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -58,6 +58,7 @@ import {
   ENGINE_CONTEXT,
   ENGINE_RPC_OPTS,
   SESSION_REQUEST_EXPIRY_BOUNDARIES,
+  PROPOSAL_EXPIRY_MESSAGE,
 } from "../constants";
 
 export class Engine extends IEngine {
@@ -120,7 +121,11 @@ export class Engine extends IEngine {
       },
       ...(sessionProperties && { sessionProperties }),
     };
-    const { reject, resolve, done: approval } = createDelayedPromise<SessionTypes.Struct>();
+    const {
+      reject,
+      resolve,
+      done: approval,
+    } = createDelayedPromise<SessionTypes.Struct>(FIVE_MINUTES, PROPOSAL_EXPIRY_MESSAGE);
     this.events.once<"session_connect">(
       engineEvent("session_connect"),
       async ({ error, session }) => {

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -211,7 +211,10 @@ export function capitalize(str: string) {
 }
 
 // -- promises --------------------------------------------- //
-export function createDelayedPromise<T>(expiry?: number | undefined) {
+export function createDelayedPromise<T>(
+  expiry: number = FIVE_MINUTES,
+  expireErrorMessage?: string,
+) {
   const timeout = toMiliseconds(expiry || FIVE_MINUTES);
   let cacheResolve: undefined | ((value: T | PromiseLike<T>) => void);
   let cacheReject: undefined | ((value?: ErrorResponse) => void);
@@ -219,7 +222,9 @@ export function createDelayedPromise<T>(expiry?: number | undefined) {
 
   const done = () =>
     new Promise<T>((promiseResolve, promiseReject) => {
-      cacheTimeout = setTimeout(promiseReject, timeout);
+      cacheTimeout = setTimeout(() => {
+        promiseReject(new Error(expireErrorMessage));
+      }, timeout);
       cacheResolve = promiseResolve;
       cacheReject = promiseReject;
     });

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -247,8 +247,10 @@ export class EthereumProvider implements IEthereumProvider {
           if (this.rpc.showQrModal) {
             this.modal?.subscribeModal((state) => {
               // the modal was closed so reject the promise
-              if (!state.open && !this.signer.session)
+              if (!state.open && !this.signer.session) {
+                this.signer.abortPairingAttempt();
                 reject(new Error("Connection request reset. Please try again."));
+              }
             });
           }
           await this.signer
@@ -361,6 +363,9 @@ export class EthereumProvider implements IEthereumProvider {
 
     this.signer.on("display_uri", (uri: string) => {
       if (this.rpc.showQrModal) {
+        // to refresh the QR we have to close the modal and open it again
+        // untill proper API is provided by web3modal
+        this.modal?.closeModal();
         this.modal?.openModal({ uri });
       }
       this.events.emit("display_uri", uri);

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -364,7 +364,7 @@ export class EthereumProvider implements IEthereumProvider {
     this.signer.on("display_uri", (uri: string) => {
       if (this.rpc.showQrModal) {
         // to refresh the QR we have to close the modal and open it again
-        // untill proper API is provided by web3modal
+        // until proper API is provided by web3modal
         this.modal?.closeModal();
         this.modal?.openModal({ uri });
       }

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -1,5 +1,5 @@
 import pino from "pino";
-import SignClient from "@walletconnect/sign-client";
+import SignClient, { PROPOSAL_EXPIRY_MESSAGE } from "@walletconnect/sign-client";
 import { ProviderAccounts } from "eip1193-provider";
 import { SessionTypes } from "@walletconnect/types";
 import { getSdkError, isValidArray } from "@walletconnect/utils";
@@ -167,7 +167,7 @@ export class UniversalProvider implements IUniversalProvider {
           this.session = session;
         })
         .catch((error) => {
-          if (error.message !== "Proposal expired") {
+          if (error.message !== PROPOSAL_EXPIRY_MESSAGE) {
             throw error;
           }
           pairingAttempts++;

--- a/providers/universal-provider/src/types/providers.ts
+++ b/providers/universal-provider/src/types/providers.ts
@@ -41,4 +41,5 @@ export interface IUniversalProvider extends IEthereumProvider {
   connect: (opts: ConnectParams) => Promise<SessionTypes.Struct | undefined>;
   disconnect: () => void;
   cleanupPendingPairings: () => Promise<void>;
+  abortPairingAttempt(): void;
 }


### PR DESCRIPTION
# Description
PR to address behavior when pairing is not scanned within 5 mins expiry. 

- in `sign-client`  throw an error in `delayedPromise` with an appropriate message which resolves `unhandled undefined`.

- In `universal-provider` a retry mechanism is implemented that generates new pairing if the previous one expires with a `10` retries limit.

- In `ethereum-provider` the web3modal is refreshed when the URI is received

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves # ([browse](https://github.com/WalletConnect/walletconnect-monorepo/issues) or [create](https://github.com/WalletConnect/walletconnect-monorepo/issues/new/choose))

## How Has This Been Tested?
dogfooding
covered by existing integration tests
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
