### PR TITLE
chore(generic-storage): add a generic storage

### DIFF
--- a/packages/core/src/constants/core.ts
+++ b/packages/core/src/constants/core.ts
@@ -12,3 +12,7 @@ export const CORE_DEFAULT = {
 export const CORE_STORAGE_OPTIONS = {
   database: ":memory:",
 };
+
+export const CORE_GENERIC_STORAGE_OPTIONS = {
+  table: "generic_storage",
+};

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from "events";
 import pino from "pino";
 
-import KeyValueStorage from "@walletconnect/keyvaluestorage";
 import { HeartBeat } from "@walletconnect/heartbeat";
+import KeyValueStorage from "@walletconnect/keyvaluestorage";
 import {
   generateChildLogger,
   getDefaultLoggerOptions,
@@ -10,15 +10,16 @@ import {
 } from "@walletconnect/logger";
 import { CoreTypes, ICore } from "@walletconnect/types";
 
-import { Crypto, Relayer, Pairing, JsonRpcHistory, Expirer } from "./controllers";
 import {
   CORE_CONTEXT,
   CORE_DEFAULT,
+  CORE_GENERIC_STORAGE_OPTIONS,
   CORE_PROTOCOL,
   CORE_STORAGE_OPTIONS,
   CORE_VERSION,
   RELAYER_DEFAULT_RELAY_URL,
 } from "./constants";
+import { Crypto, Expirer, JsonRpcHistory, Pairing, Relayer } from "./controllers";
 
 export class Core extends ICore {
   public readonly protocol = CORE_PROTOCOL;
@@ -33,6 +34,7 @@ export class Core extends ICore {
   public relayer: ICore["relayer"];
   public crypto: ICore["crypto"];
   public storage: ICore["storage"];
+  public genericStorage: ICore["genericStorage"];
   public history: ICore["history"];
   public expirer: ICore["expirer"];
   public pairing: ICore["pairing"];
@@ -63,6 +65,9 @@ export class Core extends ICore {
     this.storage = opts?.storage
       ? opts.storage
       : new KeyValueStorage({ ...CORE_STORAGE_OPTIONS, ...opts?.storageOptions });
+
+    this.genericStorage = new KeyValueStorage(CORE_GENERIC_STORAGE_OPTIONS);
+
     this.relayer = new Relayer({
       core: this,
       logger: this.logger,

--- a/packages/types/src/core/core.ts
+++ b/packages/types/src/core/core.ts
@@ -1,14 +1,14 @@
 import { IEvents } from "@walletconnect/events";
 import { IHeartBeat } from "@walletconnect/heartbeat";
 import { IKeyValueStorage, KeyValueStorageOptions } from "@walletconnect/keyvaluestorage";
+import { Logger } from "@walletconnect/logger";
 
 import { ICrypto } from "./crypto";
-import { IRelayer } from "./relayer";
-import { IKeyChain } from "./keychain";
-import { IJsonRpcHistory } from "./history";
 import { IExpirer } from "./expirer";
+import { IJsonRpcHistory } from "./history";
+import { IKeyChain } from "./keychain";
 import { IPairing } from "./pairing";
-import { Logger } from "@walletconnect/logger";
+import { IRelayer } from "./relayer";
 
 export declare namespace CoreTypes {
   interface Options {
@@ -43,6 +43,7 @@ export abstract class ICore extends IEvents {
   public abstract crypto: ICrypto;
   public abstract relayer: IRelayer;
   public abstract storage: IKeyValueStorage;
+  public abstract genericStorage: IKeyValueStorage;
   public abstract history: IJsonRpcHistory;
   public abstract expirer: IExpirer;
   public abstract pairing: IPairing;


### PR DESCRIPTION
# Description

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

This adds a generic storage meaning that it can be used to store arbitrary data.
The first use case is for a util that will provide a shared storage between push and chat clients.

Related to [this issue](https://github.com/WalletConnect/walletconnect-utils/issues/79)
## How Has This Been Tested?

Current tests already cover such a functionality as we are just exposing an additional `KeyValueStorage`

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
