### PR TITLE
fix: catches correctly `socket stalled` rejection

### DIFF
--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -189,10 +189,13 @@ export class Relayer extends IRelayer {
           });
         }),
         await Promise.race([
-          new Promise<void>(async (resolve) => {
-            await createExpiringPromise(this.provider.connect(), 5_000, "socket stalled");
-            this.removeListener(RELAYER_EVENTS.transport_closed, this.rejectTransportOpen);
-            resolve();
+          new Promise<void>(async (resolve, reject) => {
+            await createExpiringPromise(this.provider.connect(), 5_000, "socket stalled")
+              .catch((e) => reject(e))
+              .then(() => resolve())
+              .finally(() =>
+                this.removeListener(RELAYER_EVENTS.transport_closed, this.rejectTransportOpen),
+              );
           }),
           new Promise<void>((_res) =>
             // rejects pending promise if transport is closed before connection is established


### PR DESCRIPTION
# Description
as per title...
Extension of PR https://github.com/WalletConnect/walletconnect-monorepo/pull/2108

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->


## How Has This Been Tested?
Ci runs
https://github.com/WalletConnect/rs-relay/actions/runs/4479534370/jobs/7873720848
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
