### PR TITLE
fix: get pending requests

### DIFF
--- a/packages/core/src/controllers/store.ts
+++ b/packages/core/src/controllers/store.ts
@@ -50,14 +50,14 @@ export class Store<Key, Data extends Record<string, any>> extends IStore<Key, Da
       await this.restore();
 
       this.cached.forEach((value) => {
-        if (isProposalStruct(value)) {
+        if (!isUndefined(this.getKey)) {
+          this.map.set(this.getKey(value), value);
+        } else if (isProposalStruct(value)) {
           // TODO(pedro) revert type casting as any
           this.map.set(value.id as any, value);
         } else if (isSessionStruct(value)) {
           // TODO(pedro) revert type casting as any
           this.map.set(value.topic as any, value);
-        } else if (this.getKey && value !== null && !isUndefined(value)) {
-          this.map.set(this.getKey(value), value);
         }
       });
 

--- a/packages/core/src/controllers/store.ts
+++ b/packages/core/src/controllers/store.ts
@@ -50,7 +50,7 @@ export class Store<Key, Data extends Record<string, any>> extends IStore<Key, Da
       await this.restore();
 
       this.cached.forEach((value) => {
-        if (!isUndefined(this.getKey)) {
+        if (this.getKey && value !== null && !isUndefined(value)) {
           this.map.set(this.getKey(value), value);
         } else if (isProposalStruct(value)) {
           // TODO(pedro) revert type casting as any

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -45,7 +45,7 @@ describe("Store", () => {
         (val) => val.id,
       );
       await store.init();
-      for (let id of ids) {
+      for (const id of ids) {
         expect(store.keys).includes(id);
       }
     });
@@ -160,6 +160,44 @@ describe("Store", () => {
       const filtered = store.getAll({ active: true });
       expect(filtered.length).to.equal(1);
       expect(filtered[0].active).to.equal(true);
+    });
+  });
+  describe("persistence", () => {
+    type MockValue = { id: string; value: string };
+    it("repopulate values with getKey correctly after restart", async () => {
+      const coreOptions = {
+        ...TEST_CORE_OPTIONS,
+        storageOptions: { database: "tmp/store-persistence.db" },
+      };
+      const core = new Core(coreOptions);
+      const store = new Store<string, MockValue>(
+        core,
+        logger,
+        MOCK_STORE_NAME,
+        undefined,
+        (val) => val.value,
+      );
+      await store.init();
+      const values = [
+        { id: "1", value: "foo" },
+        { id: "2", value: "bar" },
+        { id: "3", value: "baz" },
+      ];
+      values.forEach((val) => store.set(val.id, val));
+
+      expect(store.getAll()).to.toMatchObject(values);
+
+      const coreAfter = new Core(coreOptions);
+
+      const storeAfter = new Store<string, MockValue>(
+        coreAfter,
+        logger,
+        MOCK_STORE_NAME,
+        undefined,
+        (val) => val.value,
+      );
+      await storeAfter.init();
+      expect(storeAfter.getAll()).to.toMatchObject(values);
     });
   });
 });

--- a/packages/sign-client/src/controllers/pendingRequest.ts
+++ b/packages/sign-client/src/controllers/pendingRequest.ts
@@ -5,6 +5,12 @@ import { REQUEST_CONTEXT, SIGN_CLIENT_STORAGE_PREFIX } from "../constants";
 
 export class PendingRequest extends Store<number, PendingRequestTypes.Struct> {
   constructor(public core: ICore, public logger: Logger) {
-    super(core, logger, REQUEST_CONTEXT, SIGN_CLIENT_STORAGE_PREFIX);
+    super(
+      core,
+      logger,
+      REQUEST_CONTEXT,
+      SIGN_CLIENT_STORAGE_PREFIX,
+      (val: PendingRequestTypes.Struct) => val.id,
+    );
   }
 }


### PR DESCRIPTION
# Description
Fixed a bug where `getPendingRequests` was returning a single result after reloading due to an issue in the `store` repopulating incorrectly from persistence
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?
persistence test
dogfooding
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
