### PR TITLE
fix: dedicated session ack tests

### DIFF
--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -51,6 +51,17 @@ describe("Sign Client Integration", () => {
       });
       await deleteClients(clients);
     });
+    it("should receive session acknowledge", async () => {
+      const clients = await initTwoClients();
+      const {
+        sessionA: { topic, acknowledged },
+      } = await testConnectMethod(clients);
+      await throttle(5_000);
+      const session = clients.B.session.get(topic);
+      expect(session.acknowledged).to.be.true;
+      expect(acknowledged).to.be.true;
+      await deleteClients(clients);
+    });
   });
 
   describe("disconnect", () => {

--- a/packages/sign-client/test/shared/connect.ts
+++ b/packages/sign-client/test/shared/connect.ts
@@ -61,10 +61,6 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
           sessionB = await acknowledged();
           expect(sessionB.acknowledged).to.be.false;
         }
-        // with the optimistic resolve of acknowledged(), we need to wait for the session to be updated
-        await throttle(1_000);
-        sessionB = clients.B.session.get(sessionB.topic);
-        expect(sessionB.acknowledged).to.be.true;
         resolve();
       } catch (e) {
         reject(e);
@@ -169,8 +165,6 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
   expect(sessionA.sessionProperties).to.eql(TEST_SESSION_PROPERTIES_APPROVE);
   // expiry
   expect(Math.abs(sessionA.expiry - sessionB.expiry)).to.be.lessThan(5);
-  // acknowledged
-  expect(sessionA.acknowledged).to.eql(sessionB.acknowledged);
   // participants
   expect(sessionA.self).to.eql(sessionB.peer);
   expect(sessionA.peer).to.eql(sessionB.self);


### PR DESCRIPTION
# Description
Removed session ack checks in the shared `connect` test util and added dedicated test for session ack

## How Has This Been Tested?
tests
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
