### PR TITLE
fix: catch request error

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -255,7 +255,7 @@ export function createExpiringPromise<T>(promise: Promise<T>, expiry: number) {
     try {
       const res = await promise;
       resolve(res);
-    } catch(error) {
+    } catch (error) {
       reject(error);
     }
     clearTimeout(timeout);

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -252,9 +252,13 @@ export function createDelayedPromise<T>(
 export function createExpiringPromise<T>(promise: Promise<T>, expiry: number) {
   return new Promise(async (resolve, reject) => {
     const timeout = setTimeout(() => reject(), expiry);
-    const res = await promise;
+    try {
+      const res = await promise;
+      resolve(res);
+    } catch(error) {
+      reject(error);
+    }
     clearTimeout(timeout);
-    resolve(res);
   });
 }
 


### PR DESCRIPTION
# Description
Catch request error in `createExpiringPromise` helper.

Partial Resolves
[Pairing didn't respect error from the relay #2128](https://github.com/WalletConnect/walletconnect-monorepo/issues/2128)

## How Has This Been Tested?
Local demo wallet

![image](https://user-images.githubusercontent.com/16781093/226290388-28f7dcff-6bad-42e1-9558-1da7a3935af7.png)

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
