### PR TITLE
feat(relayer): surface abnormal websocket close reasons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6764,8 +6764,9 @@
       "license": "0BSD"
     },
     "node_modules/@walletconnect/jsonrpc-utils": {
-      "version": "1.0.4",
-      "license": "MIT",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.6.tgz",
+      "integrity": "sha512-snp0tfkjPiDLQp/jrBewI+9SM33GPV4+Gjgldod6XQ7rFyQ5FZjnBxUkY4xWH0+arNxzQSi6v5iDXjCjSaorpg==",
       "dependencies": {
         "@walletconnect/environment": "^1.0.1",
         "@walletconnect/jsonrpc-types": "^1.0.2",
@@ -6777,14 +6778,21 @@
       "license": "0BSD"
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.7.tgz",
-      "integrity": "sha512-iEIWUAIQih0TDF+RRjExZL3jd84UWX/rvzAmQ6fZWhyBP/qSlxGrMuAwNhpk2zj6P8dZuf8sSaaNuWgXFJIa5A==",
+      "version": "1.0.9-f14036a",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.9-f14036a.tgz",
+      "integrity": "sha512-8YhzW+j8yoDLejjydWXcmlJFntn7CIkFPTNQuP+ra7gHGeS+PU0ovE7u8+iBXJKa0sRozM47zy/jojetVYRNZQ==",
       "dependencies": {
-        "@walletconnect/jsonrpc-utils": "^1.0.4",
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.1",
+        "events": "^3.3.0",
+        "tslib": "1.14.1",
         "ws": "^7.5.1"
       }
+    },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/keyvaluestorage": {
       "version": "1.0.2",
@@ -25363,9 +25371,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.0",
-        "@walletconnect/jsonrpc-provider": "^1.0.6",
+        "@walletconnect/jsonrpc-provider": "1.0.8-7c26f7a",
         "@walletconnect/jsonrpc-utils": "^1.0.4",
-        "@walletconnect/jsonrpc-ws-connection": "^1.0.7",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.9-f14036a",
         "@walletconnect/keyvaluestorage": "^1.0.2",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
@@ -25382,6 +25390,21 @@
       "devDependencies": {
         "@types/lodash.isequal": "4.5.6"
       }
+    },
+    "packages/core/node_modules/@walletconnect/jsonrpc-provider": {
+      "version": "1.0.8-7c26f7a",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.8-7c26f7a.tgz",
+      "integrity": "sha512-7X3nIpRE/lAsaGijIolbwlqBj7Wh/mU0Su61cMo2TokiBpC81d1qDGJ2QWrlNSHsF6MpmHEtHW82/dcWaAOrVg==",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.1",
+        "tslib": "1.14.1"
+      }
+    },
+    "packages/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "packages/react-native-compat": {
       "name": "@walletconnect/react-native-compat",
@@ -25414,7 +25437,7 @@
         "pino": "7.11.0"
       },
       "devDependencies": {
-        "@walletconnect/jsonrpc-ws-connection": "^1.0.7",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.9-f14036a",
         "@walletconnect/relay-api": "^1.0.9",
         "aws-sdk": "2.1194.0",
         "lokijs": "^1.5.12"
@@ -30293,9 +30316,9 @@
       "requires": {
         "@types/lodash.isequal": "4.5.6",
         "@walletconnect/heartbeat": "1.2.0",
-        "@walletconnect/jsonrpc-provider": "^1.0.6",
+        "@walletconnect/jsonrpc-provider": "1.0.8-7c26f7a",
         "@walletconnect/jsonrpc-utils": "^1.0.4",
-        "@walletconnect/jsonrpc-ws-connection": "^1.0.7",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.9-f14036a",
         "@walletconnect/keyvaluestorage": "^1.0.2",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
@@ -30308,6 +30331,23 @@
         "lodash.isequal": "4.5.0",
         "pino": "7.11.0",
         "uint8arrays": "^3.1.0"
+      },
+      "dependencies": {
+        "@walletconnect/jsonrpc-provider": {
+          "version": "1.0.8-7c26f7a",
+          "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.8-7c26f7a.tgz",
+          "integrity": "sha512-7X3nIpRE/lAsaGijIolbwlqBj7Wh/mU0Su61cMo2TokiBpC81d1qDGJ2QWrlNSHsF6MpmHEtHW82/dcWaAOrVg==",
+          "requires": {
+            "@walletconnect/jsonrpc-utils": "^1.0.6",
+            "@walletconnect/safe-json": "^1.0.1",
+            "tslib": "1.14.1"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@walletconnect/environment": {
@@ -30410,7 +30450,9 @@
       }
     },
     "@walletconnect/jsonrpc-utils": {
-      "version": "1.0.4",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.6.tgz",
+      "integrity": "sha512-snp0tfkjPiDLQp/jrBewI+9SM33GPV4+Gjgldod6XQ7rFyQ5FZjnBxUkY4xWH0+arNxzQSi6v5iDXjCjSaorpg==",
       "requires": {
         "@walletconnect/environment": "^1.0.1",
         "@walletconnect/jsonrpc-types": "^1.0.2",
@@ -30423,13 +30465,22 @@
       }
     },
     "@walletconnect/jsonrpc-ws-connection": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.7.tgz",
-      "integrity": "sha512-iEIWUAIQih0TDF+RRjExZL3jd84UWX/rvzAmQ6fZWhyBP/qSlxGrMuAwNhpk2zj6P8dZuf8sSaaNuWgXFJIa5A==",
+      "version": "1.0.9-f14036a",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.9-f14036a.tgz",
+      "integrity": "sha512-8YhzW+j8yoDLejjydWXcmlJFntn7CIkFPTNQuP+ra7gHGeS+PU0ovE7u8+iBXJKa0sRozM47zy/jojetVYRNZQ==",
       "requires": {
-        "@walletconnect/jsonrpc-utils": "^1.0.4",
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.1",
+        "events": "^3.3.0",
+        "tslib": "1.14.1",
         "ws": "^7.5.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@walletconnect/keyvaluestorage": {
@@ -30512,7 +30563,7 @@
         "@walletconnect/heartbeat": "1.2.0",
         "@walletconnect/jsonrpc-provider": "^1.0.6",
         "@walletconnect/jsonrpc-utils": "^1.0.4",
-        "@walletconnect/jsonrpc-ws-connection": "^1.0.7",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.9-f14036a",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/time": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6739,10 +6739,11 @@
       "license": "0BSD"
     },
     "node_modules/@walletconnect/jsonrpc-provider": {
-      "version": "1.0.6",
-      "license": "MIT",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.9.tgz",
+      "integrity": "sha512-8CwmiDW42F+F8Qct13lX2x4lJOsi0mNBtUln3VS6TpWioTaL1VfforC/8ULc3tHXv+SNWwAXn2lCZbDcYhdRcA==",
       "dependencies": {
-        "@walletconnect/jsonrpc-utils": "^1.0.4",
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.1",
         "tslib": "1.14.1"
       }
@@ -6778,9 +6779,9 @@
       "license": "0BSD"
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection": {
-      "version": "1.0.9-f14036a",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.9-f14036a.tgz",
-      "integrity": "sha512-8YhzW+j8yoDLejjydWXcmlJFntn7CIkFPTNQuP+ra7gHGeS+PU0ovE7u8+iBXJKa0sRozM47zy/jojetVYRNZQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.10.tgz",
+      "integrity": "sha512-/tidvjfCXZuYugjF5fOswsNDPoMo9QRML3DFQ0dfNUarL4f5HGqu8NDGerr2n0+4MOX23GsT6Vv2POSwFbvgGw==",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.1",
@@ -25371,9 +25372,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.0",
-        "@walletconnect/jsonrpc-provider": "1.0.8-f37f36d",
+        "@walletconnect/jsonrpc-provider": "1.0.9",
         "@walletconnect/jsonrpc-utils": "^1.0.4",
-        "@walletconnect/jsonrpc-ws-connection": "1.0.9-f14036a",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.10",
         "@walletconnect/keyvaluestorage": "^1.0.2",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
@@ -25390,21 +25391,6 @@
       "devDependencies": {
         "@types/lodash.isequal": "4.5.6"
       }
-    },
-    "packages/core/node_modules/@walletconnect/jsonrpc-provider": {
-      "version": "1.0.8-f37f36d",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.8-f37f36d.tgz",
-      "integrity": "sha512-GFD4kg8trENV/8wV3UhKFjGNg8RojsWadtrajOkyFdDcgvvh5z6QhkNVdr+DxBd9gDWiLR6/JVAATZUncTM+GQ==",
-      "dependencies": {
-        "@walletconnect/jsonrpc-utils": "^1.0.6",
-        "@walletconnect/safe-json": "^1.0.1",
-        "tslib": "1.14.1"
-      }
-    },
-    "packages/core/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "packages/react-native-compat": {
       "name": "@walletconnect/react-native-compat",
@@ -25427,7 +25413,6 @@
         "@walletconnect/core": "2.4.9",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.0",
-        "@walletconnect/jsonrpc-provider": "1.0.8-f37f36d",
         "@walletconnect/jsonrpc-utils": "^1.0.4",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/time": "^1.0.2",
@@ -25437,26 +25422,12 @@
         "pino": "7.11.0"
       },
       "devDependencies": {
-        "@walletconnect/jsonrpc-ws-connection": "1.0.9-f14036a",
+        "@walletconnect/jsonrpc-provider": "1.0.9",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.10",
         "@walletconnect/relay-api": "^1.0.9",
         "aws-sdk": "2.1194.0",
         "lokijs": "^1.5.12"
       }
-    },
-    "packages/sign-client/node_modules/@walletconnect/jsonrpc-provider": {
-      "version": "1.0.8-f37f36d",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.8-f37f36d.tgz",
-      "integrity": "sha512-GFD4kg8trENV/8wV3UhKFjGNg8RojsWadtrajOkyFdDcgvvh5z6QhkNVdr+DxBd9gDWiLR6/JVAATZUncTM+GQ==",
-      "dependencies": {
-        "@walletconnect/jsonrpc-utils": "^1.0.6",
-        "@walletconnect/safe-json": "^1.0.1",
-        "tslib": "1.14.1"
-      }
-    },
-    "packages/sign-client/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "packages/types": {
       "name": "@walletconnect/types",
@@ -30331,9 +30302,9 @@
       "requires": {
         "@types/lodash.isequal": "4.5.6",
         "@walletconnect/heartbeat": "1.2.0",
-        "@walletconnect/jsonrpc-provider": "1.0.8-f37f36d",
+        "@walletconnect/jsonrpc-provider": "1.0.9",
         "@walletconnect/jsonrpc-utils": "^1.0.4",
-        "@walletconnect/jsonrpc-ws-connection": "1.0.9-f14036a",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.10",
         "@walletconnect/keyvaluestorage": "^1.0.2",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
@@ -30346,23 +30317,6 @@
         "lodash.isequal": "4.5.0",
         "pino": "7.11.0",
         "uint8arrays": "^3.1.0"
-      },
-      "dependencies": {
-        "@walletconnect/jsonrpc-provider": {
-          "version": "1.0.8-f37f36d",
-          "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.8-f37f36d.tgz",
-          "integrity": "sha512-GFD4kg8trENV/8wV3UhKFjGNg8RojsWadtrajOkyFdDcgvvh5z6QhkNVdr+DxBd9gDWiLR6/JVAATZUncTM+GQ==",
-          "requires": {
-            "@walletconnect/jsonrpc-utils": "^1.0.6",
-            "@walletconnect/safe-json": "^1.0.1",
-            "tslib": "1.14.1"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
       }
     },
     "@walletconnect/environment": {
@@ -30440,9 +30394,11 @@
       }
     },
     "@walletconnect/jsonrpc-provider": {
-      "version": "1.0.6",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.9.tgz",
+      "integrity": "sha512-8CwmiDW42F+F8Qct13lX2x4lJOsi0mNBtUln3VS6TpWioTaL1VfforC/8ULc3tHXv+SNWwAXn2lCZbDcYhdRcA==",
       "requires": {
-        "@walletconnect/jsonrpc-utils": "^1.0.4",
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.1",
         "tslib": "1.14.1"
       },
@@ -30480,9 +30436,9 @@
       }
     },
     "@walletconnect/jsonrpc-ws-connection": {
-      "version": "1.0.9-f14036a",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.9-f14036a.tgz",
-      "integrity": "sha512-8YhzW+j8yoDLejjydWXcmlJFntn7CIkFPTNQuP+ra7gHGeS+PU0ovE7u8+iBXJKa0sRozM47zy/jojetVYRNZQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.10.tgz",
+      "integrity": "sha512-/tidvjfCXZuYugjF5fOswsNDPoMo9QRML3DFQ0dfNUarL4f5HGqu8NDGerr2n0+4MOX23GsT6Vv2POSwFbvgGw==",
       "requires": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.1",
@@ -30576,9 +30532,9 @@
         "@walletconnect/core": "2.4.9",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.0",
-        "@walletconnect/jsonrpc-provider": "1.0.8-f37f36d",
+        "@walletconnect/jsonrpc-provider": "1.0.9",
         "@walletconnect/jsonrpc-utils": "^1.0.4",
-        "@walletconnect/jsonrpc-ws-connection": "1.0.9-f14036a",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.10",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/time": "^1.0.2",
@@ -30588,23 +30544,6 @@
         "events": "^3.3.0",
         "lokijs": "^1.5.12",
         "pino": "7.11.0"
-      },
-      "dependencies": {
-        "@walletconnect/jsonrpc-provider": {
-          "version": "1.0.8-f37f36d",
-          "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.8-f37f36d.tgz",
-          "integrity": "sha512-GFD4kg8trENV/8wV3UhKFjGNg8RojsWadtrajOkyFdDcgvvh5z6QhkNVdr+DxBd9gDWiLR6/JVAATZUncTM+GQ==",
-          "requires": {
-            "@walletconnect/jsonrpc-utils": "^1.0.6",
-            "@walletconnect/safe-json": "^1.0.1",
-            "tslib": "1.14.1"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
       }
     },
     "@walletconnect/signer-connection": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25371,7 +25371,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.0",
-        "@walletconnect/jsonrpc-provider": "1.0.8-7c26f7a",
+        "@walletconnect/jsonrpc-provider": "1.0.8-f37f36d",
         "@walletconnect/jsonrpc-utils": "^1.0.4",
         "@walletconnect/jsonrpc-ws-connection": "1.0.9-f14036a",
         "@walletconnect/keyvaluestorage": "^1.0.2",
@@ -25392,9 +25392,9 @@
       }
     },
     "packages/core/node_modules/@walletconnect/jsonrpc-provider": {
-      "version": "1.0.8-7c26f7a",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.8-7c26f7a.tgz",
-      "integrity": "sha512-7X3nIpRE/lAsaGijIolbwlqBj7Wh/mU0Su61cMo2TokiBpC81d1qDGJ2QWrlNSHsF6MpmHEtHW82/dcWaAOrVg==",
+      "version": "1.0.8-f37f36d",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.8-f37f36d.tgz",
+      "integrity": "sha512-GFD4kg8trENV/8wV3UhKFjGNg8RojsWadtrajOkyFdDcgvvh5z6QhkNVdr+DxBd9gDWiLR6/JVAATZUncTM+GQ==",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.1",
@@ -25427,7 +25427,7 @@
         "@walletconnect/core": "2.4.9",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.0",
-        "@walletconnect/jsonrpc-provider": "^1.0.6",
+        "@walletconnect/jsonrpc-provider": "1.0.8-f37f36d",
         "@walletconnect/jsonrpc-utils": "^1.0.4",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/time": "^1.0.2",
@@ -25442,6 +25442,21 @@
         "aws-sdk": "2.1194.0",
         "lokijs": "^1.5.12"
       }
+    },
+    "packages/sign-client/node_modules/@walletconnect/jsonrpc-provider": {
+      "version": "1.0.8-f37f36d",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.8-f37f36d.tgz",
+      "integrity": "sha512-GFD4kg8trENV/8wV3UhKFjGNg8RojsWadtrajOkyFdDcgvvh5z6QhkNVdr+DxBd9gDWiLR6/JVAATZUncTM+GQ==",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.1",
+        "tslib": "1.14.1"
+      }
+    },
+    "packages/sign-client/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "packages/types": {
       "name": "@walletconnect/types",
@@ -30316,7 +30331,7 @@
       "requires": {
         "@types/lodash.isequal": "4.5.6",
         "@walletconnect/heartbeat": "1.2.0",
-        "@walletconnect/jsonrpc-provider": "1.0.8-7c26f7a",
+        "@walletconnect/jsonrpc-provider": "1.0.8-f37f36d",
         "@walletconnect/jsonrpc-utils": "^1.0.4",
         "@walletconnect/jsonrpc-ws-connection": "1.0.9-f14036a",
         "@walletconnect/keyvaluestorage": "^1.0.2",
@@ -30334,9 +30349,9 @@
       },
       "dependencies": {
         "@walletconnect/jsonrpc-provider": {
-          "version": "1.0.8-7c26f7a",
-          "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.8-7c26f7a.tgz",
-          "integrity": "sha512-7X3nIpRE/lAsaGijIolbwlqBj7Wh/mU0Su61cMo2TokiBpC81d1qDGJ2QWrlNSHsF6MpmHEtHW82/dcWaAOrVg==",
+          "version": "1.0.8-f37f36d",
+          "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.8-f37f36d.tgz",
+          "integrity": "sha512-GFD4kg8trENV/8wV3UhKFjGNg8RojsWadtrajOkyFdDcgvvh5z6QhkNVdr+DxBd9gDWiLR6/JVAATZUncTM+GQ==",
           "requires": {
             "@walletconnect/jsonrpc-utils": "^1.0.6",
             "@walletconnect/safe-json": "^1.0.1",
@@ -30561,7 +30576,7 @@
         "@walletconnect/core": "2.4.9",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.0",
-        "@walletconnect/jsonrpc-provider": "^1.0.6",
+        "@walletconnect/jsonrpc-provider": "1.0.8-f37f36d",
         "@walletconnect/jsonrpc-utils": "^1.0.4",
         "@walletconnect/jsonrpc-ws-connection": "1.0.9-f14036a",
         "@walletconnect/logger": "^2.0.1",
@@ -30573,6 +30588,23 @@
         "events": "^3.3.0",
         "lokijs": "^1.5.12",
         "pino": "7.11.0"
+      },
+      "dependencies": {
+        "@walletconnect/jsonrpc-provider": {
+          "version": "1.0.8-f37f36d",
+          "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.8-f37f36d.tgz",
+          "integrity": "sha512-GFD4kg8trENV/8wV3UhKFjGNg8RojsWadtrajOkyFdDcgvvh5z6QhkNVdr+DxBd9gDWiLR6/JVAATZUncTM+GQ==",
+          "requires": {
+            "@walletconnect/jsonrpc-utils": "^1.0.6",
+            "@walletconnect/safe-json": "^1.0.1",
+            "tslib": "1.14.1"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@walletconnect/signer-connection": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@walletconnect/heartbeat": "1.2.0",
-    "@walletconnect/jsonrpc-provider": "1.0.8-7c26f7a",
+    "@walletconnect/jsonrpc-provider": "1.0.8-f37f36d",
     "@walletconnect/jsonrpc-utils": "^1.0.4",
     "@walletconnect/jsonrpc-ws-connection": "1.0.9-f14036a",
     "@walletconnect/keyvaluestorage": "^1.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,9 +31,9 @@
   },
   "dependencies": {
     "@walletconnect/heartbeat": "1.2.0",
-    "@walletconnect/jsonrpc-provider": "1.0.8-f37f36d",
+    "@walletconnect/jsonrpc-provider": "1.0.9",
     "@walletconnect/jsonrpc-utils": "^1.0.4",
-    "@walletconnect/jsonrpc-ws-connection": "1.0.9-f14036a",
+    "@walletconnect/jsonrpc-ws-connection": "1.0.10",
     "@walletconnect/keyvaluestorage": "^1.0.2",
     "@walletconnect/logger": "^2.0.1",
     "@walletconnect/relay-api": "^1.0.9",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,9 +31,9 @@
   },
   "dependencies": {
     "@walletconnect/heartbeat": "1.2.0",
-    "@walletconnect/jsonrpc-provider": "^1.0.6",
+    "@walletconnect/jsonrpc-provider": "1.0.8-7c26f7a",
     "@walletconnect/jsonrpc-utils": "^1.0.4",
-    "@walletconnect/jsonrpc-ws-connection": "^1.0.7",
+    "@walletconnect/jsonrpc-ws-connection": "1.0.9-f14036a",
     "@walletconnect/keyvaluestorage": "^1.0.2",
     "@walletconnect/logger": "^2.0.1",
     "@walletconnect/relay-api": "^1.0.9",

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -283,9 +283,10 @@ export class Relayer extends IRelayer {
 
       this.attemptToReconnect();
     });
-    this.provider.on(RELAYER_PROVIDER_EVENTS.error, (err: unknown) =>
-      this.events.emit(RELAYER_EVENTS.error, err),
-    );
+    this.provider.on(RELAYER_PROVIDER_EVENTS.error, (err: unknown) => {
+      this.logger.error(err);
+      this.events.emit(RELAYER_EVENTS.error, err);
+    });
 
     this.events.on(RELAYER_EVENTS.connection_stalled, async () => {
       await this.restartTransport();

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -226,6 +226,7 @@ export class Relayer extends IRelayer {
           relayUrl: this.relayUrl,
           projectId: this.projectId,
           auth,
+          useOnCloseEvent: true,
         }),
       ),
     );

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -50,7 +50,7 @@
     "pino": "7.11.0"
   },
   "devDependencies": {
-    "@walletconnect/jsonrpc-ws-connection": "^1.0.7",
+    "@walletconnect/jsonrpc-ws-connection": "1.0.9-f14036a",
     "@walletconnect/relay-api": "^1.0.9",
     "aws-sdk": "2.1194.0",
     "lokijs": "^1.5.12"

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -40,7 +40,6 @@
     "@walletconnect/core": "2.4.9",
     "@walletconnect/events": "^1.0.1",
     "@walletconnect/heartbeat": "1.2.0",
-    "@walletconnect/jsonrpc-provider": "1.0.8-f37f36d",
     "@walletconnect/jsonrpc-utils": "^1.0.4",
     "@walletconnect/logger": "^2.0.1",
     "@walletconnect/time": "^1.0.2",
@@ -50,7 +49,8 @@
     "pino": "7.11.0"
   },
   "devDependencies": {
-    "@walletconnect/jsonrpc-ws-connection": "1.0.9-f14036a",
+    "@walletconnect/jsonrpc-provider": "1.0.9",
+    "@walletconnect/jsonrpc-ws-connection": "1.0.10",
     "@walletconnect/relay-api": "^1.0.9",
     "aws-sdk": "2.1194.0",
     "lokijs": "^1.5.12"

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -40,7 +40,7 @@
     "@walletconnect/core": "2.4.9",
     "@walletconnect/events": "^1.0.1",
     "@walletconnect/heartbeat": "1.2.0",
-    "@walletconnect/jsonrpc-provider": "^1.0.6",
+    "@walletconnect/jsonrpc-provider": "1.0.8-f37f36d",
     "@walletconnect/jsonrpc-utils": "^1.0.4",
     "@walletconnect/logger": "^2.0.1",
     "@walletconnect/time": "^1.0.2",

--- a/packages/types/src/core/relayer.ts
+++ b/packages/types/src/core/relayer.ts
@@ -49,6 +49,7 @@ export declare namespace RelayerTypes {
     relayUrl: string;
     sdkVersion: string;
     projectId?: string;
+    useOnCloseEvent?: boolean;
   }
 }
 

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -125,10 +125,11 @@ export function formatRelayRpcUrl({
   sdkVersion,
   auth,
   projectId,
+  useOnCloseEvent,
 }: RelayerTypes.RpcUrlParams) {
   const splitUrl = relayUrl.split("?");
   const ua = formatUA(protocol, version, sdkVersion);
-  const params = { auth, ua, projectId };
+  const params = { auth, ua, projectId, useOnCloseEvent: useOnCloseEvent || undefined };
   const queryString = appendToQueryString(splitUrl[1] || "", params);
   return splitUrl[0] + "?" + queryString;
 }

--- a/packages/utils/test/misc.spec.ts
+++ b/packages/utils/test/misc.spec.ts
@@ -22,6 +22,12 @@ const EXPECTED_RPC_URL_2 =
     formatUA(PROTOCOL, VERSION, SDK_VERSION),
   )}`;
 
+const EXPECTED_RPC_URL_3 =
+  RELAY_URL +
+  `?auth=${AUTH}&projectId=${PROJECT_ID}&ua=${encodeURIComponent(
+    formatUA(PROTOCOL, VERSION, SDK_VERSION),
+  )}&useOnCloseEvent=true`;
+
 const SEVEN_DAYS_IN_SECONDS = 604800;
 
 describe("Misc", () => {
@@ -45,6 +51,17 @@ describe("Misc", () => {
         auth: AUTH,
       }),
     ).to.eql(EXPECTED_RPC_URL_2);
+    expect(
+      formatRelayRpcUrl({
+        protocol: PROTOCOL,
+        version: VERSION,
+        sdkVersion: SDK_VERSION,
+        relayUrl: RELAY_URL,
+        projectId: PROJECT_ID,
+        auth: AUTH,
+        useOnCloseEvent: true,
+      }),
+    ).to.eql(EXPECTED_RPC_URL_3);
   });
   it("hasOverlap", () => {
     expect(hasOverlap([], [])).to.be.true;


### PR DESCRIPTION
# Description

- Resolves #2091 
- Surface the websocket close context provided via https://github.com/WalletConnect/walletconnect-utils/pull/56 in the relayer.
- The relayer will now emit an error such as `Error: WebSocket connection closed abnormally with code: 3000 (Authorization error: Project ID is missing)` if the WebSocket connection closes with an unexpected `3000` code, surfacing the `event.reason` in the error string.

## How Has This Been Tested?

- Unit tests
- Canary/dogfooding (canary `2.4.9-c072c335`)

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
