### PR TITLE
fix: ethereum-provider `on` return type

### DIFF
--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -185,7 +185,7 @@ export interface EthereumProviderOptions {
 }
 
 export class EthereumProvider implements IEthereumProvider {
-  public events: IEthereumProviderEvents = new EventEmitter();
+  public events = new EventEmitter();
   public namespace = "eip155";
   public accounts: string[] = [];
   public signer: InstanceType<typeof UniversalProvider>;
@@ -295,19 +295,23 @@ export class EthereumProvider implements IEthereumProvider {
   }
 
   public on: IEthereumProviderEvents["on"] = (event, listener) => {
-    return this.events.on(event, listener);
+    this.events.on(event, listener);
+    return this;
   };
 
   public once: IEthereumProviderEvents["once"] = (event, listener) => {
-    return this.events.once(event, listener);
+    this.events.once(event, listener);
+    return this;
   };
 
   public removeListener: IEthereumProviderEvents["removeListener"] = (event, listener) => {
-    return this.events.removeListener(event, listener);
+    this.events.removeListener(event, listener);
+    return this;
   };
 
   public off: IEthereumProviderEvents["off"] = (event, listener) => {
-    return this.events.off(event, listener);
+    this.events.off(event, listener);
+    return this;
   };
 
   get isWalletConnect() {

--- a/providers/ethereum-provider/src/types.ts
+++ b/providers/ethereum-provider/src/types.ts
@@ -1,5 +1,5 @@
 import { SignClientTypes } from "@walletconnect/types";
-import EventEmitter from "events";
+import EthereumProvider from "./EthereumProvider";
 
 export interface ProviderRpcError extends Error {
   message: string;
@@ -53,44 +53,44 @@ export declare namespace IProviderEvents {
     display_uri: string;
   }
 }
-export interface IEthereumProviderEvents extends EventEmitter {
+export interface IEthereumProviderEvents {
   on: <E extends IProviderEvents.Event>(
     event: E,
-    listener: (args: IProviderEvents.EventArguments[E]) => any,
-  ) => any;
+    listener: (args: IProviderEvents.EventArguments[E]) => void,
+  ) => EthereumProvider;
 
   once: <E extends IProviderEvents.Event>(
     event: E,
     listener: (args: IProviderEvents.EventArguments[E]) => any,
-  ) => any;
+  ) => EthereumProvider;
 
   off: <E extends IProviderEvents.Event>(
     event: E,
     listener: (args: IProviderEvents.EventArguments[E]) => any,
-  ) => any;
+  ) => EthereumProvider;
 
   removeListener: <E extends IProviderEvents.Event>(
     event: E,
-    listener: (args: IProviderEvents.EventArguments[E]) => any,
-  ) => any;
+    listener: (args: IProviderEvents.EventArguments[E]) => void,
+  ) => EthereumProvider;
 
   emit: <E extends IProviderEvents.Event>(
     event: E,
     payload: IProviderEvents.EventArguments[E],
-  ) => any;
+  ) => boolean;
 }
 
 export interface EIP1193Provider {
   // connection event
-  on(event: "connect", listener: (info: ProviderInfo) => void): this;
+  on(event: "connect", listener: (info: ProviderInfo) => void): EthereumProvider;
   // disconnection event
-  on(event: "disconnect", listener: (error: ProviderRpcError) => void): this;
+  on(event: "disconnect", listener: (error: ProviderRpcError) => void): EthereumProvider;
   // arbitrary messages
-  on(event: "message", listener: (message: ProviderMessage) => void): this;
+  on(event: "message", listener: (message: ProviderMessage) => void): EthereumProvider;
   // chain changed event
-  on(event: "chainChanged", listener: (chainId: ProviderChainId) => void): this;
+  on(event: "chainChanged", listener: (chainId: ProviderChainId) => void): EthereumProvider;
   // accounts changed event
-  on(event: "accountsChanged", listener: (accounts: ProviderAccounts) => void): this;
+  on(event: "accountsChanged", listener: (accounts: ProviderAccounts) => void): EthereumProvider;
   // make an Ethereum RPC method call.
   request(args: RequestArguments): Promise<unknown>;
 }

--- a/providers/ethereum-provider/src/types.ts
+++ b/providers/ethereum-provider/src/types.ts
@@ -1,5 +1,5 @@
 import { SignClientTypes } from "@walletconnect/types";
-import EthereumProvider from "./EthereumProvider";
+import { EthereumProvider } from "./EthereumProvider";
 
 export interface ProviderRpcError extends Error {
   message: string;
@@ -61,12 +61,12 @@ export interface IEthereumProviderEvents {
 
   once: <E extends IProviderEvents.Event>(
     event: E,
-    listener: (args: IProviderEvents.EventArguments[E]) => any,
+    listener: (args: IProviderEvents.EventArguments[E]) => void,
   ) => EthereumProvider;
 
   off: <E extends IProviderEvents.Event>(
     event: E,
-    listener: (args: IProviderEvents.EventArguments[E]) => any,
+    listener: (args: IProviderEvents.EventArguments[E]) => void,
   ) => EthereumProvider;
 
   removeListener: <E extends IProviderEvents.Event>(


### PR DESCRIPTION
# Description
Updated the return type of `on/off/once/removeListener` to `EthereumProvider` as per the spec https://eips.ethereum.org/EIPS/eip-1193#connect-1
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?
dogfooding
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
