### PR TITLE
refactor: reimplements pairing checks

### DIFF
--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -110,6 +110,11 @@ export class Pairing implements IPairing {
     this.isInitialized();
     this.isValidPair(params);
     const { topic, symKey, relay } = parseUri(params.uri);
+
+    if (this.pairings.keys.includes(topic)) {
+      throw new Error(`Pairing already exists: ${topic}`);
+    }
+
     const expiry = calcExpiry(FIVE_MINUTES);
     const pairing = { topic, relay, expiry, active: false };
     await this.pairings.set(topic, pairing);

--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -115,6 +115,10 @@ export class Pairing implements IPairing {
       throw new Error(`Pairing already exists: ${topic}`);
     }
 
+    if (this.core.crypto.hasKeys(topic)) {
+      throw new Error(`Keychain already exists: ${topic}`);
+    }
+
     const expiry = calcExpiry(FIVE_MINUTES);
     const pairing = { topic, relay, expiry, active: false };
     await this.pairings.set(topic, pairing);

--- a/packages/core/test/pairing.spec.ts
+++ b/packages/core/test/pairing.spec.ts
@@ -2,6 +2,7 @@ import { expect, describe, it, beforeEach, afterEach } from "vitest";
 import { ICore } from "@walletconnect/types";
 import { Core, CORE_PROTOCOL, CORE_VERSION } from "../src";
 import { TEST_CORE_OPTIONS, disconnectSocket } from "./shared";
+import { generateRandomBytes32 } from "@walletconnect/utils";
 
 const waitForEvent = async (checkForEvent: (...args: any[]) => boolean) => {
   await new Promise((resolve) => {
@@ -76,6 +77,16 @@ describe("Pairing", () => {
       const { topic, uri } = await coreA.pairing.create();
       await expect(coreA.pairing.pair({ uri })).rejects.toThrowError(
         `Pairing already exists: ${topic}`,
+      );
+    });
+
+    it("throws when keychain already exists", async () => {
+      const maliciousTopic = generateRandomBytes32();
+      let { topic, uri } = await coreA.pairing.create();
+      coreA.crypto.keychain.set(maliciousTopic, maliciousTopic);
+      uri = uri.replace(topic, maliciousTopic);
+      await expect(coreA.pairing.pair({ uri })).rejects.toThrowError(
+        `Keychain already exists: ${maliciousTopic}`,
       );
     });
   });

--- a/packages/core/test/pairing.spec.ts
+++ b/packages/core/test/pairing.spec.ts
@@ -175,25 +175,6 @@ describe("Pairing", () => {
           "Missing or invalid. pair() uri: undefined",
         );
       });
-
-      it("throws when invalid pairing topic is provided", async () => {
-        let { topic, uri } = await coreA.pairing.create();
-        const maliciousTopic = "maliciousTopic";
-        uri = uri.replace(topic, maliciousTopic);
-        await expect(coreA.pairing.pair({ uri })).rejects.toThrowError(
-          `Invalid topic: ${maliciousTopic}`,
-        );
-      });
-
-      it("throws when invalid symKey is provided", async () => {
-        let { uri } = await coreA.pairing.create();
-        const symKey = uri.split("symKey=")[1];
-        const maliciousSymKey = "maliciousSymKey";
-        uri = uri.replace(symKey, maliciousSymKey);
-        await expect(coreA.pairing.pair({ uri })).rejects.toThrowError(
-          `Invalid symKey: ${maliciousSymKey}`,
-        );
-      });
     });
 
     describe("ping", () => {

--- a/packages/core/test/pairing.spec.ts
+++ b/packages/core/test/pairing.spec.ts
@@ -71,6 +71,13 @@ describe("Pairing", () => {
       expect(coreA.pairing.getPairings()[0].active).toBe(false);
       expect(coreB.pairing.getPairings()[0].active).toBe(true);
     });
+
+    it("throws when pairing is attempted on topic that already exists", async () => {
+      const { topic, uri } = await coreA.pairing.create();
+      await expect(coreA.pairing.pair({ uri })).rejects.toThrowError(
+        `Pairing already exists: ${topic}`,
+      );
+    });
   });
 
   describe("activate", () => {

--- a/packages/utils/src/uri.ts
+++ b/packages/utils/src/uri.ts
@@ -1,6 +1,5 @@
 import * as qs from "query-string";
 import { EngineTypes, RelayerTypes } from "@walletconnect/types";
-import { hashKey } from "./crypto";
 
 // -- uri -------------------------------------------------- //
 
@@ -23,27 +22,13 @@ export function parseUri(str: string): EngineTypes.UriParameters {
   const protocol: string = str.substring(0, pathStart);
   const path: string = str.substring(pathStart + 1, pathEnd);
   const requiredValues = path.split("@");
-  const proposedTopic = requiredValues[0];
-
   const queryString: string = typeof pathEnd !== "undefined" ? str.substring(pathEnd) : "";
   const queryParams = qs.parse(queryString);
-  const symKey = queryParams.symKey as string;
-
-  if (symKey.length !== 64) {
-    throw new Error(`Invalid symKey: ${symKey}`);
-  }
-
-  const expectedTopic = hashKey(symKey as string);
-
-  if (proposedTopic !== expectedTopic) {
-    throw new Error(`Invalid topic: ${proposedTopic}`);
-  }
-
   const result = {
     protocol,
-    topic: proposedTopic,
+    topic: requiredValues[0],
     version: parseInt(requiredValues[1], 10),
-    symKey,
+    symKey: queryParams.symKey as string,
     relay: parseRelayParams(queryParams),
   };
   return result;

--- a/packages/utils/test/uri.spec.ts
+++ b/packages/utils/test/uri.spec.ts
@@ -1,16 +1,13 @@
 import { EngineTypes } from "@walletconnect/types";
 import { expect, describe, it } from "vitest";
-import { formatUri, generateRandomBytes32, hashKey, parseUri } from "../src";
+import { formatUri, parseUri } from "../src";
 import { TEST_PAIRING_TOPIC, TEST_RELAY_OPTIONS, TEST_SYM_KEY } from "./shared";
-
-const symKey = generateRandomBytes32();
-const topic = hashKey(symKey);
 
 const TEST_URI_PARAMS: EngineTypes.UriParameters = {
   protocol: "wc",
   version: 2,
-  topic,
-  symKey,
+  topic: TEST_PAIRING_TOPIC,
+  symKey: TEST_SYM_KEY,
   relay: TEST_RELAY_OPTIONS,
 };
 


### PR DESCRIPTION
# Description
Reverted https://github.com/WalletConnect/walletconnect-monorepo/pull/2049 and reimplemented pairing uri validation by rejecting pairing attempts if a topic already exists
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?
integration test
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
