### PR TITLE
fix: inline chain validation

### DIFF
--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -402,6 +402,21 @@ export function isConformingNamespaces(
     );
   }
 
+  // validate inline defined chains with approved accounts
+  Object.keys(namespaces).forEach((chain) => {
+    if (!chain.includes(":")) return;
+    if (error) return;
+    const chains = getAccountsChains(namespaces[chain].accounts);
+    if (!chains.includes(chain)) {
+      error = getInternalError(
+        "NON_CONFORMING_NAMESPACES",
+        `${context} namespaces accounts don't satisfy namespace accounts for ${chain}
+        Required: ${chain}
+        Approved: ${chains.toString()}`,
+      );
+    }
+  });
+
   requiredChains.forEach((chain) => {
     if (error) return;
 

--- a/packages/utils/test/validators.spec.ts
+++ b/packages/utils/test/validators.spec.ts
@@ -201,7 +201,7 @@ describe("Validators", () => {
       },
     };
 
-    const approveOptional = {
+    const approved = {
       eip155: {
         accounts: [
           "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
@@ -211,7 +211,32 @@ describe("Validators", () => {
         methods: ["eth_accounts", "personal_sign"],
       },
     };
-    const err = isConformingNamespaces(required, approveOptional, "validators");
+    const err = isConformingNamespaces(required, approved, "validators");
+    expect(err).to.be.null;
+  });
+
+  it("should validate namespaces (configuration 4)", () => {
+    const required = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2"],
+        events: [],
+        methods: ["eth_accounts"],
+      },
+    };
+
+    const approved = {
+      "eip155:1": {
+        accounts: ["eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"],
+        events: ["chainChanged"],
+        methods: ["eth_accounts"],
+      },
+      "eip155:2": {
+        accounts: ["eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"],
+        events: ["chainChanged"],
+        methods: ["eth_accounts"],
+      },
+    };
+    const err = isConformingNamespaces(required, approved, "validators");
     expect(err).to.be.null;
   });
 
@@ -224,14 +249,16 @@ describe("Validators", () => {
       },
     };
 
-    const approveOptional = {
+    const approved = {
       eip155: {
         accounts: ["eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"],
         events: ["chainChanged"],
         methods: ["eth_accounts", "personal_sign"],
       },
     };
-    expect(isConformingNamespaces(required, approveOptional, "validators")).to.throw;
+    const error = isConformingNamespaces(required, approved, "validators");
+    expect(error).to.not.be.null;
+    expect(error).to.throw;
   });
   it("should throw on invalid namespace", () => {
     const required = {
@@ -242,15 +269,18 @@ describe("Validators", () => {
       },
     };
 
-    const approveOptional = {
+    const approved = {
       solana: {
         accounts: ["solana:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"],
         events: ["chainChanged"],
         methods: ["eth_accounts", "personal_sign"],
       },
     };
-    expect(isConformingNamespaces(required, approveOptional, "validators")).to.throw;
+    const error = isConformingNamespaces(required, approved, "validators");
+    expect(error).to.not.be.null;
+    expect(error).to.throw;
   });
+
   it("should throw on invalid methods", () => {
     const required = {
       eip155: {
@@ -260,13 +290,41 @@ describe("Validators", () => {
       },
     };
 
-    const approveOptional = {
+    const approved = {
       eip155: {
         accounts: ["eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"],
         events: ["chainChanged"],
         methods: ["personal_sign"],
       },
     };
-    expect(isConformingNamespaces(required, approveOptional, "validators")).to.throw;
+    const error = isConformingNamespaces(required, approved, "validators");
+    expect(error).to.not.be.null;
+    expect(error).to.throw;
+  });
+
+  it("should throw on CAIP2 namespace not including that CAIP2 in accouns", () => {
+    const required = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2"],
+        events: [],
+        methods: ["eth_accounts"],
+      },
+    };
+
+    const approved = {
+      "eip155:1": {
+        accounts: ["eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"],
+        events: ["chainChanged"],
+        methods: ["eth_accounts"],
+      },
+      "eip155:2": {
+        accounts: ["eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"],
+        events: ["chainChanged"],
+        methods: ["eth_accounts"],
+      },
+    };
+    const error = isConformingNamespaces(required, approved, "validators");
+    expect(error).to.not.be.null;
+    expect(error).to.throw;
   });
 });


### PR DESCRIPTION
# Description
Resolves a bug where approved namespace validation was taking chains only from the accounts and was not accounting for the mismatch between namespace & accounts e.g. 
```
{ 
     "eip155:2": {
        accounts: ["eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"],
     }
},
```
The bug + test cases were noted by @antondalgren in previous PR, thanks a ton :1st_place_medal: :100: 
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?
integration tests
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
