### PR TITLE
feat: duplicate pairings cleanup

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -361,7 +361,10 @@ export class Engine extends IEngine {
       const pairing = this.client.core.pairing.pairings.get(session.pairingTopic);
       const allPairings = this.client.core.pairing.pairings.getAll();
       const duplicates = allPairings.filter(
-        (p) => p.peerMetadata?.url === session.self.metadata.url && p.topic !== pairing.topic,
+        (p) =>
+          p.peerMetadata?.url &&
+          p.peerMetadata?.url === session.self.metadata.url &&
+          p.topic !== pairing.topic,
       );
       if (duplicates.length === 0) return;
       this.client.logger.info(`Cleaning up ${duplicates.length} duplicate pairing(s)`);

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -354,6 +354,26 @@ export class Engine extends IEngine {
 
   // ---------- Private Helpers --------------------------------------- //
 
+  private cleanupDuplicatePairings: EnginePrivate["cleanupDuplicatePairings"] = async (
+    session: SessionTypes.Struct,
+  ) => {
+    try {
+      const pairing = this.client.core.pairing.pairings.get(session.pairingTopic);
+      const allPairings = this.client.core.pairing.pairings.getAll();
+      const duplicates = allPairings.filter(
+        (p) => p.peerMetadata?.url === session.self.metadata.url && p.topic !== pairing.topic,
+      );
+      if (duplicates.length === 0) return;
+      this.client.logger.info(`Cleaning up ${duplicates.length} duplicate pairing(s)`);
+      await Promise.all(
+        duplicates.map((p) => this.client.core.pairing.disconnect({ topic: p.topic })),
+      );
+      this.client.logger.info(`Duplicate pairings clean up finished`);
+    } catch (error) {
+      this.client.logger.error(error);
+    }
+  };
+
   private deleteSession: EnginePrivate["deleteSession"] = async (topic, expirerHasDeleted) => {
     const { self } = this.client.session.get(topic);
     // Await the unsubscribe first to avoid deleting the symKey too early below.
@@ -644,6 +664,7 @@ export class Engine extends IEngine {
       };
       await this.sendResult<"wc_sessionSettle">(payload.id, topic, true);
       this.events.emit(engineEvent("session_connect"), { session });
+      this.cleanupDuplicatePairings(session);
     } catch (err: any) {
       await this.sendError(id, topic, err);
       this.client.logger.error(err);

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -77,6 +77,7 @@ describe("Sign Client Integration", () => {
       });
       expect(clients.A.pairing.getAll().length).to.eq(1);
       const { pairingA: pairingAfter, sessionA: sessionAfter } = await testConnectMethod(clients);
+      await throttle(1_000);
       expect(pairingA.topic).to.not.eq(pairingAfter.topic);
       expect(sessionA.topic).to.not.eq(sessionAfter.topic);
       expect(sessionA.pairingTopic).to.not.eq(sessionAfter.pairingTopic);

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -184,10 +184,7 @@ export interface EnginePrivate {
     expirerHasDeleted?: boolean,
   ): Promise<void>;
 
-  cleanupDuplicatePairings(
-    session: SessionTypes.Struct,
-  ): Promise<void>;
-
+  cleanupDuplicatePairings(session: SessionTypes.Struct): Promise<void>;
 
   cleanup(): Promise<void>;
 

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -184,6 +184,11 @@ export interface EnginePrivate {
     expirerHasDeleted?: boolean,
   ): Promise<void>;
 
+  cleanupDuplicatePairings(
+    session: SessionTypes.Struct,
+  ): Promise<void>;
+
+
   cleanup(): Promise<void>;
 
   onSessionProposeRequest(


### PR DESCRIPTION
# Description
Implemented duplicate pairings cleanup that removes old pairings when new one is created with the same peer.
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?
dogfooding
tests
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

- [ ] Breaking change
- [ ] Requires a documentation update
  - [ ] Related docs issue/PR (if docs are not included in this PR):
- [ ] Requires a e2e/integration test update
