### PR TITLE
Make web3modal a peerDependency, expose theming options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3957,12 +3957,14 @@
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.0.0.tgz",
-      "integrity": "sha512-ic93MBXfApIFTrup4a70M/+ddD8xdt2zxxj9sRwHQzhS9ag/syqkD8JPdTXsc1gUy2K8TTirhlCqyTEM/sifNw=="
+      "integrity": "sha512-ic93MBXfApIFTrup4a70M/+ddD8xdt2zxxj9sRwHQzhS9ag/syqkD8JPdTXsc1gUy2K8TTirhlCqyTEM/sifNw==",
+      "dev": true
     },
     "node_modules/@lit/reactive-element": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.1.tgz",
       "integrity": "sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==",
+      "dev": true,
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
@@ -3971,6 +3973,7 @@
       "version": "10.15.1",
       "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.15.1.tgz",
       "integrity": "sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==",
+      "dev": true,
       "dependencies": {
         "@motionone/easing": "^10.15.1",
         "@motionone/types": "^10.15.1",
@@ -3982,6 +3985,7 @@
       "version": "10.15.5",
       "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.15.5.tgz",
       "integrity": "sha512-Xc5avlgyh3xukU9tydh9+8mB8+2zAq+WlLsC3eEIp7Ax7DnXgY7Bj/iv0a4X2R9z9ZFZiaXK3BO0xMYHKbAAdA==",
+      "dev": true,
       "dependencies": {
         "@motionone/animation": "^10.15.1",
         "@motionone/generators": "^10.15.1",
@@ -3995,6 +3999,7 @@
       "version": "10.15.1",
       "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.15.1.tgz",
       "integrity": "sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==",
+      "dev": true,
       "dependencies": {
         "@motionone/utils": "^10.15.1",
         "tslib": "^2.3.1"
@@ -4004,6 +4009,7 @@
       "version": "10.15.1",
       "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.15.1.tgz",
       "integrity": "sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==",
+      "dev": true,
       "dependencies": {
         "@motionone/types": "^10.15.1",
         "@motionone/utils": "^10.15.1",
@@ -4014,6 +4020,7 @@
       "version": "10.15.5",
       "resolved": "https://registry.npmjs.org/@motionone/svelte/-/svelte-10.15.5.tgz",
       "integrity": "sha512-Xyxtgp7BlVnSBwcoFmXGHUVnpNktzeXsEifu2NJJWc7VGuxutDsBZxNdz80qvpLIC5MeBa1wh7GGegZzTm1msg==",
+      "dev": true,
       "dependencies": {
         "@motionone/dom": "^10.15.5",
         "tslib": "^2.3.1"
@@ -4022,12 +4029,14 @@
     "node_modules/@motionone/types": {
       "version": "10.15.1",
       "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.15.1.tgz",
-      "integrity": "sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA=="
+      "integrity": "sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA==",
+      "dev": true
     },
     "node_modules/@motionone/utils": {
       "version": "10.15.1",
       "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.15.1.tgz",
       "integrity": "sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==",
+      "dev": true,
       "dependencies": {
         "@motionone/types": "^10.15.1",
         "hey-listen": "^1.0.8",
@@ -4038,6 +4047,7 @@
       "version": "10.15.5",
       "resolved": "https://registry.npmjs.org/@motionone/vue/-/vue-10.15.5.tgz",
       "integrity": "sha512-cUENrLYAolUacHvCgU+8wF9OgSlVutfWbHMLERI/bElCJ+e2YVQvG/CpGhIM5fYOOJzuvg2T2wHmLLmvJoavEw==",
+      "dev": true,
       "dependencies": {
         "@motionone/dom": "^10.15.5",
         "tslib": "^2.3.1"
@@ -6447,7 +6457,8 @@
     "node_modules/@types/trusted-types": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
-      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
+      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.19",
@@ -6937,6 +6948,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@web3modal/core/-/core-2.2.0.tgz",
       "integrity": "sha512-Kafg/KtK6S9x0Ofcaq9hj7dRK5/541nM+LnayPmHxx4fSrDgcM9YYhL12fI4BG1xGOJwkeZjgFOtS0qf123Cjw==",
+      "dev": true,
       "dependencies": {
         "buffer": "6.0.3",
         "valtio": "1.9.0"
@@ -6946,6 +6958,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6969,6 +6982,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@web3modal/standalone/-/standalone-2.2.0.tgz",
       "integrity": "sha512-cLFW4VamSJ7L4sM5OGmr1SHK3FgyLUMEaacvHsCA3XSvUF0LxbMC+N4uBsONrW4c0JyIjTdeii1GqG4B3jwn7Q==",
+      "dev": true,
       "dependencies": {
         "@web3modal/core": "2.2.0",
         "@web3modal/ui": "2.2.0"
@@ -6978,6 +6992,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@web3modal/ui/-/ui-2.2.0.tgz",
       "integrity": "sha512-jcV5C9AuMdsFdf6Ljsr0v2lInu8FJJyXcZPaMHkgYNIczzgMEpDE+UOA7hLnyCTUxM9R0AgRcgfTyMWb9H8Ssw==",
+      "dev": true,
       "dependencies": {
         "@web3modal/core": "2.2.0",
         "lit": "2.6.1",
@@ -9646,7 +9661,8 @@
     "node_modules/dijkstrajs": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.2.tgz",
-      "integrity": "sha512-QV6PMaHTCNmKSeP6QoXhVTw9snc9VD8MulTT0Bd99Pacp4SS1cjcrYPgBPmibqKVtMJJfqC6XvOXgPMEEPH/fg=="
+      "integrity": "sha512-QV6PMaHTCNmKSeP6QoXhVTw9snc9VD8MulTT0Bd99Pacp4SS1cjcrYPgBPmibqKVtMJJfqC6XvOXgPMEEPH/fg==",
+      "dev": true
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -9760,7 +9776,8 @@
     "node_modules/encode-utf8": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
-      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw=="
+      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==",
+      "dev": true
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -14810,7 +14827,8 @@
     "node_modules/hey-listen": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
+      "dev": true
     },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
@@ -16753,6 +16771,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/lit/-/lit-2.6.1.tgz",
       "integrity": "sha512-DT87LD64f8acR7uVp7kZfhLRrHkfC/N4BVzAtnw9Yg8087mbBJ//qedwdwX0kzDbxgPccWRW6mFwGbRQIxy0pw==",
+      "dev": true,
       "dependencies": {
         "@lit/reactive-element": "^1.6.0",
         "lit-element": "^3.2.0",
@@ -16763,6 +16782,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.2.tgz",
       "integrity": "sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==",
+      "dev": true,
       "dependencies": {
         "@lit/reactive-element": "^1.3.0",
         "lit-html": "^2.2.0"
@@ -16772,6 +16792,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.6.1.tgz",
       "integrity": "sha512-Z3iw+E+3KKFn9t2YKNjsXNEu/LRLI98mtH/C6lnFg7kvaqPIzPn124Yd4eT/43lyqrejpc5Wb6BHq3fdv4S8Rw==",
+      "dev": true,
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -18689,6 +18710,7 @@
       "version": "10.15.5",
       "resolved": "https://registry.npmjs.org/motion/-/motion-10.15.5.tgz",
       "integrity": "sha512-ejP6KioN4pigTGxL93APzOnvtLklParL59UQB2T3HWXQBxFcIp5/7YXFmkgiA6pNKKzjvnLhnonRBN5iSFMnNw==",
+      "dev": true,
       "dependencies": {
         "@motionone/animation": "^10.15.1",
         "@motionone/dom": "^10.15.5",
@@ -20418,6 +20440,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
       "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "dev": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -20677,7 +20700,8 @@
     "node_modules/proxy-compare": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.4.0.tgz",
-      "integrity": "sha512-FD8KmQUQD6Mfpd0hywCOzcon/dbkFP8XBd9F1ycbKtvVsfv6TsFUKJ2eC0Iz2y+KzlkdT1Z8SY6ZSgm07zOyqg=="
+      "integrity": "sha512-FD8KmQUQD6Mfpd0hywCOzcon/dbkFP8XBd9F1ycbKtvVsfv6TsFUKJ2eC0Iz2y+KzlkdT1Z8SY6ZSgm07zOyqg==",
+      "dev": true
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -20741,6 +20765,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.1.tgz",
       "integrity": "sha512-nS8NJ1Z3md8uTjKtP+SGGhfqmTCs5flU/xR623oI0JX+Wepz9R8UrRVCTBTJm3qGw3rH6jJ6MUHjkDx15cxSSg==",
+      "dev": true,
       "dependencies": {
         "dijkstrajs": "^1.0.1",
         "encode-utf8": "^1.0.3",
@@ -20758,6 +20783,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
       "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -20768,6 +20794,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -20780,6 +20807,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -20791,6 +20819,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -20805,6 +20834,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -20816,6 +20846,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -20828,12 +20859,14 @@
     "node_modules/qrcode/node_modules/y18n": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
     },
     "node_modules/qrcode/node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
       "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
       "dependencies": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -20855,6 +20888,7 @@
       "version": "18.1.3",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
       "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -24212,6 +24246,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.9.0.tgz",
       "integrity": "sha512-mQLFsAlKbYascZygFQh6lXuDjU5WHLoeZ8He4HqMnWfasM96V6rDbeFkw1XeG54xycmDonr/Jb4xgviHtuySrA==",
+      "dev": true,
       "dependencies": {
         "proxy-compare": "2.4.0",
         "use-sync-external-store": "1.2.0"
@@ -25469,7 +25504,7 @@
     },
     "packages/web3wallet": {
       "name": "@walletconnect/web3wallet",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/auth-client": "^2.0.3",
@@ -25498,14 +25533,22 @@
         "@walletconnect/types": "2.4.10",
         "@walletconnect/universal-provider": "2.4.10",
         "@walletconnect/utils": "2.4.10",
-        "@web3modal/standalone": "^2.2.0",
         "events": "^3.3.0"
       },
       "devDependencies": {
+        "@web3modal/standalone": "^2.2.0",
         "ethereum-test-network": "0.1.6",
         "ethers": "5.6.9",
         "uint8arrays": "^3.1.0",
         "web3": "1.7.5"
+      },
+      "peerDependencies": {
+        "@web3modal/standalone": ">=2"
+      },
+      "peerDependenciesMeta": {
+        "@web3modal/standalone": {
+          "optional": true
+        }
       }
     },
     "providers/signer-connection": {
@@ -28328,12 +28371,14 @@
     "@lit-labs/ssr-dom-shim": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.0.0.tgz",
-      "integrity": "sha512-ic93MBXfApIFTrup4a70M/+ddD8xdt2zxxj9sRwHQzhS9ag/syqkD8JPdTXsc1gUy2K8TTirhlCqyTEM/sifNw=="
+      "integrity": "sha512-ic93MBXfApIFTrup4a70M/+ddD8xdt2zxxj9sRwHQzhS9ag/syqkD8JPdTXsc1gUy2K8TTirhlCqyTEM/sifNw==",
+      "dev": true
     },
     "@lit/reactive-element": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.1.tgz",
       "integrity": "sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==",
+      "dev": true,
       "requires": {
         "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
@@ -28342,6 +28387,7 @@
       "version": "10.15.1",
       "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.15.1.tgz",
       "integrity": "sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==",
+      "dev": true,
       "requires": {
         "@motionone/easing": "^10.15.1",
         "@motionone/types": "^10.15.1",
@@ -28353,6 +28399,7 @@
       "version": "10.15.5",
       "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.15.5.tgz",
       "integrity": "sha512-Xc5avlgyh3xukU9tydh9+8mB8+2zAq+WlLsC3eEIp7Ax7DnXgY7Bj/iv0a4X2R9z9ZFZiaXK3BO0xMYHKbAAdA==",
+      "dev": true,
       "requires": {
         "@motionone/animation": "^10.15.1",
         "@motionone/generators": "^10.15.1",
@@ -28366,6 +28413,7 @@
       "version": "10.15.1",
       "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.15.1.tgz",
       "integrity": "sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==",
+      "dev": true,
       "requires": {
         "@motionone/utils": "^10.15.1",
         "tslib": "^2.3.1"
@@ -28375,6 +28423,7 @@
       "version": "10.15.1",
       "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.15.1.tgz",
       "integrity": "sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==",
+      "dev": true,
       "requires": {
         "@motionone/types": "^10.15.1",
         "@motionone/utils": "^10.15.1",
@@ -28385,6 +28434,7 @@
       "version": "10.15.5",
       "resolved": "https://registry.npmjs.org/@motionone/svelte/-/svelte-10.15.5.tgz",
       "integrity": "sha512-Xyxtgp7BlVnSBwcoFmXGHUVnpNktzeXsEifu2NJJWc7VGuxutDsBZxNdz80qvpLIC5MeBa1wh7GGegZzTm1msg==",
+      "dev": true,
       "requires": {
         "@motionone/dom": "^10.15.5",
         "tslib": "^2.3.1"
@@ -28393,12 +28443,14 @@
     "@motionone/types": {
       "version": "10.15.1",
       "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.15.1.tgz",
-      "integrity": "sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA=="
+      "integrity": "sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA==",
+      "dev": true
     },
     "@motionone/utils": {
       "version": "10.15.1",
       "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.15.1.tgz",
       "integrity": "sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==",
+      "dev": true,
       "requires": {
         "@motionone/types": "^10.15.1",
         "hey-listen": "^1.0.8",
@@ -28409,6 +28461,7 @@
       "version": "10.15.5",
       "resolved": "https://registry.npmjs.org/@motionone/vue/-/vue-10.15.5.tgz",
       "integrity": "sha512-cUENrLYAolUacHvCgU+8wF9OgSlVutfWbHMLERI/bElCJ+e2YVQvG/CpGhIM5fYOOJzuvg2T2wHmLLmvJoavEw==",
+      "dev": true,
       "requires": {
         "@motionone/dom": "^10.15.5",
         "tslib": "^2.3.1"
@@ -30170,7 +30223,8 @@
     "@types/trusted-types": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
-      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
+      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "17.0.19",
@@ -30829,6 +30883,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@web3modal/core/-/core-2.2.0.tgz",
       "integrity": "sha512-Kafg/KtK6S9x0Ofcaq9hj7dRK5/541nM+LnayPmHxx4fSrDgcM9YYhL12fI4BG1xGOJwkeZjgFOtS0qf123Cjw==",
+      "dev": true,
       "requires": {
         "buffer": "6.0.3",
         "valtio": "1.9.0"
@@ -30838,6 +30893,7 @@
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
           "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.2.1"
@@ -30849,6 +30905,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@web3modal/standalone/-/standalone-2.2.0.tgz",
       "integrity": "sha512-cLFW4VamSJ7L4sM5OGmr1SHK3FgyLUMEaacvHsCA3XSvUF0LxbMC+N4uBsONrW4c0JyIjTdeii1GqG4B3jwn7Q==",
+      "dev": true,
       "requires": {
         "@web3modal/core": "2.2.0",
         "@web3modal/ui": "2.2.0"
@@ -30858,6 +30915,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@web3modal/ui/-/ui-2.2.0.tgz",
       "integrity": "sha512-jcV5C9AuMdsFdf6Ljsr0v2lInu8FJJyXcZPaMHkgYNIczzgMEpDE+UOA7hLnyCTUxM9R0AgRcgfTyMWb9H8Ssw==",
+      "dev": true,
       "requires": {
         "@web3modal/core": "2.2.0",
         "lit": "2.6.1",
@@ -32669,7 +32727,8 @@
     "dijkstrajs": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.2.tgz",
-      "integrity": "sha512-QV6PMaHTCNmKSeP6QoXhVTw9snc9VD8MulTT0Bd99Pacp4SS1cjcrYPgBPmibqKVtMJJfqC6XvOXgPMEEPH/fg=="
+      "integrity": "sha512-QV6PMaHTCNmKSeP6QoXhVTw9snc9VD8MulTT0Bd99Pacp4SS1cjcrYPgBPmibqKVtMJJfqC6XvOXgPMEEPH/fg==",
+      "dev": true
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -32757,7 +32816,8 @@
     "encode-utf8": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
-      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw=="
+      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==",
+      "dev": true
     },
     "encodeurl": {
       "version": "1.0.2"
@@ -36043,7 +36103,8 @@
     "hey-listen": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -37335,6 +37396,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/lit/-/lit-2.6.1.tgz",
       "integrity": "sha512-DT87LD64f8acR7uVp7kZfhLRrHkfC/N4BVzAtnw9Yg8087mbBJ//qedwdwX0kzDbxgPccWRW6mFwGbRQIxy0pw==",
+      "dev": true,
       "requires": {
         "@lit/reactive-element": "^1.6.0",
         "lit-element": "^3.2.0",
@@ -37345,6 +37407,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.2.tgz",
       "integrity": "sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==",
+      "dev": true,
       "requires": {
         "@lit/reactive-element": "^1.3.0",
         "lit-html": "^2.2.0"
@@ -37354,6 +37417,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.6.1.tgz",
       "integrity": "sha512-Z3iw+E+3KKFn9t2YKNjsXNEu/LRLI98mtH/C6lnFg7kvaqPIzPn124Yd4eT/43lyqrejpc5Wb6BHq3fdv4S8Rw==",
+      "dev": true,
       "requires": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -38777,6 +38841,7 @@
       "version": "10.15.5",
       "resolved": "https://registry.npmjs.org/motion/-/motion-10.15.5.tgz",
       "integrity": "sha512-ejP6KioN4pigTGxL93APzOnvtLklParL59UQB2T3HWXQBxFcIp5/7YXFmkgiA6pNKKzjvnLhnonRBN5iSFMnNw==",
+      "dev": true,
       "requires": {
         "@motionone/animation": "^10.15.1",
         "@motionone/dom": "^10.15.5",
@@ -39926,7 +39991,8 @@
     "pngjs": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -40098,7 +40164,8 @@
     "proxy-compare": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.4.0.tgz",
-      "integrity": "sha512-FD8KmQUQD6Mfpd0hywCOzcon/dbkFP8XBd9F1ycbKtvVsfv6TsFUKJ2eC0Iz2y+KzlkdT1Z8SY6ZSgm07zOyqg=="
+      "integrity": "sha512-FD8KmQUQD6Mfpd0hywCOzcon/dbkFP8XBd9F1ycbKtvVsfv6TsFUKJ2eC0Iz2y+KzlkdT1Z8SY6ZSgm07zOyqg==",
+      "dev": true
     },
     "proxy-from-env": {
       "version": "1.1.0",
@@ -40149,6 +40216,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.1.tgz",
       "integrity": "sha512-nS8NJ1Z3md8uTjKtP+SGGhfqmTCs5flU/xR623oI0JX+Wepz9R8UrRVCTBTJm3qGw3rH6jJ6MUHjkDx15cxSSg==",
+      "dev": true,
       "requires": {
         "dijkstrajs": "^1.0.1",
         "encode-utf8": "^1.0.3",
@@ -40160,6 +40228,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
           "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
           "requires": {
             "string-width": "^4.2.0",
             "strip-ansi": "^6.0.0",
@@ -40170,6 +40239,7 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
@@ -40179,6 +40249,7 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
           }
@@ -40187,6 +40258,7 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -40195,6 +40267,7 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
           }
@@ -40203,6 +40276,7 @@
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
           "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
             "string-width": "^4.1.0",
@@ -40212,12 +40286,14 @@
         "y18n": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+          "dev": true
         },
         "yargs": {
           "version": "15.4.1",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
           "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "dev": true,
           "requires": {
             "cliui": "^6.0.0",
             "decamelize": "^1.2.0",
@@ -40236,6 +40312,7 @@
           "version": "18.1.3",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
           "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -42477,6 +42554,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.9.0.tgz",
       "integrity": "sha512-mQLFsAlKbYascZygFQh6lXuDjU5WHLoeZ8He4HqMnWfasM96V6rDbeFkw1XeG54xycmDonr/Jb4xgviHtuySrA==",
+      "dev": true,
       "requires": {
         "proxy-compare": "2.4.0",
         "use-sync-external-store": "1.2.0"

--- a/providers/ethereum-provider/README.md
+++ b/providers/ethereum-provider/README.md
@@ -20,7 +20,8 @@ const provider = await EthereumProvider.init({
   events, // OPTIONAL ethereum events
   rpcMap, // OPTIONAL rpc urls for each chain
   metadata, // OPTIONAL metadata of your app
-  showQrModal, // OPTIONAL - `true` by default
+  showQrModal, // OPTIONAL - `true` by default,
+  qrModalOptions, // OPTIONAL - `undefined` by default, see https://docs.walletconnect.com/2.0/web3modal/theming
 });
 ```
 

--- a/providers/ethereum-provider/package.json
+++ b/providers/ethereum-provider/package.json
@@ -50,13 +50,21 @@
     "@walletconnect/types": "2.4.10",
     "@walletconnect/universal-provider": "2.4.10",
     "@walletconnect/utils": "2.4.10",
-    "@web3modal/standalone": "^2.2.0",
     "events": "^3.3.0"
   },
   "devDependencies": {
+    "@web3modal/standalone": "^2.2.0",
     "ethereum-test-network": "0.1.6",
     "ethers": "5.6.9",
     "uint8arrays": "^3.1.0",
     "web3": "1.7.5"
+  },
+  "peerDependencies": {
+    "@web3modal/standalone": ">=2"
+  },
+  "peerDependenciesMeta": {
+    "@web3modal/standalone": {
+      "optional": true
+    }
   }
 }

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -57,6 +57,7 @@ export interface EthereumRpcConfig {
   projectId: string;
   metadata?: Metadata;
   showQrModal: boolean;
+  qrModalOptions?: Parameters<Web3Modal["setTheme"]>[0];
 }
 export interface ConnectOps {
   chains?: number[];
@@ -182,6 +183,7 @@ export interface EthereumProviderOptions {
   rpcMap?: EthereumRpcMap;
   metadata?: Metadata;
   showQrModal?: boolean;
+  qrModalOptions?: Parameters<Web3Modal["setTheme"]>[0];
 }
 
 export class EthereumProvider implements IEthereumProvider {
@@ -463,12 +465,18 @@ export class EthereumProvider implements IEthereumProvider {
     this.registerEventListeners();
     await this.loadPersistedSession();
     if (this.rpc.showQrModal) {
-      const { Web3Modal } = await import("@web3modal/standalone");
-      this.modal = new Web3Modal({
-        walletConnectVersion: 2,
-        projectId: this.rpc.projectId,
-        standaloneChains: this.rpc.chains,
-      });
+      try {
+        const { Web3Modal } = await import("@web3modal/standalone");
+        this.modal = new Web3Modal({
+          walletConnectVersion: 2,
+          projectId: this.rpc.projectId,
+          standaloneChains: this.rpc.chains,
+          themeMode: this.rpc.qrModalOptions?.themeMode,
+          themeVariables: this.rpc.qrModalOptions?.themeVariables,
+        });
+      } catch {
+        throw new Error("To use QR modal, please install @web3modal/standalone package");
+      }
     }
   }
 

--- a/providers/ethereum-provider/test/index.spec.ts
+++ b/providers/ethereum-provider/test/index.spec.ts
@@ -41,6 +41,12 @@ describe("EthereumProvider", function () {
       methods: TEST_ETHEREUM_METHODS_REQUIRED,
       optionalMethods: TEST_ETHEREUM_METHODS_OPTIONAL,
       showQrModal: true,
+      qrModalOptions: {
+        themeMode: "dark",
+        themeVariables: {
+          "--w3m-z-index": "99",
+        },
+      },
     });
     walletClient = await WalletClient.init(provider, TEST_WALLET_CLIENT_OPTS);
     await provider.connect({


### PR DESCRIPTION
# Description

- Makes web3modal an optional peer dependency, with install error thrown when necessary
- Exposes modal's theming options on new `qrModalOptions` argument

## How Has This Been Tested?

Local tests

## Due Diligence

- [x] Breaking change
- [x] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
