### PR TITLE
fix: removes session from storage before emitting `session_delete` event

### DIFF
--- a/packages/sign-client/test/sdk/integration/events.spec.ts
+++ b/packages/sign-client/test/sdk/integration/events.spec.ts
@@ -100,10 +100,16 @@ describe("Sign Client Events Validation", () => {
           ...TEST_EMIT_PARAMS,
         };
 
+        const activeSessions = clients.B.session.getAll();
+        expect(activeSessions.length).to.eql(1);
+
         await new Promise<void>(async (resolve, reject) => {
           try {
             clients.B.on("session_delete", (event) => {
               expect(eventPayload.topic).to.eql(event.topic);
+
+              const sessionsLeft = clients.B.session.getAll();
+              expect(sessionsLeft.length).to.eql(0);
               resolve();
             });
             await clients.A.disconnect({


### PR DESCRIPTION
# Description
Updated sign-client's engine to emit `session_delete` after the session is removed from storage
Updated `session_delete` tests to confirm the fix

Resolves https://github.com/WalletConnect/walletconnect-monorepo/issues/2196
## How Has This Been Tested?
integration tests
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
