### PR TITLE
fix: transport restart

### DIFF
--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -227,6 +227,7 @@ export class Relayer extends IRelayer {
       }),
       this.transportClose(),
     ]);
+    // wait a bit to give the socket time to close
     await new Promise((resolve) => setTimeout(resolve, 1_000));
     await this.createProvider();
     await this.transportOpen();

--- a/packages/core/src/controllers/subscriber.ts
+++ b/packages/core/src/controllers/subscriber.ts
@@ -350,15 +350,13 @@ export class Subscriber extends ISubscriber {
   }
 
   private async reset() {
-    if (!this.cached.length) return;
-
-    const batches = Math.ceil(this.cached.length / this.batchSubscribeTopicsLimit);
-
-    for (let i = 0; i < batches; i++) {
-      const batch = this.cached.splice(0, this.batchSubscribeTopicsLimit);
-      await this.batchSubscribe(batch);
+    if (this.cached.length) {
+      const batches = Math.ceil(this.cached.length / this.batchSubscribeTopicsLimit);
+      for (let i = 0; i < batches; i++) {
+        const batch = this.cached.splice(0, this.batchSubscribeTopicsLimit);
+        await this.batchSubscribe(batch);
+      }
     }
-
     this.events.emit(SUBSCRIBER_EVENTS.resubscribed);
   }
 

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -220,4 +220,36 @@ describe("Relayer", () => {
       ).to.be.true;
     });
   });
+  describe("transport", () => {
+    beforeEach(async () => {
+      relayer = new Relayer({
+        core,
+        logger,
+        relayUrl: TEST_CORE_OPTIONS.relayUrl,
+        projectId: TEST_CORE_OPTIONS.projectId,
+      });
+      await relayer.init();
+    });
+    it("should restart transport with new endpoint", async () => {
+      const newEndpoint = "us-east-1.relay.walletconnect.com";
+      expect(relayer.provider.connection.socket._sender._socket.servername).to.eq(
+        TEST_CORE_OPTIONS.relayUrl.replace("wss://", ""),
+      );
+      await relayer.restartTransport(`wss://${newEndpoint}`);
+      expect(relayer.provider.connection.socket._sender._socket.servername).to.eq(newEndpoint);
+    });
+
+    it("should restart transport with new endpoint (multiple)", async () => {
+      const endpointOne = "us-east-1.relay.walletconnect.com";
+      expect(relayer.provider.connection.socket._sender._socket.servername).to.eq(
+        TEST_CORE_OPTIONS.relayUrl.replace("wss://", ""),
+      );
+      await relayer.restartTransport(`wss://${endpointOne}`);
+      expect(relayer.provider.connection.socket._sender._socket.servername).to.eq(endpointOne);
+
+      const endpointTwo = "eu-central-1.relay.walletconnect.com";
+      await relayer.restartTransport(`wss://${endpointTwo}`);
+      expect(relayer.provider.connection.socket._sender._socket.servername).to.eq(endpointTwo);
+    });
+  });
 });


### PR DESCRIPTION
# Description
- After closing a socket, await for disconnect event before proceeding
- emits `SUBSCRIBER_EVENTS.resubscribed` even when cache is empty to avoid blocking transport restart
- tests for `transportRestart`

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves # ([browse](https://github.com/WalletConnect/walletconnect-monorepo/issues) or [create](https://github.com/WalletConnect/walletconnect-monorepo/issues/new/choose))

## How Has This Been Tested?
canary release `2.6.2-rc-0.2`
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
