### PR TITLE
Add signature verification for cacao

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2332,6 +2332,8 @@
     },
     "node_modules/@ethersproject/hash": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
       "funding": [
         {
           "type": "individual",
@@ -2342,7 +2344,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/address": "^5.7.0",
@@ -2679,6 +2680,8 @@
     },
     "node_modules/@ethersproject/transactions": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
       "funding": [
         {
           "type": "individual",
@@ -2689,7 +2692,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/address": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -25438,6 +25440,8 @@
       "version": "2.4.7",
       "license": "Apache-2.0",
       "dependencies": {
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
         "@stablelib/random": "^1.0.2",
@@ -27285,6 +27289,8 @@
     },
     "@ethersproject/hash": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
       "requires": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/address": "^5.7.0",
@@ -27454,6 +27460,8 @@
     },
     "@ethersproject/transactions": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
       "requires": {
         "@ethersproject/address": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -30806,6 +30814,8 @@
     "@walletconnect/utils": {
       "version": "file:packages/utils",
       "requires": {
+        "@ethersproject/hash": "*",
+        "@ethersproject/transactions": "^5.7.0",
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
         "@stablelib/random": "^1.0.2",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -30,6 +30,8 @@
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },
   "dependencies": {
+    "@ethersproject/hash": "^5.7.0",
+    "@ethersproject/transactions": "^5.7.0",
     "@stablelib/chacha20poly1305": "1.0.1",
     "@stablelib/hkdf": "1.0.1",
     "@stablelib/random": "^1.0.2",


### PR DESCRIPTION
# Description

- Add `verifySignature` function to verify cacaos

Does not include `eip1271`. This will be used in chat client until auth team wants to adopt the functions from core.

## How Has This Been Tested?
Has been tested in auth client.


## Due Diligence

- [x] Breaking change
- [x] Requires a documentation update
- [x] Related docs issue/PR (if docs are not included in this PR):
- [x] Requires a e2e/integration test update

## Note
Maybe it'd be worth it to create a sub-package to prevent further enlarging core?
