### PR TITLE
fix: removes setting `this.initialized = false`

### DIFF
--- a/packages/core/src/controllers/subscriber.ts
+++ b/packages/core/src/controllers/subscriber.ts
@@ -180,7 +180,6 @@ export class Subscriber extends ISubscriber {
     this.cached = this.values;
     this.subscriptions.clear();
     this.topicMap.clear();
-    this.initialized = false;
   }
 
   private async unsubscribeByTopic(topic: string, opts?: RelayerTypes.UnsubscribeOptions) {


### PR DESCRIPTION
# Description
Removed setting `this.initialized = false` in subscriber when the connection drops as its causing unnecessary `not initialized` exceptions in rare cases when subscribe was attempted during reconnection timeout. 
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?
Dogfooding with various network settings such as throttling, reconnecting network etc.
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
