### PR TITLE
fix: wrapps try-catch around `verify-api`'s resolve fx

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -1157,13 +1157,18 @@ export class Engine extends IEngine {
       },
     };
 
-    const origin = await this.client.core.verify.resolve({
-      attestationId: hash,
-      verifyUrl: metadata.verifyUrl,
-    });
+    try {
+      const origin = await this.client.core.verify.resolve({
+        attestationId: hash,
+        verifyUrl: metadata.verifyUrl,
+      });
 
-    context.verified.origin = origin;
-    context.verified.validation = origin === metadata.url ? "VALID" : "INVALID";
+      context.verified.origin = origin;
+      context.verified.validation = origin === metadata.url ? "VALID" : "INVALID";
+    } catch (e) {
+      this.client.logger.error(e);
+    }
+
     this.client.logger.info(`Verify context: ${JSON.stringify(context)}`);
     return context;
   };


### PR DESCRIPTION
# Description
Added try-catch around `resolve` to avoid cases of invalid verify urls or rejected requests
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
