### PR TITLE
fix: validate pairing uri

### DIFF
--- a/packages/core/test/pairing.spec.ts
+++ b/packages/core/test/pairing.spec.ts
@@ -175,6 +175,25 @@ describe("Pairing", () => {
           "Missing or invalid. pair() uri: undefined",
         );
       });
+
+      it("throws when invalid pairing topic is provided", async () => {
+        let { topic, uri } = await coreA.pairing.create();
+        const maliciousTopic = "maliciousTopic";
+        uri = uri.replace(topic, maliciousTopic);
+        await expect(coreA.pairing.pair({ uri })).rejects.toThrowError(
+          `Invalid topic: ${maliciousTopic}`,
+        );
+      });
+
+      it("throws when invalid symKey is provided", async () => {
+        let { uri } = await coreA.pairing.create();
+        const symKey = uri.split("symKey=")[1];
+        const maliciousSymKey = "maliciousSymKey";
+        uri = uri.replace(symKey, maliciousSymKey);
+        await expect(coreA.pairing.pair({ uri })).rejects.toThrowError(
+          `Invalid symKey: ${maliciousSymKey}`,
+        );
+      });
     });
 
     describe("ping", () => {

--- a/packages/utils/test/uri.spec.ts
+++ b/packages/utils/test/uri.spec.ts
@@ -1,13 +1,16 @@
 import { EngineTypes } from "@walletconnect/types";
 import { expect, describe, it } from "vitest";
-import { formatUri, parseUri } from "../src";
+import { formatUri, generateRandomBytes32, hashKey, parseUri } from "../src";
 import { TEST_PAIRING_TOPIC, TEST_RELAY_OPTIONS, TEST_SYM_KEY } from "./shared";
+
+const symKey = generateRandomBytes32();
+const topic = hashKey(symKey);
 
 const TEST_URI_PARAMS: EngineTypes.UriParameters = {
   protocol: "wc",
   version: 2,
-  topic: TEST_PAIRING_TOPIC,
-  symKey: TEST_SYM_KEY,
+  topic,
+  symKey,
   relay: TEST_RELAY_OPTIONS,
 };
 


### PR DESCRIPTION
# Description

Added additional validation for `topic` & `symKey` params provided in pairing URI as per https://walletconnect.slack.com/archives/C04R47PC821/p1677276608096529 

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?

* integration tests
* Dogfooding via canary `2.4.6-956e5f87`

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
