### PR TITLE
fix: clients init retry

### DIFF
--- a/packages/sign-client/test/shared/init.ts
+++ b/packages/sign-client/test/shared/init.ts
@@ -62,9 +62,8 @@ export async function initTwoPairedClients(
       pairingA = settled.pairingA;
       sessionA = settled.sessionA;
     } catch (e) {
-      console.log("initTwoPairedClients retrying ...", retries, e);
-      await deleteClients(clients);
-      clients = await initTwoClients();
+      console.error("Error initTwoPairedClients, attempts: ", retries, e);
+      if (clients) await deleteClients(clients);
     }
     retries++;
   }


### PR DESCRIPTION
# Description
Added a check in `initTwoPairedClients` catch statement if the clients are initialized before disconnecting after
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?
dogfooding
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
