### PR TITLE
feat(core): adds `getPayloadSenderPublicKey` method to `core.crypto`

### DIFF
--- a/packages/core/src/controllers/crypto.ts
+++ b/packages/core/src/controllers/crypto.ts
@@ -16,7 +16,10 @@ import {
   isTypeOneEnvelope,
   deserialize,
   decodeTypeByte,
+  BASE16,
 } from "@walletconnect/utils";
+import { toString } from "uint8arrays";
+
 import { CRYPTO_CONTEXT, CRYPTO_CLIENT_SEED, CRYPTO_JWT_TTL } from "../constants";
 import { KeyChain } from "./keychain";
 
@@ -129,10 +132,18 @@ export class Crypto implements ICrypto {
     return payload;
   };
 
-  public getPayloadType(encoded: string): number {
+  public getPayloadType: ICrypto["getPayloadType"] = (encoded) => {
     const deserialized = deserialize(encoded);
     return decodeTypeByte(deserialized.type);
-  }
+  };
+
+  public getPayloadSenderPublicKey: ICrypto["getPayloadSenderPublicKey"] = (encoded) => {
+    const deserialized = deserialize(encoded);
+    return deserialized.senderPublicKey
+      ? toString(deserialized.senderPublicKey, BASE16)
+      : undefined;
+  };
+
   // ---------- Private ----------------------------------------------- //
 
   private async setPrivateKey(publicKey: string, privateKey: string): Promise<string> {

--- a/packages/types/src/core/crypto.ts
+++ b/packages/types/src/core/crypto.ts
@@ -104,4 +104,5 @@ export abstract class ICrypto {
 
   public abstract signJWT(aud: string): Promise<string>;
   public abstract getPayloadType(encoded: string): number;
+  public abstract getPayloadSenderPublicKey(encoded: string): string | undefined;
 }


### PR DESCRIPTION
# Description
- Adds `core.crypto.getPayloadSenderPublicKey` method to return only the encoded payload's `senderPublicKey` (if present), similarly to what `getPayloadType` already does.
- This is necessary in Push (and probably useful in Chat where `TYPE_1` envelope messages are also used), as the response for `wc_pushRequest` no longer contains the `senderPublicKey` (see change [here](https://github.com/WalletConnect/walletconnect-docs/pull/502/files#diff-13680fc4bd48de744b4ba1a6debcf4f699f65a2abfcf54669e9d29cf527235aeR50)), leaving extraction from the `TYPE_1` envelope encoding as the only option.
- Also: formalises type reference for existing `getPayloadType`

## How Has This Been Tested?

- Pre-released as `core@2.5.2-4198a778` canary
- Integrated in PushClient via above canary and tested via unit tests + dogfooding in push dapp/wallet samples

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
