### PR TITLE
fix: auto namespace builder chains match

### DIFF
--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -127,7 +127,7 @@ export function buildApprovedNamespaces(
     const accounts = chains
       .map((chain: string) =>
         supportedNamespaces[requiredNamespace].accounts.filter((account: string) =>
-          account.includes(chain),
+          account.includes(`${chain}:`),
         ),
       )
       .flat();

--- a/packages/utils/test/validators.spec.ts
+++ b/packages/utils/test/validators.spec.ts
@@ -978,6 +978,51 @@ describe("buildApprovedNamespaces (validators)", () => {
     };
     expect(approvedNamespaces).to.deep.eq(expected);
   });
+  it("should build namespaces (config 12 - chains fuzzing)", () => {
+    const required = {
+      "eip155:1": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+    const optional = {};
+
+    const chains = ["eip155:1", "eip155:11", "eip155:111"];
+    const methods = ["personal_sign", "eth_sendTransaction", "eth_signTransaction"];
+    const events = ["chainChanged"];
+    const accounts = [
+      "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:11:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:111:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+    ];
+
+    const approvedNamespaces = buildApprovedNamespaces({
+      proposal: {
+        ...TEST_PROPOSAL,
+        requiredNamespaces: required,
+        optionalNamespaces: optional,
+      },
+      supportedNamespaces: {
+        eip155: {
+          chains,
+          methods,
+          events,
+          accounts,
+        },
+      },
+    });
+
+    const expected = {
+      eip155: {
+        chains: ["eip155:1"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+        events,
+        accounts: ["eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"],
+      },
+    };
+    expect(approvedNamespaces).to.deep.eq(expected);
+  });
+
   it.fails(
     "should throw while building namespaces (config 1 - no supported required chains)",
     () => {


### PR DESCRIPTION
# Description
Fixed an issue where chains were incorrectly matched with accounts with similar chains e.g. ChainId `1` with `eip155:11:0x...`
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?
new tests
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
