### PR TITLE
chore(w3w): update auth-client to latest, other @walletconnect/* deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6650,26 +6650,26 @@
       }
     },
     "node_modules/@walletconnect/auth-client": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/auth-client/-/auth-client-2.0.3.tgz",
-      "integrity": "sha512-PU28c1xmx27arRcd675/CdJrK5QHntdPaMLkqOKmrFmtgi5L/kS1vPFPJ3txT/eXyuIf3cQDsore6G4gr/iajw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/auth-client/-/auth-client-2.0.4.tgz",
+      "integrity": "sha512-lLp9w1P8zS4wf/Ji/7mIpxvAf67mKwh53Z8R49qXVNM2uLZwoelpL0wTfgF5c5tFQteOZ87+MPP2uftD3VU5HQ==",
       "dependencies": {
         "@ethersproject/hash": "^5.7.0",
         "@ethersproject/transactions": "^5.7.0",
         "@stablelib/random": "1.0.2",
-        "@walletconnect/core": "^2.2.1",
+        "@walletconnect/core": "2.5.1",
         "@walletconnect/events": "1.0.0",
         "@walletconnect/heartbeat": "1.0.0",
-        "@walletconnect/jsonrpc-provider": "^1.0.6",
-        "@walletconnect/jsonrpc-utils": "^1.0.4",
-        "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/time": "^1.0.2",
-        "@walletconnect/utils": "^2.2.1",
+        "@walletconnect/jsonrpc-provider": "1.0.10",
+        "@walletconnect/jsonrpc-utils": "1.0.6",
+        "@walletconnect/logger": "2.0.1",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/utils": "2.5.1",
         "events": "^3.3.0",
         "isomorphic-unfetch": "^3.1.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16 <17"
       }
     },
     "node_modules/@walletconnect/auth-client/node_modules/@walletconnect/events": {
@@ -25504,13 +25504,13 @@
       "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@walletconnect/auth-client": "^2.0.3",
-        "@walletconnect/core": "^2.4.10",
-        "@walletconnect/jsonrpc-utils": "^1.0.4",
+        "@walletconnect/auth-client": "^2.0.4",
+        "@walletconnect/core": "^2.5.1",
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sign-client": "^2.4.10",
-        "@walletconnect/types": "^2.4.10",
-        "@walletconnect/utils": "^2.4.10"
+        "@walletconnect/sign-client": "^2.5.1",
+        "@walletconnect/types": "^2.5.1",
+        "@walletconnect/utils": "^2.5.1"
       },
       "devDependencies": {
         "@ethersproject/wallet": "^5.7.0",
@@ -30314,21 +30314,21 @@
       }
     },
     "@walletconnect/auth-client": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/auth-client/-/auth-client-2.0.3.tgz",
-      "integrity": "sha512-PU28c1xmx27arRcd675/CdJrK5QHntdPaMLkqOKmrFmtgi5L/kS1vPFPJ3txT/eXyuIf3cQDsore6G4gr/iajw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/auth-client/-/auth-client-2.0.4.tgz",
+      "integrity": "sha512-lLp9w1P8zS4wf/Ji/7mIpxvAf67mKwh53Z8R49qXVNM2uLZwoelpL0wTfgF5c5tFQteOZ87+MPP2uftD3VU5HQ==",
       "requires": {
         "@ethersproject/hash": "^5.7.0",
         "@ethersproject/transactions": "^5.7.0",
         "@stablelib/random": "1.0.2",
-        "@walletconnect/core": "^2.2.1",
+        "@walletconnect/core": "2.5.1",
         "@walletconnect/events": "1.0.0",
         "@walletconnect/heartbeat": "1.0.0",
-        "@walletconnect/jsonrpc-provider": "^1.0.6",
-        "@walletconnect/jsonrpc-utils": "^1.0.4",
-        "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/time": "^1.0.2",
-        "@walletconnect/utils": "^2.2.1",
+        "@walletconnect/jsonrpc-provider": "1.0.10",
+        "@walletconnect/jsonrpc-utils": "1.0.6",
+        "@walletconnect/logger": "2.0.1",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/utils": "2.5.1",
         "events": "^3.3.0",
         "isomorphic-unfetch": "^3.1.0"
       },
@@ -30843,13 +30843,13 @@
       "version": "file:packages/web3wallet",
       "requires": {
         "@ethersproject/wallet": "^5.7.0",
-        "@walletconnect/auth-client": "^2.0.3",
-        "@walletconnect/core": "^2.4.10",
-        "@walletconnect/jsonrpc-utils": "^1.0.4",
+        "@walletconnect/auth-client": "^2.0.4",
+        "@walletconnect/core": "^2.5.1",
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sign-client": "^2.4.10",
-        "@walletconnect/types": "^2.4.10",
-        "@walletconnect/utils": "^2.4.10",
+        "@walletconnect/sign-client": "^2.5.1",
+        "@walletconnect/types": "^2.5.1",
+        "@walletconnect/utils": "^2.5.1",
         "lokijs": "^1.5.12"
       }
     },

--- a/packages/web3wallet/package.json
+++ b/packages/web3wallet/package.json
@@ -28,13 +28,13 @@
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },
   "dependencies": {
-    "@walletconnect/auth-client": "^2.0.3",
-    "@walletconnect/core": "^2.4.10",
-    "@walletconnect/jsonrpc-utils": "^1.0.4",
+    "@walletconnect/auth-client": "^2.0.4",
+    "@walletconnect/core": "^2.5.1",
+    "@walletconnect/jsonrpc-utils": "^1.0.6",
     "@walletconnect/logger": "^2.0.1",
-    "@walletconnect/sign-client": "^2.4.10",
-    "@walletconnect/types": "^2.4.10",
-    "@walletconnect/utils": "^2.4.10"
+    "@walletconnect/sign-client": "^2.5.1",
+    "@walletconnect/types": "^2.5.1",
+    "@walletconnect/utils": "^2.5.1"
   },
   "devDependencies": {
     "@ethersproject/wallet": "^5.7.0",


### PR DESCRIPTION
# Description

- Ensures auth-client has latest fixes and dependencies accounted for in web3wallet

## How Has This Been Tested?

- Unit tests
- Auth samples: https://react-auth-dapp.walletconnect.com/ and https://react-auth-wallet.walletconnect.com/

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
