### PR TITLE
providers: universal-provider: fix wrong return type

### DIFF
--- a/providers/universal-provider/src/types/providers.ts
+++ b/providers/universal-provider/src/types/providers.ts
@@ -39,7 +39,7 @@ export interface IUniversalProvider extends IEthereumProvider {
   ) => void;
   pair: (pairingTopic: string | undefined) => Promise<SessionTypes.Struct>;
   connect: (opts: ConnectParams) => Promise<SessionTypes.Struct | undefined>;
-  disconnect: () => void;
+  disconnect: () => Promise<void>;
   cleanupPendingPairings: () => Promise<void>;
   abortPairingAttempt(): void;
 }


### PR DESCRIPTION

# Description
The disconnect function in the universal provider is async while in the interface it implements doesn't return a promise.

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

fixes #2363