### PR TITLE
feat: auto namespaces

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -317,3 +317,7 @@ export function isExpired(expiry: number) {
 export function engineEvent(event: EngineTypes.Event, id?: number | string | undefined) {
   return `${event}${id ? `:${id}` : ""}`;
 }
+
+export function mergeArrays<T>(a: T[] = [], b: T[] = []): T[] {
+  return [...new Set([...a, ...b])];
+}

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -65,14 +65,25 @@ export function getRequiredNamespacesFromNamespaces(
   return required;
 }
 
-export function buildApprovedNamespaces(params: {
+export type BuildApprovedNamespacesParams = {
   requiredNamespaces: ProposalTypes.RequiredNamespaces;
   optionalNamespaces?: ProposalTypes.OptionalNamespaces;
   supportedNamespaces: Record<
     string,
     { chains: string[]; methods: string[]; events: string[]; accounts: string[] }
   >;
-}): SessionTypes.Namespaces {
+};
+
+/**
+ * util designed for Wallets that builds namespaces structure by provided supported chains, methods, events & accounts.
+ * It takes required & optional namespaces provided in the session proposal
+ * along with the supported chains/methods/events/accounts by the wallet and returns a structured namespaces object
+ * @param {BuildApprovedNamespacesParams} params
+ * @returns {SessionTypes.Namespaces}
+ */
+export function buildApprovedNamespaces(
+  params: BuildApprovedNamespacesParams,
+): SessionTypes.Namespaces {
   const { requiredNamespaces, optionalNamespaces = {}, supportedNamespaces } = params;
 
   const normalizedRequired = normalizeNamespaces(requiredNamespaces);

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -169,18 +169,21 @@ export function parseNamespaceKey(namespace: string) {
 
 /**
  * Converts
+ * ```
  * {
  *  "eip155:1": {...},
  *  "eip155:2": {...},
  * }
+ * ```
  * into
+ * ```
  * {
  *  "eip155": {
  *      chains: ["eip155:1", "eip155:2"],
  *      ...
  *    }
  * }
- *
+ *```
  */
 export function normalizeNamespaces(
   namespaces: ProposalTypes.RequiredNamespaces,

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -70,7 +70,7 @@ export function buildApprovedNamespaces(params: {
   optionalNamespaces?: ProposalTypes.OptionalNamespaces;
   supportedNamespaces: Record<
     string,
-    { chains?: string[]; methods: string[]; events: string[]; accounts: string[] }
+    { chains: string[]; methods: string[]; events: string[]; accounts: string[] }
   >;
 }): SessionTypes.Namespaces {
   const { requiredNamespaces, optionalNamespaces = {}, supportedNamespaces } = params;
@@ -81,9 +81,7 @@ export function buildApprovedNamespaces(params: {
   const namespaces = {};
   // build approved namespaces
   Object.keys(supportedNamespaces).forEach((namespace) => {
-    const supportedChains = [
-      ...new Set(isCaipNamespace(namespace) ? [namespace] : supportedNamespaces[namespace].chains),
-    ];
+    const supportedChains = supportedNamespaces[namespace].chains;
     const supportedMethods = supportedNamespaces[namespace].methods;
     const supportedEvents = supportedNamespaces[namespace].events;
     const supportedAccounts = supportedNamespaces[namespace].accounts;
@@ -104,7 +102,7 @@ export function buildApprovedNamespaces(params: {
 
   // assign accounts for the required namespaces
   Object.keys(normalizedRequired).forEach((requiredNamespace) => {
-    const chains = supportedNamespaces[requiredNamespace].chains?.filter((chain) =>
+    const chains = supportedNamespaces[requiredNamespace].chains.filter((chain) =>
       normalizedRequired[requiredNamespace]?.chains?.includes(chain),
     );
     const methods = supportedNamespaces[requiredNamespace].methods.filter((method) =>
@@ -119,7 +117,7 @@ export function buildApprovedNamespaces(params: {
       methods,
       events,
       accounts: chains
-        ?.map((chain: string) =>
+        .map((chain: string) =>
           supportedNamespaces[requiredNamespace].accounts.filter((account: string) =>
             account.includes(chain),
           ),
@@ -133,7 +131,7 @@ export function buildApprovedNamespaces(params: {
     if (!supportedNamespaces[optionalNamespace]) return;
 
     const chainsToAdd = normalizedOptional[optionalNamespace]?.chains?.filter((chain) =>
-      supportedNamespaces[optionalNamespace].chains?.includes(chain),
+      supportedNamespaces[optionalNamespace].chains.includes(chain),
     );
     const methodsToAdd = supportedNamespaces[optionalNamespace].methods.filter((method) =>
       normalizedOptional[optionalNamespace]?.methods?.includes(method),

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -72,14 +72,8 @@ export function buildApprovedNamespaces(params: {
     string,
     { chains?: string[]; methods: string[]; events: string[]; accounts: string[] }
   >;
-  sessionProperties?: ProposalTypes.SessionProperties;
-}) {
-  const {
-    requiredNamespaces,
-    optionalNamespaces = {},
-    supportedNamespaces,
-    sessionProperties,
-  } = params;
+}): SessionTypes.Namespaces {
+  const { requiredNamespaces, optionalNamespaces = {}, supportedNamespaces } = params;
 
   const normalizedRequired = normalizeNamespaces(requiredNamespaces);
   const normalizedOptional = normalizeNamespaces(optionalNamespaces);
@@ -164,10 +158,7 @@ export function buildApprovedNamespaces(params: {
     };
   });
 
-  return {
-    ...approvedNamespaces,
-    ...(sessionProperties && { sessionProperties }),
-  };
+  return approvedNamespaces;
 }
 
 export function isCaipNamespace(namespace: string): boolean {

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -78,8 +78,8 @@ export function buildApprovedNamespaces(params: {
   const normalizedRequired = normalizeNamespaces(requiredNamespaces);
   const normalizedOptional = normalizeNamespaces(optionalNamespaces);
 
-  const namespaces = {};
   // build approved namespaces
+  const namespaces = {};
   Object.keys(supportedNamespaces).forEach((namespace) => {
     const supportedChains = supportedNamespaces[namespace].chains;
     const supportedMethods = supportedNamespaces[namespace].methods;
@@ -112,17 +112,19 @@ export function buildApprovedNamespaces(params: {
       normalizedRequired[requiredNamespace]?.events?.includes(event),
     );
 
+    const accounts = chains
+      .map((chain: string) =>
+        supportedNamespaces[requiredNamespace].accounts.filter((account: string) =>
+          account.includes(chain),
+        ),
+      )
+      .flat();
+
     approvedNamespaces[requiredNamespace] = {
       chains,
       methods,
       events,
-      accounts: chains
-        .map((chain: string) =>
-          supportedNamespaces[requiredNamespace].accounts.filter((account: string) =>
-            account.includes(chain),
-          ),
-        )
-        .flat(),
+      accounts,
     };
   });
 

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -1,5 +1,6 @@
 import { ProposalTypes, SessionTypes } from "@walletconnect/types";
-import { isValidNamespaces } from "./validators";
+import { mergeArrays } from "./misc";
+import { isConformingNamespaces, isValidNamespaces, isValidObject } from "./validators";
 
 export function getAccountsChains(accounts: SessionTypes.Namespace["accounts"]) {
   const chains: string[] = [];
@@ -62,4 +63,152 @@ export function getRequiredNamespacesFromNamespaces(
     };
   }
   return required;
+}
+
+export function buildApprovedNamespaces(params: {
+  requiredNamespaces: ProposalTypes.RequiredNamespaces;
+  optionalNamespaces?: ProposalTypes.OptionalNamespaces;
+  supportedNamespaces: Record<
+    string,
+    { chains?: string[]; methods: string[]; events: string[]; accounts: string[] }
+  >;
+  sessionProperties?: ProposalTypes.SessionProperties;
+}) {
+  const {
+    requiredNamespaces,
+    optionalNamespaces = {},
+    supportedNamespaces,
+    sessionProperties,
+  } = params;
+
+  const normalizedRequired = normalizeNamespaces(requiredNamespaces);
+  const normalizedOptional = normalizeNamespaces(optionalNamespaces);
+
+  const namespaces = {};
+  // build approved namespaces
+  Object.keys(supportedNamespaces).forEach((namespace) => {
+    const supportedChains = [
+      ...new Set(isCaipNamespace(namespace) ? [namespace] : supportedNamespaces[namespace].chains),
+    ];
+    const supportedMethods = supportedNamespaces[namespace].methods;
+    const supportedEvents = supportedNamespaces[namespace].events;
+    const supportedAccounts = supportedNamespaces[namespace].accounts;
+
+    namespaces[namespace] = {
+      chains: supportedChains,
+      methods: supportedMethods,
+      events: supportedEvents,
+      accounts: supportedAccounts,
+    };
+  });
+
+  // verify all required namespaces are supported
+  const err = isConformingNamespaces(requiredNamespaces, namespaces, "approve()");
+  if (err) throw new Error(err.message);
+
+  const approvedNamespaces = {};
+
+  // assign accounts for the required namespaces
+  Object.keys(normalizedRequired).forEach((requiredNamespace) => {
+    const chains = supportedNamespaces[requiredNamespace].chains?.filter((chain) =>
+      normalizedRequired[requiredNamespace]?.chains?.includes(chain),
+    );
+    const methods = supportedNamespaces[requiredNamespace].methods.filter((method) =>
+      normalizedRequired[requiredNamespace]?.methods?.includes(method),
+    );
+    const events = supportedNamespaces[requiredNamespace].events.filter((event) =>
+      normalizedRequired[requiredNamespace]?.events?.includes(event),
+    );
+
+    approvedNamespaces[requiredNamespace] = {
+      chains,
+      methods,
+      events,
+      accounts: chains
+        ?.map((chain: string) =>
+          supportedNamespaces[requiredNamespace].accounts.filter((account: string) =>
+            account.includes(chain),
+          ),
+        )
+        .flat(),
+    };
+  });
+
+  // add optional namespaces
+  Object.keys(normalizedOptional).forEach((optionalNamespace) => {
+    if (!supportedNamespaces[optionalNamespace]) return;
+
+    const chainsToAdd = normalizedOptional[optionalNamespace]?.chains?.filter((chain) =>
+      supportedNamespaces[optionalNamespace].chains?.includes(chain),
+    );
+    const methodsToAdd = supportedNamespaces[optionalNamespace].methods.filter((method) =>
+      normalizedOptional[optionalNamespace]?.methods?.includes(method),
+    );
+    const eventsToAdd = supportedNamespaces[optionalNamespace].events.filter((event) =>
+      normalizedOptional[optionalNamespace]?.events?.includes(event),
+    );
+
+    const accountsToAdd = chainsToAdd
+      ?.map((chain: string) =>
+        supportedNamespaces[optionalNamespace].accounts.filter((account: string) =>
+          account.includes(chain),
+        ),
+      )
+      .flat();
+
+    approvedNamespaces[optionalNamespace] = {
+      chains: mergeArrays(approvedNamespaces[optionalNamespace]?.chains, chainsToAdd),
+      methods: mergeArrays(approvedNamespaces[optionalNamespace]?.methods, methodsToAdd),
+      events: mergeArrays(approvedNamespaces[optionalNamespace]?.events, eventsToAdd),
+      accounts: mergeArrays(approvedNamespaces[optionalNamespace]?.accounts, accountsToAdd),
+    };
+  });
+
+  return {
+    ...approvedNamespaces,
+    ...(sessionProperties && { sessionProperties }),
+  };
+}
+
+export function isCaipNamespace(namespace: string): boolean {
+  return namespace.includes(":");
+}
+
+export function parseNamespaceKey(namespace: string) {
+  return isCaipNamespace(namespace) ? namespace.split(":")[0] : namespace;
+}
+
+/**
+ * Converts
+ * {
+ *  "eip155:1": {...},
+ *  "eip155:2": {...},
+ * }
+ * into
+ * {
+ *  "eip155": {
+ *      chains: ["eip155:1", "eip155:2"],
+ *      ...
+ *    }
+ * }
+ *
+ */
+export function normalizeNamespaces(
+  namespaces: ProposalTypes.RequiredNamespaces,
+): ProposalTypes.RequiredNamespaces {
+  const normalizedNamespaces = {} as ProposalTypes.RequiredNamespaces;
+  if (!isValidObject(namespaces)) return normalizedNamespaces;
+  for (const [key, values] of Object.entries(namespaces)) {
+    const chains = isCaipNamespace(key) ? [key] : values.chains;
+    const methods = values.methods || [];
+    const events = values.events || [];
+    const normalizedKey = parseNamespaceKey(key);
+    normalizedNamespaces[normalizedKey] = {
+      ...normalizedNamespaces[normalizedKey],
+      chains: mergeArrays(chains, normalizedNamespaces[normalizedKey]?.chains),
+      methods: mergeArrays(methods, normalizedNamespaces[normalizedKey]?.methods),
+      events: mergeArrays(events, normalizedNamespaces[normalizedKey]?.events),
+    };
+  }
+  return normalizedNamespaces;
 }

--- a/packages/utils/test/validators.spec.ts
+++ b/packages/utils/test/validators.spec.ts
@@ -329,7 +329,7 @@ describe("Validators", () => {
   });
 });
 describe("buildApprovedNamespaces (validators)", () => {
-  it("should build namespaces (config 1 - optional method)", async () => {
+  it("should build namespaces (config 1 - optional method)", () => {
     const required = {
       eip155: {
         chains: ["eip155:1"],
@@ -373,7 +373,7 @@ describe("buildApprovedNamespaces (validators)", () => {
     };
     expect(approvedNamespaces).to.deep.equal(expected);
   });
-  it("should build namespaces (config 2 - optional chain)", async () => {
+  it("should build namespaces (config 2 - optional chain)", () => {
     const required = {
       eip155: {
         chains: ["eip155:1"],
@@ -420,7 +420,7 @@ describe("buildApprovedNamespaces (validators)", () => {
     };
     expect(approvedNamespaces).to.deep.eq(expected);
   });
-  it("should build namespaces (config 3 - inline chain)", async () => {
+  it("should build namespaces (config 3 - inline chain)", () => {
     const required = {
       "eip155:1": {
         events: ["chainChanged"],
@@ -466,7 +466,7 @@ describe("buildApprovedNamespaces (validators)", () => {
     };
     expect(approvedNamespaces).to.deep.eq(expected);
   });
-  it("should build namespaces (config 4 - multiple inline chains)", async () => {
+  it("should build namespaces (config 4 - multiple inline chains)", () => {
     const required = {
       "eip155:1": {
         events: ["chainChanged"],
@@ -517,7 +517,7 @@ describe("buildApprovedNamespaces (validators)", () => {
     };
     expect(approvedNamespaces).to.deep.eq(expected);
   });
-  it("should build namespaces (config 5 - multiple inline chains)", async () => {
+  it("should build namespaces (config 5 - multiple inline chains)", () => {
     const required = {
       "eip155:1": {
         events: ["chainChanged"],
@@ -573,7 +573,7 @@ describe("buildApprovedNamespaces (validators)", () => {
     };
     expect(approvedNamespaces).to.deep.eq(expected);
   });
-  it("should build namespaces (config 6 - unsupported optional chains)", async () => {
+  it("should build namespaces (config 6 - unsupported optional chains)", () => {
     const required = {
       "eip155:1": {
         events: ["chainChanged"],
@@ -627,7 +627,7 @@ describe("buildApprovedNamespaces (validators)", () => {
     };
     expect(approvedNamespaces).to.deep.eq(expected);
   });
-  it("should build namespaces (config 7 - partially supported optional chains)", async () => {
+  it("should build namespaces (config 7 - partially supported optional chains)", () => {
     const required = {
       "eip155:1": {
         events: ["chainChanged"],
@@ -682,7 +682,7 @@ describe("buildApprovedNamespaces (validators)", () => {
     };
     expect(approvedNamespaces).to.deep.eq(expected);
   });
-  it("should build namespaces (config 8 - partially supported optional methods)", async () => {
+  it("should build namespaces (config 8 - partially supported optional methods)", () => {
     const required = {
       "eip155:1": {
         events: ["chainChanged"],
@@ -737,7 +737,7 @@ describe("buildApprovedNamespaces (validators)", () => {
     };
     expect(approvedNamespaces).to.deep.eq(expected);
   });
-  it("should build namespaces (config 9 - partially supported optional events)", async () => {
+  it("should build namespaces (config 9 - partially supported optional events)", () => {
     const required = {
       "eip155:1": {
         events: ["chainChanged"],
@@ -792,7 +792,7 @@ describe("buildApprovedNamespaces (validators)", () => {
     };
     expect(approvedNamespaces).to.deep.eq(expected);
   });
-  it("should build namespaces (config 10 - extra supported chains)", async () => {
+  it("should build namespaces (config 10 - extra supported chains)", () => {
     const required = {
       "eip155:1": {
         events: ["chainChanged"],
@@ -851,7 +851,7 @@ describe("buildApprovedNamespaces (validators)", () => {
     };
     expect(approvedNamespaces).to.deep.eq(expected);
   });
-  it("should build namespaces (config 11 - multiple namespaces - required)", async () => {
+  it("should build namespaces (config 11 - multiple namespaces - required)", () => {
     const required = {
       "eip155:1": {
         events: ["chainChanged"],

--- a/packages/utils/test/validators.spec.ts
+++ b/packages/utils/test/validators.spec.ts
@@ -1146,7 +1146,7 @@ describe("buildApprovedNamespaces (validators)", () => {
     },
   );
   it.fails(
-    "should throw while building namespaces (config 6 - partiall accounts for required chain)",
+    "should throw while building namespaces (config 6 - partial accounts for required chain)",
     () => {
       const required = {
         "eip155:1": {

--- a/packages/utils/test/validators.spec.ts
+++ b/packages/utils/test/validators.spec.ts
@@ -8,7 +8,7 @@ import {
   TEST_SESSION,
 } from "./shared/values";
 
-import { isConformingNamespaces, isSessionCompatible } from "../src";
+import { buildApprovedNamespaces, isConformingNamespaces, isSessionCompatible } from "../src";
 
 describe("Validators", () => {
   it("isSessionCompatible", () => {
@@ -326,5 +326,605 @@ describe("Validators", () => {
     const error = isConformingNamespaces(required, approved, "validators");
     expect(error).to.not.be.null;
     expect(error).to.throw;
+  });
+});
+describe("buildApprovedNamespaces (validators)", () => {
+  it("should build namespaces (config 1 - optional method)", async () => {
+    const required = {
+      eip155: {
+        chains: ["eip155:1"],
+        events: ["chainChanged"],
+        methods: ["personal_sign"],
+      },
+    };
+    const optional = {
+      eip155: {
+        chains: ["eip155:1"],
+        events: [""],
+        methods: ["eth_sendTransaction"],
+      },
+    };
+
+    const chains = ["eip155:1", "eip155:2", "eip155:3"];
+    const methods = ["personal_sign", "eth_sendTransaction", "eth_signTransaction"];
+    const events = ["chainChanged"];
+    const accounts = ["eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"];
+
+    const approvedNamespaces = buildApprovedNamespaces({
+      requiredNamespaces: required,
+      optionalNamespaces: optional,
+      supportedNamespaces: {
+        eip155: {
+          chains,
+          methods,
+          events,
+          accounts,
+        },
+      },
+    });
+
+    const expected = {
+      eip155: {
+        chains: ["eip155:1"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+        events,
+        accounts,
+      },
+    };
+    expect(approvedNamespaces).to.deep.equal(expected);
+  });
+  it("should build namespaces (config 2 - optional chain)", async () => {
+    const required = {
+      eip155: {
+        chains: ["eip155:1"],
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+    const optional = {
+      eip155: {
+        chains: ["eip155:2"],
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+
+    const chains = ["eip155:1", "eip155:2", "eip155:3"];
+    const methods = ["personal_sign", "eth_sendTransaction", "eth_signTransaction"];
+    const events = ["chainChanged"];
+    const accounts = [
+      "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+    ];
+
+    const approvedNamespaces = buildApprovedNamespaces({
+      requiredNamespaces: required,
+      optionalNamespaces: optional,
+      supportedNamespaces: {
+        eip155: {
+          chains,
+          methods,
+          events,
+          accounts,
+        },
+      },
+    });
+
+    const expected = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+        events,
+        accounts,
+      },
+    };
+    expect(approvedNamespaces).to.deep.eq(expected);
+  });
+  it("should build namespaces (config 3 - inline chain)", async () => {
+    const required = {
+      "eip155:1": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+    const optional = {
+      eip155: {
+        chains: ["eip155:2"],
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+
+    const chains = ["eip155:1", "eip155:2", "eip155:3"];
+    const methods = ["personal_sign", "eth_sendTransaction", "eth_signTransaction"];
+    const events = ["chainChanged"];
+    const accounts = [
+      "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+    ];
+
+    const approvedNamespaces = buildApprovedNamespaces({
+      requiredNamespaces: required,
+      optionalNamespaces: optional,
+      supportedNamespaces: {
+        eip155: {
+          chains,
+          methods,
+          events,
+          accounts,
+        },
+      },
+    });
+
+    const expected = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+        events,
+        accounts,
+      },
+    };
+    expect(approvedNamespaces).to.deep.eq(expected);
+  });
+  it("should build namespaces (config 4 - multiple inline chains)", async () => {
+    const required = {
+      "eip155:1": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+      "eip155:2": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+    const optional = {
+      eip155: {
+        chains: ["eip155:3"],
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+
+    const chains = ["eip155:1", "eip155:2", "eip155:3"];
+    const methods = ["personal_sign", "eth_sendTransaction", "eth_signTransaction"];
+    const events = ["chainChanged"];
+    const accounts = [
+      "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:3:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+    ];
+
+    const approvedNamespaces = buildApprovedNamespaces({
+      requiredNamespaces: required,
+      optionalNamespaces: optional,
+      supportedNamespaces: {
+        eip155: {
+          chains,
+          methods,
+          events,
+          accounts,
+        },
+      },
+    });
+
+    const expected = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2", "eip155:3"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+        events,
+        accounts,
+      },
+    };
+    expect(approvedNamespaces).to.deep.eq(expected);
+  });
+  it("should build namespaces (config 5 - multiple inline chains)", async () => {
+    const required = {
+      "eip155:1": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+      "eip155:2": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+    const optional = {
+      eip155: {
+        chains: ["eip155:3"],
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+      "eip155:4": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+
+    const chains = ["eip155:1", "eip155:2", "eip155:3", "eip155:4"];
+    const methods = ["personal_sign", "eth_sendTransaction", "eth_signTransaction"];
+    const events = ["chainChanged"];
+    const accounts = [
+      "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:4:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:3:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+    ];
+
+    const approvedNamespaces = buildApprovedNamespaces({
+      requiredNamespaces: required,
+      optionalNamespaces: optional,
+      supportedNamespaces: {
+        eip155: {
+          chains,
+          methods,
+          events,
+          accounts,
+        },
+      },
+    });
+
+    const expected = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2", "eip155:4", "eip155:3"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+        events,
+        accounts,
+      },
+    };
+    expect(approvedNamespaces).to.deep.eq(expected);
+  });
+  it("should build namespaces (config 6 - unsupported optional chains)", async () => {
+    const required = {
+      "eip155:1": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+      "eip155:2": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+    const optional = {
+      eip155: {
+        chains: ["eip155:3"],
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+      "eip155:4": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+
+    const chains = ["eip155:1", "eip155:2"];
+    const methods = ["personal_sign", "eth_sendTransaction", "eth_signTransaction"];
+    const events = ["chainChanged"];
+    const accounts = [
+      "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+    ];
+
+    const approvedNamespaces = buildApprovedNamespaces({
+      requiredNamespaces: required,
+      optionalNamespaces: optional,
+      supportedNamespaces: {
+        eip155: {
+          chains,
+          methods,
+          events,
+          accounts,
+        },
+      },
+    });
+
+    const expected = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+        events,
+        accounts,
+      },
+    };
+    expect(approvedNamespaces).to.deep.eq(expected);
+  });
+  it("should build namespaces (config 7 - partially supported optional chains)", async () => {
+    const required = {
+      "eip155:1": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+      "eip155:2": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+    const optional = {
+      eip155: {
+        chains: ["eip155:3"],
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+      "eip155:4": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+
+    const chains = ["eip155:1", "eip155:2", "eip155:4"];
+    const methods = ["personal_sign", "eth_sendTransaction", "eth_signTransaction"];
+    const events = ["chainChanged"];
+    const accounts = [
+      "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:4:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+    ];
+
+    const approvedNamespaces = buildApprovedNamespaces({
+      requiredNamespaces: required,
+      optionalNamespaces: optional,
+      supportedNamespaces: {
+        eip155: {
+          chains,
+          methods,
+          events,
+          accounts,
+        },
+      },
+    });
+
+    const expected = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2", "eip155:4"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+        events,
+        accounts,
+      },
+    };
+    expect(approvedNamespaces).to.deep.eq(expected);
+  });
+  it("should build namespaces (config 8 - partially supported optional methods)", async () => {
+    const required = {
+      "eip155:1": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+      "eip155:2": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+    const optional = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2"],
+        events: ["chainChanged"],
+        methods: [
+          "personal_sign",
+          "eth_sendTransaction",
+          "eth_signTransaction",
+          "eth_signTypedData",
+        ],
+      },
+    };
+
+    const chains = ["eip155:1", "eip155:2", "eip155:4"];
+    const methods = ["personal_sign", "eth_sendTransaction", "eth_signTransaction"];
+    const events = ["chainChanged"];
+    const accounts = [
+      "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+    ];
+
+    const approvedNamespaces = buildApprovedNamespaces({
+      requiredNamespaces: required,
+      optionalNamespaces: optional,
+      supportedNamespaces: {
+        eip155: {
+          chains,
+          methods,
+          events,
+          accounts,
+        },
+      },
+    });
+
+    const expected = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2"],
+        methods: ["personal_sign", "eth_sendTransaction", "eth_signTransaction"],
+        events,
+        accounts,
+      },
+    };
+    expect(approvedNamespaces).to.deep.eq(expected);
+  });
+  it("should build namespaces (config 9 - partially supported optional events)", async () => {
+    const required = {
+      "eip155:1": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+      "eip155:2": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+    const optional = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2"],
+        events: ["chainChanged", "accountsChanged"],
+        methods: [
+          "personal_sign",
+          "eth_sendTransaction",
+          "eth_signTransaction",
+          "eth_signTypedData",
+        ],
+      },
+    };
+
+    const chains = ["eip155:1", "eip155:2", "eip155:4"];
+    const methods = ["personal_sign", "eth_sendTransaction", "eth_signTransaction"];
+    const events = ["chainChanged", "accountsChanged"];
+    const accounts = [
+      "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+    ];
+
+    const approvedNamespaces = buildApprovedNamespaces({
+      requiredNamespaces: required,
+      optionalNamespaces: optional,
+      supportedNamespaces: {
+        eip155: {
+          chains,
+          methods,
+          events,
+          accounts,
+        },
+      },
+    });
+
+    const expected = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2"],
+        methods: ["personal_sign", "eth_sendTransaction", "eth_signTransaction"],
+        events,
+        accounts,
+      },
+    };
+    expect(approvedNamespaces).to.deep.eq(expected);
+  });
+  it("should build namespaces (config 10 - extra supported chains)", async () => {
+    const required = {
+      "eip155:1": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+      "eip155:2": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+    const optional = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2"],
+        events: ["chainChanged", "accountsChanged"],
+        methods: [
+          "personal_sign",
+          "eth_sendTransaction",
+          "eth_signTransaction",
+          "eth_signTypedData",
+        ],
+      },
+    };
+
+    const chains = ["eip155:1", "eip155:2", "eip155:4"];
+    const methods = ["personal_sign", "eth_sendTransaction", "eth_signTransaction"];
+    const events = ["chainChanged", "accountsChanged"];
+    const accounts = [
+      "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:4:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+    ];
+
+    const approvedNamespaces = buildApprovedNamespaces({
+      requiredNamespaces: required,
+      optionalNamespaces: optional,
+      supportedNamespaces: {
+        eip155: {
+          chains,
+          methods,
+          events,
+          accounts,
+        },
+      },
+    });
+
+    const expected = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2"],
+        methods: ["personal_sign", "eth_sendTransaction", "eth_signTransaction"],
+        events,
+        accounts: [
+          "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+          "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+        ],
+      },
+    };
+    expect(approvedNamespaces).to.deep.eq(expected);
+  });
+  it("should build namespaces (config 11 - multiple namespaces - required)", async () => {
+    const required = {
+      "eip155:1": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+      cosmos: {
+        chains: ["cosmos:cosmoshub-4"],
+        events: ["cosmos_event"],
+        methods: ["cosmos_method"],
+      },
+    };
+    const optional = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2"],
+        events: ["chainChanged", "accountsChanged"],
+        methods: [
+          "personal_sign",
+          "eth_sendTransaction",
+          "eth_signTransaction",
+          "eth_signTypedData",
+        ],
+      },
+    };
+
+    const chainsEip = ["eip155:1", "eip155:2", "eip155:4"];
+    const chainsCosmos = ["cosmos:cosmoshub-4"];
+    const methods = ["personal_sign", "eth_sendTransaction", "eth_signTransaction"];
+    const events = ["chainChanged", "accountsChanged"];
+    const accountsEip = [
+      "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:4:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+    ];
+    const accountsCosmos = ["cosmos:cosmoshub-4:cosmos1hsk6jryyqjfhp5dhc55tc9jtckygx0eph6dd02"];
+    const eventsCosmos = ["cosmos_event"];
+    const methodsCosmos = ["cosmos_method"];
+
+    const approvedNamespaces = buildApprovedNamespaces({
+      requiredNamespaces: required,
+      optionalNamespaces: optional,
+      supportedNamespaces: {
+        eip155: {
+          chains: chainsEip,
+          methods,
+          events,
+          accounts: accountsEip,
+        },
+        cosmos: {
+          chains: chainsCosmos,
+          methods: methodsCosmos,
+          events: eventsCosmos,
+          accounts: accountsCosmos,
+        },
+      },
+    });
+
+    const expected = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2"],
+        methods: ["personal_sign", "eth_sendTransaction", "eth_signTransaction"],
+        events,
+        accounts: [
+          "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+          "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+        ],
+      },
+      cosmos: {
+        chains: chainsCosmos,
+        methods: methodsCosmos,
+        events: eventsCosmos,
+        accounts: accountsCosmos,
+      },
+    };
+    expect(approvedNamespaces).to.deep.eq(expected);
   });
 });

--- a/packages/utils/test/validators.spec.ts
+++ b/packages/utils/test/validators.spec.ts
@@ -927,4 +927,315 @@ describe("buildApprovedNamespaces (validators)", () => {
     };
     expect(approvedNamespaces).to.deep.eq(expected);
   });
+  it.fails(
+    "should throw while building namespaces (config 1 - no supported required chains)",
+    () => {
+      const required = {
+        "eip155:1": {
+          events: ["chainChanged"],
+          methods: ["personal_sign", "eth_sendTransaction"],
+        },
+        cosmos: {
+          chains: ["cosmos:cosmoshub-4"],
+          events: ["cosmos_event"],
+          methods: ["cosmos_method"],
+        },
+      };
+      const optional = {
+        eip155: {
+          chains: ["eip155:1", "eip155:2"],
+          events: ["chainChanged", "accountsChanged"],
+          methods: [
+            "personal_sign",
+            "eth_sendTransaction",
+            "eth_signTransaction",
+            "eth_signTypedData",
+          ],
+        },
+      };
+
+      const chainsEip = ["eip155:5"];
+      const methods = ["personal_sign", "eth_sendTransaction", "eth_signTransaction"];
+      const events = ["chainChanged", "accountsChanged"];
+      const accountsEip = ["eip155:5:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"];
+
+      buildApprovedNamespaces({
+        requiredNamespaces: required,
+        optionalNamespaces: optional,
+        supportedNamespaces: {
+          eip155: {
+            chains: chainsEip,
+            methods,
+            events,
+            accounts: accountsEip,
+          },
+        },
+      });
+    },
+  );
+  it.fails(
+    "should throw while building namespaces (config 2 - partially supported required chains)",
+    () => {
+      const required = {
+        "eip155:1": {
+          events: ["chainChanged"],
+          methods: ["personal_sign", "eth_sendTransaction"],
+        },
+        cosmos: {
+          chains: ["cosmos:cosmoshub-4"],
+          events: ["cosmos_event"],
+          methods: ["cosmos_method"],
+        },
+      };
+      const optional = {
+        eip155: {
+          chains: ["eip155:1", "eip155:2"],
+          events: ["chainChanged", "accountsChanged"],
+          methods: [
+            "personal_sign",
+            "eth_sendTransaction",
+            "eth_signTransaction",
+            "eth_signTypedData",
+          ],
+        },
+      };
+
+      const chainsEip = ["eip155:1", "eip155:5"];
+      const methods = ["personal_sign", "eth_sendTransaction", "eth_signTransaction"];
+      const events = ["chainChanged", "accountsChanged"];
+      const accountsEip = [
+        "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+        "eip155:5:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      ];
+
+      buildApprovedNamespaces({
+        requiredNamespaces: required,
+        optionalNamespaces: optional,
+        supportedNamespaces: {
+          eip155: {
+            chains: chainsEip,
+            methods,
+            events,
+            accounts: accountsEip,
+          },
+        },
+      });
+    },
+  );
+  it.fails(
+    "should throw while building namespaces (config 3 - no supported required methods)",
+    () => {
+      const required = {
+        "eip155:1": {
+          events: ["chainChanged"],
+          methods: ["personal_sign", "eth_sendTransaction"],
+        },
+      };
+      const optional = {
+        eip155: {
+          chains: ["eip155:1", "eip155:2"],
+          events: ["chainChanged", "accountsChanged"],
+          methods: [
+            "personal_sign",
+            "eth_sendTransaction",
+            "eth_signTransaction",
+            "eth_signTypedData",
+          ],
+        },
+      };
+
+      const chainsEip = ["eip155:1"];
+      const methods = ["personal_sign"];
+      const events = ["chainChanged", "accountsChanged"];
+      const accountsEip = ["eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"];
+
+      buildApprovedNamespaces({
+        requiredNamespaces: required,
+        optionalNamespaces: optional,
+        supportedNamespaces: {
+          eip155: {
+            chains: chainsEip,
+            methods,
+            events,
+            accounts: accountsEip,
+          },
+        },
+      });
+    },
+  );
+  it.fails(
+    "should throw while building namespaces (config 4 - no supported required events)",
+    () => {
+      const required = {
+        "eip155:1": {
+          events: ["chainChanged"],
+          methods: ["personal_sign", "eth_sendTransaction"],
+        },
+      };
+      const optional = {
+        eip155: {
+          chains: ["eip155:1", "eip155:2"],
+          events: ["chainChanged", "accountsChanged"],
+          methods: [
+            "personal_sign",
+            "eth_sendTransaction",
+            "eth_signTransaction",
+            "eth_signTypedData",
+          ],
+        },
+      };
+
+      const chainsEip = ["eip155:1"];
+      const methods = ["personal_sign", "eth_sendTransaction"];
+      const events = [] as string[];
+      const accountsEip = ["eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"];
+
+      buildApprovedNamespaces({
+        requiredNamespaces: required,
+        optionalNamespaces: optional,
+        supportedNamespaces: {
+          eip155: {
+            chains: chainsEip,
+            methods,
+            events,
+            accounts: accountsEip,
+          },
+        },
+      });
+    },
+  );
+  it.fails(
+    "should throw while building namespaces (config 5 - no accounts for required chain)",
+    () => {
+      const required = {
+        "eip155:1": {
+          events: ["chainChanged"],
+          methods: ["personal_sign", "eth_sendTransaction"],
+        },
+      };
+      const optional = {
+        eip155: {
+          chains: ["eip155:1", "eip155:2"],
+          events: ["chainChanged", "accountsChanged"],
+          methods: [
+            "personal_sign",
+            "eth_sendTransaction",
+            "eth_signTransaction",
+            "eth_signTypedData",
+          ],
+        },
+      };
+
+      const chainsEip = ["eip155:1"];
+      const methods = ["personal_sign", "eth_sendTransaction"];
+      const events = ["chainChanged"];
+      const accountsEip = ["eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"];
+
+      buildApprovedNamespaces({
+        requiredNamespaces: required,
+        optionalNamespaces: optional,
+        supportedNamespaces: {
+          eip155: {
+            chains: chainsEip,
+            methods,
+            events,
+            accounts: accountsEip,
+          },
+        },
+      });
+    },
+  );
+  it.fails(
+    "should throw while building namespaces (config 6 - partiall accounts for required chain)",
+    () => {
+      const required = {
+        "eip155:1": {
+          events: ["chainChanged"],
+          methods: ["personal_sign", "eth_sendTransaction"],
+        },
+        "eip155:2": {
+          events: ["chainChanged"],
+          methods: ["personal_sign", "eth_sendTransaction"],
+        },
+      };
+      const optional = {
+        eip155: {
+          chains: ["eip155:1", "eip155:2"],
+          events: ["chainChanged", "accountsChanged"],
+          methods: [
+            "personal_sign",
+            "eth_sendTransaction",
+            "eth_signTransaction",
+            "eth_signTypedData",
+          ],
+        },
+      };
+
+      const chainsEip = ["eip155:1", "eip155:2"];
+      const methods = ["personal_sign", "eth_sendTransaction"];
+      const events = ["chainChanged"];
+      const accountsEip = ["eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"];
+
+      buildApprovedNamespaces({
+        requiredNamespaces: required,
+        optionalNamespaces: optional,
+        supportedNamespaces: {
+          eip155: {
+            chains: chainsEip,
+            methods,
+            events,
+            accounts: accountsEip,
+          },
+        },
+      });
+    },
+  );
+  it.fails(
+    "should throw while building namespaces (config 7 - misconfigured supported accounts - caip10)",
+    () => {
+      const required = {
+        "eip155:1": {
+          events: ["chainChanged"],
+          methods: ["personal_sign", "eth_sendTransaction"],
+        },
+        "eip155:2": {
+          events: ["chainChanged"],
+          methods: ["personal_sign", "eth_sendTransaction"],
+        },
+      };
+      const optional = {
+        eip155: {
+          chains: ["eip155:1", "eip155:2"],
+          events: ["chainChanged", "accountsChanged"],
+          methods: [
+            "personal_sign",
+            "eth_sendTransaction",
+            "eth_signTransaction",
+            "eth_signTypedData",
+          ],
+        },
+      };
+
+      const chainsEip = ["eip155:1", "eip155:2"];
+      const methods = ["personal_sign", "eth_sendTransaction"];
+      const events = ["chainChanged"];
+      const accountsEip = [
+        "0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+        "0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      ];
+
+      buildApprovedNamespaces({
+        requiredNamespaces: required,
+        optionalNamespaces: optional,
+        supportedNamespaces: {
+          eip155: {
+            chains: chainsEip,
+            methods,
+            events,
+            accounts: accountsEip,
+          },
+        },
+      });
+    },
+  );
 });


### PR DESCRIPTION
# Description
Implemented util that builds `namespaces` structure by provided supported `chains, methods, events & accounts`. 
interface
```
export function buildApprovedNamespaces(params: {
  requiredNamespaces: ProposalTypes.RequiredNamespaces;
  optionalNamespaces?: ProposalTypes.OptionalNamespaces;
  supportedNamespaces: Record<
    string,
    { chains: string[]; methods: string[]; events: string[]; accounts: string[] }
  >
}) 
```
It takes `required` & `optional` namespaces provided in the `session proposal` along with the supported chains/methods/events/accounts by the wallet and returns a structured `namespaces` object

## How Has This Been Tested?
multiple tests with different configuration
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
