### PR TITLE
feat: added buffer polyfill to react-native-compat

### DIFF
--- a/packages/react-native-compat/index.js
+++ b/packages/react-native-compat/index.js
@@ -3,3 +3,8 @@ import "fast-text-encoding";
 
 // Polyfill crypto.getRandomvalues
 import "react-native-get-random-values";
+
+// Polyfill Buffer
+if (typeof Buffer === "undefined") {
+  global.Buffer = require("buffer").Buffer;
+}


### PR DESCRIPTION
# Description
Added buffer polyfill to react-native-compat as it is needed to make the universal-provider work

## How Has This Been Tested?
We are manually polyfilling Buffer in react native dapp example, and it's been working well

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
