### PR TITLE
fix(ci): don't use auto-promote job on `renovate[bot]`

### DIFF
--- a/.github/workflows/intake.yml
+++ b/.github/workflows/intake.yml
@@ -25,7 +25,7 @@ jobs:
           label-operator: OR
   auto-promote:
     name: auto-promote
-    if: github.event.action == 'opened'
+    if: github.event.action == 'opened' && github.event.sender.login != 'renovate[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check Core Team membership


### PR DESCRIPTION
# Description

* The `intake.yml` workflow is trying to treat `renovatebot` like a team member and causing CI checks to fail only on this step unnecessarily.
* Exclude user `renovate[bot]` from the `auto-promote` job

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
