### PR TITLE
fix(deps): use non-caret explicit version for heartbeat

### DIFF
--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@walletconnect/core": "2.6.2",
     "@walletconnect/events": "^1.0.1",
-    "@walletconnect/heartbeat": "^1.2.0",
+    "@walletconnect/heartbeat": "1.2.0",
     "@walletconnect/jsonrpc-utils": "^1.0.7",
     "@walletconnect/logger": "^2.0.1",
     "@walletconnect/time": "^1.0.2",


### PR DESCRIPTION
# Description

- Aligning version specifications for `@walletconnect/heartbeat` across all the pkgs in preparation for #2204
- Currently renovatebot is not updating the concrete version for this dep in `sign-client` due to caret (`^`) semver, but we want to ensure we have `1.2.1` across all pkgs.

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
