### PR TITLE
fix: namespace validation

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -944,7 +944,6 @@ export class Engine extends IEngine {
       proposal.requiredNamespaces,
       namespaces,
       "approve()",
-      "requiredNamespaces",
     );
     if (conformingNamespacesError) throw new Error(conformingNamespacesError.message);
     if (!isValidString(relayProtocol, true)) {
@@ -953,28 +952,6 @@ export class Engine extends IEngine {
         `approve() relayProtocol: ${relayProtocol}`,
       );
       throw new Error(message);
-    }
-
-    // if the length of the namespaces is greater than the length of the required namespaces
-    // then the user is trying to approve part or all of the optional namespaces so we need to validate
-    if (Object.keys(namespaces).length > Object.keys(proposal.requiredNamespaces).length) {
-      // filter out the optional namespaces that are not being used
-      const namespacesToValidate = Object.keys(proposal.optionalNamespaces).filter(
-        (namespace) => namespaces[namespace],
-      );
-      const usedOptionalNamespaces = {};
-      for (const key in proposal.optionalNamespaces) {
-        if (namespacesToValidate.includes(key)) {
-          usedOptionalNamespaces[key] = proposal.optionalNamespaces[key];
-        }
-      }
-      const conformingNamespacesError = isConformingNamespaces(
-        usedOptionalNamespaces,
-        namespaces,
-        "approve()",
-        "optionalNamespaces",
-      );
-      if (conformingNamespacesError) throw new Error(conformingNamespacesError.message);
     }
 
     if (!isUndefined(sessionProperties)) {
@@ -1038,7 +1015,6 @@ export class Engine extends IEngine {
       session.requiredNamespaces,
       namespaces,
       "update()",
-      "requiredNamespaces",
     );
     if (conformingNamespacesError) throw new Error(conformingNamespacesError.message);
     // TODO(ilja) - check if wallet

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -16,6 +16,7 @@ import {
   TEST_REQUEST_PARAMS_OPTIONAL_NAMESPACE,
   TEST_AVALANCHE_CHAIN,
   TEST_REQUIRED_NAMESPACES_V2,
+  TEST_NAMESPACES_V2,
 } from "../shared";
 
 describe("Sign Client Integration", () => {
@@ -284,7 +285,10 @@ describe("Sign Client Integration", () => {
       const clients = await initTwoClients();
       const {
         sessionA: { topic },
-      } = await testConnectMethod(clients, { requiredNamespaces: TEST_REQUIRED_NAMESPACES_V2 });
+      } = await testConnectMethod(clients, {
+        requiredNamespaces: TEST_REQUIRED_NAMESPACES_V2,
+        namespaces: TEST_NAMESPACES_V2,
+      });
       const testRequestProps = {
         ...TEST_REQUEST_PARAMS,
         chainId: TEST_AVALANCHE_CHAIN,
@@ -295,7 +299,11 @@ describe("Sign Client Integration", () => {
             const { params } = payload;
             const session = clients.B.session.get(payload.topic);
             expect(params).toMatchObject(testRequestProps);
-            expect(session.namespaces[TEST_AVALANCHE_CHAIN]).to.exist;
+            expect(
+              session.namespaces.eip155.accounts.filter((acc) =>
+                acc.includes(TEST_AVALANCHE_CHAIN),
+              ),
+            ).to.exist;
             expect(session.requiredNamespaces[TEST_AVALANCHE_CHAIN]).to.exist;
             resolve();
           });

--- a/packages/sign-client/test/sdk/validation.spec.ts
+++ b/packages/sign-client/test/sdk/validation.spec.ts
@@ -327,7 +327,9 @@ describe("Sign Client Validation", () => {
           namespaces: TEST_NAMESPACES_INVALID_CHAIN,
         }),
       ).rejects.toThrowError(
-        "Non conforming namespaces. update() namespaces keys don't satisfy requiredNamespaces",
+        `Non conforming namespaces. update() namespaces keys don't satisfy requiredNamespaces.
+      Required: eip155
+      Received: eip1111`,
       );
     });
   });

--- a/packages/sign-client/test/shared/values.ts
+++ b/packages/sign-client/test/shared/values.ts
@@ -148,15 +148,18 @@ export const TEST_NAMESPACES = {
     accounts: TEST_ACCOUNTS,
     events: TEST_EVENTS,
   },
-  [TEST_AVALANCHE_CHAIN]: {
-    methods: TEST_METHODS,
-    accounts: [TEST_AVALANCHE_ACCOUNT],
-    events: TEST_EVENTS,
-  },
   polkadot: {
     chains: TEST_POLKADOT_CHAINS,
     methods: TEST_POLKADOT_METHODS,
     accounts: TEST_POLKADOT_ACCOUNTS,
+    events: TEST_EVENTS,
+  },
+};
+
+export const TEST_NAMESPACES_V2 = {
+  eip155: {
+    methods: TEST_METHODS,
+    accounts: [TEST_ETHEREUM_ACCOUNT, TEST_AVALANCHE_ACCOUNT, TEST_ARBITRUM_ACCOUNT],
     events: TEST_EVENTS,
   },
 };

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -378,8 +378,10 @@ export function isConformingNamespaces(
   const requiredChains = Object.keys(parsedRequired);
   const approvedChains = Object.keys(parsedApproved);
 
-  const missingRequiredNamespaces = Object.keys(requiredNamespaces).filter(
-    (namespace) => !Object.keys(namespaces).includes(namespace),
+  const uniqueRequired = filterDuplicateNamespaces(Object.keys(requiredNamespaces));
+  const uniqueApproved = filterDuplicateNamespaces(Object.keys(namespaces));
+  const missingRequiredNamespaces = uniqueRequired.filter(
+    (namespace) => !uniqueApproved.includes(namespace),
   );
 
   if (missingRequiredNamespaces.length) {
@@ -436,6 +438,16 @@ function parseNamespaces(namespaces: ProposalTypes.RequiredNamespaces) {
     }
   });
   return parsed;
+}
+
+function filterDuplicateNamespaces(namespaces: string[]) {
+  return [
+    ...new Set(
+      namespaces.map((namespace) =>
+        namespace.includes(":") ? namespace.split(":")[0] : namespace,
+      ),
+    ),
+  ];
 }
 
 function parseApprovedNamespaces(namespaces: SessionTypes.Namespaces) {

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -370,43 +370,94 @@ export function isConformingNamespaces(
   requiredNamespaces: ProposalTypes.RequiredNamespaces,
   namespaces: SessionTypes.Namespaces,
   context: string,
-  type: string,
 ) {
   let error: ErrorObject = null;
-  const requiredNamespaceKeys = Object.keys(requiredNamespaces);
-  const namespaceKeys = Object.keys(namespaces);
 
-  if (!hasOverlap(requiredNamespaceKeys, namespaceKeys)) {
+  const parsedRequired = parseNamespaces(requiredNamespaces);
+  const parsedApproved = parseApprovedNamespaces(namespaces);
+  const requiredChains = Object.keys(parsedRequired);
+  const approvedChains = Object.keys(parsedApproved);
+
+  const missingRequiredNamespaces = Object.keys(requiredNamespaces).filter(
+    (namespace) => !Object.keys(namespaces).includes(namespace),
+  );
+
+  if (missingRequiredNamespaces.length) {
     error = getInternalError(
       "NON_CONFORMING_NAMESPACES",
-      `${context} namespaces keys don't satisfy ${type}`,
+      `${context} namespaces keys don't satisfy requiredNamespaces.
+      Required: ${missingRequiredNamespaces.toString()}
+      Received: ${Object.keys(namespaces).toString()}`,
     );
-  } else {
-    requiredNamespaceKeys.forEach((key) => {
-      if (error) return;
-
-      const namespaceChains = getAccountsChains(namespaces[key].accounts);
-
-      if (!hasOverlap(getChainsFromNamespace(key, requiredNamespaces[key]), namespaceChains)) {
-        error = getInternalError(
-          "NON_CONFORMING_NAMESPACES",
-          `${context} namespaces accounts don't satisfy namespace chains for ${key}`,
-        );
-      } else if (!hasOverlap(requiredNamespaces[key].methods, namespaces[key].methods)) {
-        error = getInternalError(
-          "NON_CONFORMING_NAMESPACES",
-          `${context} namespaces methods don't satisfy namespace methods for ${key}`,
-        );
-      } else if (!hasOverlap(requiredNamespaces[key].events, namespaces[key].events)) {
-        error = getInternalError(
-          "NON_CONFORMING_NAMESPACES",
-          `${context} namespaces events don't satisfy namespace events for ${key}`,
-        );
-      }
-    });
   }
 
+  if (!hasOverlap(requiredChains, approvedChains)) {
+    error = getInternalError(
+      "NON_CONFORMING_NAMESPACES",
+      `${context} namespaces chains don't satisfy required namespaces.
+      Required: ${requiredChains.toString()}
+      Approved: ${approvedChains.toString()}`,
+    );
+  }
+
+  requiredChains.forEach((chain) => {
+    if (error) return;
+
+    if (!hasOverlap(parsedRequired[chain].methods, parsedApproved[chain].methods)) {
+      error = getInternalError(
+        "NON_CONFORMING_NAMESPACES",
+        `${context} namespaces methods don't satisfy namespace methods for ${chain}`,
+      );
+    } else if (!hasOverlap(parsedRequired[chain].events, parsedApproved[chain].events)) {
+      error = getInternalError(
+        "NON_CONFORMING_NAMESPACES",
+        `${context} namespaces events don't satisfy namespace events for ${chain}`,
+      );
+    }
+  });
+
   return error;
+}
+
+function parseNamespaces(namespaces: ProposalTypes.RequiredNamespaces) {
+  const parsed = {};
+  Object.keys(namespaces).forEach((key) => {
+    const isInlineDefinition = key.includes(":");
+
+    if (isInlineDefinition) {
+      parsed[key] = namespaces[key];
+    } else {
+      namespaces[key].chains?.forEach((chain) => {
+        parsed[chain] = {
+          methods: namespaces[key].methods,
+          events: namespaces[key].events,
+        };
+      });
+    }
+  });
+  return parsed;
+}
+
+function parseApprovedNamespaces(namespaces: SessionTypes.Namespaces) {
+  const parsed = {};
+  Object.keys(namespaces).forEach((key) => {
+    const isInlineDefinition = key.includes(":");
+    if (isInlineDefinition) {
+      parsed[key] = namespaces[key];
+    } else {
+      const chains = getAccountsChains(namespaces[key].accounts);
+      chains?.forEach((chain) => {
+        parsed[chain] = {
+          accounts: namespaces[key].accounts.filter((account: string) =>
+            account.includes(`${chain}:`),
+          ),
+          methods: namespaces[key].methods,
+          events: namespaces[key].events,
+        };
+      });
+    }
+  });
+  return parsed;
 }
 
 export function isValidRequestExpiry(expiry: number, boundaries: { min: number; max: number }) {

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -424,9 +424,10 @@ export function isConformingNamespaces(
 function parseNamespaces(namespaces: ProposalTypes.RequiredNamespaces) {
   const parsed = {};
   Object.keys(namespaces).forEach((key) => {
-    const isInlineDefinition = key.includes(":");
+    // e.g. `eip155:1`
+    const isInlineChainDefinition = key.includes(":");
 
-    if (isInlineDefinition) {
+    if (isInlineChainDefinition) {
       parsed[key] = namespaces[key];
     } else {
       namespaces[key].chains?.forEach((chain) => {
@@ -453,8 +454,8 @@ function filterDuplicateNamespaces(namespaces: string[]) {
 function parseApprovedNamespaces(namespaces: SessionTypes.Namespaces) {
   const parsed = {};
   Object.keys(namespaces).forEach((key) => {
-    const isInlineDefinition = key.includes(":");
-    if (isInlineDefinition) {
+    const isInlineChainDefinition = key.includes(":");
+    if (isInlineChainDefinition) {
       parsed[key] = namespaces[key];
     } else {
       const chains = getAccountsChains(namespaces[key].accounts);

--- a/packages/utils/test/validators.spec.ts
+++ b/packages/utils/test/validators.spec.ts
@@ -106,7 +106,7 @@ describe("Validators", () => {
       }),
     ).to.be.false;
   });
-  it("should validate namespaces v1", () => {
+  it("should validate namespaces (configuration 1)", () => {
     const required = {
       eip155: {
         chains: ["eip155:1", "eip155:2", "eip155:3"],
@@ -157,7 +157,7 @@ describe("Validators", () => {
     const err = isConformingNamespaces(required, approved, "validators");
     expect(err).to.be.null;
   });
-  it("should validate namespaces v2", () => {
+  it("should validate namespaces (configuration 2)", () => {
     const required = {
       "eip155:1": {
         events: [],
@@ -192,7 +192,7 @@ describe("Validators", () => {
     const err = isConformingNamespaces(required, approved, "validators");
     expect(err).to.be.null;
   });
-  it("should validate namespaces v3", () => {
+  it("should validate namespaces (configuration 3)", () => {
     const required = {
       eip155: {
         chains: ["eip155:1"],
@@ -215,7 +215,7 @@ describe("Validators", () => {
     expect(err).to.be.null;
   });
 
-  it("should trow on invalid accounts", () => {
+  it("should throw on invalid accounts", () => {
     const required = {
       eip155: {
         chains: ["eip155:1"],
@@ -233,7 +233,7 @@ describe("Validators", () => {
     };
     expect(isConformingNamespaces(required, approveOptional, "validators")).to.throw;
   });
-  it("should trow on invalid namespace", () => {
+  it("should throw on invalid namespace", () => {
     const required = {
       eip155: {
         chains: ["eip155:1"],
@@ -251,7 +251,7 @@ describe("Validators", () => {
     };
     expect(isConformingNamespaces(required, approveOptional, "validators")).to.throw;
   });
-  it("should trow on invalid methods", () => {
+  it("should throw on invalid methods", () => {
     const required = {
       eip155: {
         chains: ["eip155:1"],


### PR DESCRIPTION
# Description
PR to resolve an issue where required and approved namespaces had to match in structure in order to be accepted. 
Now we're correctly validating mix-structured namespaces.
Example:
Required namespaces
```
{
      "eip155:1": {
        events: [],
        methods: ["eth_accounts", "personal_sign"],
      },
      "eip155:2": {
        events: [],
        methods: ["eth_accounts"],
      },
      "solana:1": {
        events: [],
        methods: [],
      },
    };
```
is now correctly validated against reponse of
```
{
      eip155: {
        accounts: [
          "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
          "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
        ],
        events: [],
        methods: ["eth_accounts", "personal_sign"],
      },
      solana: {
        accounts: ["solana:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"],
        events: [],
        methods: [],
      },
    }
```

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves # ([browse](https://github.com/WalletConnect/walletconnect-monorepo/issues) or [create](https://github.com/WalletConnect/walletconnect-monorepo/issues/new/choose))

## How Has This Been Tested?
added bunch of validation tests
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
