### PR TITLE
feat: optimistic proposal ack

### DIFF
--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -220,6 +220,8 @@ export class Relayer extends IRelayer {
     if (this.transportExplicitlyClosed) return;
     this.relayUrl = relayUrl || this.relayUrl;
     await this.transportClose();
+    // wait a bit to give the socket time to close
+    await new Promise((resolve) => setTimeout(resolve, 500));
     await this.createProvider();
     await this.transportOpen();
   }

--- a/packages/sign-client/test/shared/connect.ts
+++ b/packages/sign-client/test/shared/connect.ts
@@ -59,7 +59,12 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
         });
         if (!sessionB) {
           sessionB = await acknowledged();
+          expect(sessionB.acknowledged).to.be.false;
         }
+        // with the optimistic resolve of acknowledged(), we need to wait for the session to be updated
+        await throttle(1_000);
+        sessionB = clients.B.session.get(sessionB.topic);
+        expect(sessionB.acknowledged).to.be.true;
         resolve();
       } catch (e) {
         reject(e);

--- a/providers/universal-provider/test/shared/connect.ts
+++ b/providers/universal-provider/test/shared/connect.ts
@@ -142,8 +142,7 @@ export async function testConnectMethod(
   expect(sessionA.namespaces).to.eql(sessionB.namespaces);
   // expiry
   expect(Math.abs(sessionA.expiry - sessionB.expiry)).to.be.lessThan(5);
-  // acknowledged
-  expect(sessionA.acknowledged).to.eql(sessionB.acknowledged);
+
   // participants
   expect(sessionA.self).to.eql(sessionB.peer);
   expect(sessionA.peer).to.eql(sessionB.self);


### PR DESCRIPTION
# Description

Resolving `approve` and web3wallet's `approveSession` promises optimistically to avoid possible issues where the dapp loses socket connection while in the background thus preventing session ack

## How Has This Been Tested?
integration tests
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
