### PR TITLE
fix: restart connection

### DIFF
--- a/packages/core/src/constants/relayer.ts
+++ b/packages/core/src/constants/relayer.ts
@@ -27,7 +27,7 @@ export const RELAYER_PROVIDER_EVENTS = {
   error: "error",
 };
 
-export const RELAYER_RECONNECT_TIMEOUT = ONE_SECOND;
+export const RELAYER_RECONNECT_TIMEOUT = ONE_SECOND / 2;
 
 export const RELAYER_STORAGE_OPTIONS = {
   database: ":memory:",

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -219,14 +219,16 @@ export class Relayer extends IRelayer {
   public async restartTransport(relayUrl?: string) {
     if (this.transportExplicitlyClosed) return;
     this.relayUrl = relayUrl || this.relayUrl;
-    await Promise.all([
-      new Promise<void>((resolve) => {
-        this.provider.once(RELAYER_PROVIDER_EVENTS.disconnect, () => {
-          resolve();
-        });
-      }),
-      this.transportClose(),
-    ]);
+    if (this.connected) {
+      await Promise.all([
+        new Promise<void>((resolve) => {
+          this.provider.once(RELAYER_PROVIDER_EVENTS.disconnect, () => {
+            resolve();
+          });
+        }),
+        this.transportClose(),
+      ]);
+    }
     await this.createProvider();
     await this.transportOpen();
   }

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -233,7 +233,7 @@ describe("Relayer", () => {
     it("should restart transport with new endpoint", async () => {
       const newEndpoint = "us-east-1.relay.walletconnect.com";
       expect(relayer.provider.connection.socket._sender._socket.servername).to.eq(
-        TEST_CORE_OPTIONS.relayUrl.replace("wss://", ""),
+        TEST_CORE_OPTIONS.relayUrl?.replace("wss://", ""),
       );
       await relayer.restartTransport(`wss://${newEndpoint}`);
       expect(relayer.provider.connection.socket._sender._socket.servername).to.eq(newEndpoint);
@@ -242,7 +242,7 @@ describe("Relayer", () => {
     it("should restart transport with new endpoint (multiple)", async () => {
       const endpointOne = "us-east-1.relay.walletconnect.com";
       expect(relayer.provider.connection.socket._sender._socket.servername).to.eq(
-        TEST_CORE_OPTIONS.relayUrl.replace("wss://", ""),
+        TEST_CORE_OPTIONS.relayUrl?.replace("wss://", ""),
       );
       await relayer.restartTransport(`wss://${endpointOne}`);
       expect(relayer.provider.connection.socket._sender._socket.servername).to.eq(endpointOne);
@@ -250,6 +250,13 @@ describe("Relayer", () => {
       const endpointTwo = "eu-central-1.relay.walletconnect.com";
       await relayer.restartTransport(`wss://${endpointTwo}`);
       expect(relayer.provider.connection.socket._sender._socket.servername).to.eq(endpointTwo);
+    });
+
+    it("should restart transport after connection drop", async () => {
+      await relayer.provider.connection.close();
+      expect(relayer.connected).to.be.false;
+      await relayer.restartTransport();
+      expect(relayer.connected).to.be.true;
     });
   });
 });


### PR DESCRIPTION
# Description

- Fixed an issue where `restartTransport` might get stuck waiting for a `disconnect` event if the connection was already down

- reduced reconnect delay to `500`ms

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?
canary `2.0.7-rc-4`
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
