### PR TITLE
fix: resolve origin only on 200 response

### DIFF
--- a/packages/core/src/controllers/verify.ts
+++ b/packages/core/src/controllers/verify.ts
@@ -50,7 +50,7 @@ export class Verify extends IVerify {
       signal: this.abortController.signal,
     });
     clearTimeout(timeout);
-    return (await result.json())?.origin || "";
+    return result.status === 200 ? (await result.json())?.origin : "";
   };
 
   get context(): string {


### PR DESCRIPTION
# Description
Fixed an issue where Verify tries to parse responses on non-200 responses 
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?
dogfooding
canary release `2.7.1-canary-2`
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
