### PR TITLE
fix: session approval race condition

### DIFF
--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -297,6 +297,8 @@ export class Pairing implements IPairing {
       this.isValidPing({ topic });
       await this.sendResult<"wc_pairingPing">(id, topic, true);
       this.events.emit("pairing_ping", { id, topic });
+      // eslint-disable-next-line no-console
+      console.log("pairing ping request acknowledged", topic);
     } catch (err: any) {
       await this.sendError(id, topic, err);
       this.logger.error(err);

--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -147,8 +147,6 @@ export class Pairing implements IPairing {
     if (this.pairings.keys.includes(topic)) {
       const id = await this.sendRequest(topic, "wc_pairingPing", {});
       const { done, resolve, reject } = createDelayedPromise<void>();
-      // eslint-disable-next-line no-console
-      console.log("listening for pairing ping response", engineEvent("pairing_ping", id));
       this.events.once(engineEvent("pairing_ping", id), ({ error }) => {
         if (error) reject(error);
         else resolve();
@@ -298,8 +296,6 @@ export class Pairing implements IPairing {
       this.isValidPing({ topic });
       await this.sendResult<"wc_pairingPing">(id, topic, true);
       this.events.emit("pairing_ping", { id, topic });
-      // eslint-disable-next-line no-console
-      console.log("pairing ping request acknowledged", topic);
     } catch (err: any) {
       await this.sendError(id, topic, err);
       this.logger.error(err);
@@ -313,8 +309,6 @@ export class Pairing implements IPairing {
     setTimeout(() => {
       if (isJsonRpcResult(payload)) {
         this.events.emit(engineEvent("pairing_ping", id), {});
-        // eslint-disable-next-line no-console
-        console.log("pairing_ping", id, engineEvent("pairing_ping", id));
       } else if (isJsonRpcError(payload)) {
         this.events.emit(engineEvent("pairing_ping", id), { error: payload.error });
       }

--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -147,6 +147,8 @@ export class Pairing implements IPairing {
     if (this.pairings.keys.includes(topic)) {
       const id = await this.sendRequest(topic, "wc_pairingPing", {});
       const { done, resolve, reject } = createDelayedPromise<void>();
+      // eslint-disable-next-line no-console
+      console.log("listening for pairing ping response", engineEvent("pairing_ping", id));
       this.events.once(engineEvent("pairing_ping", id), ({ error }) => {
         if (error) reject(error);
         else resolve();
@@ -187,8 +189,7 @@ export class Pairing implements IPairing {
     const message = await this.core.crypto.encode(topic, payload);
     const opts = PAIRING_RPC_OPTS[method].req;
     this.core.history.set(topic, payload);
-    await this.core.relayer.publish(topic, message, opts);
-
+    this.core.relayer.publish(topic, message, opts);
     return payload.id;
   };
 

--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -312,6 +312,8 @@ export class Pairing implements IPairing {
     setTimeout(() => {
       if (isJsonRpcResult(payload)) {
         this.events.emit(engineEvent("pairing_ping", id), {});
+        // eslint-disable-next-line no-console
+        console.log("pairing_ping", id, engineEvent("pairing_ping", id));
       } else if (isJsonRpcError(payload)) {
         this.events.emit(engineEvent("pairing_ping", id), { error: payload.error });
       }

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -322,7 +322,11 @@ export class Engine extends IEngine {
       });
       await done();
     } else if (this.client.core.pairing.pairings.keys.includes(topic)) {
+      console.log("pairing ping", topic);
       await this.client.core.pairing.ping({ topic });
+      console.log("pairing ping done", topic);
+    } else {
+      console.log("no session or pairing found", topic);
     }
   };
 

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -323,11 +323,7 @@ export class Engine extends IEngine {
       });
       await done();
     } else if (this.client.core.pairing.pairings.keys.includes(topic)) {
-      console.log("pairing ping", topic);
       await this.client.core.pairing.ping({ topic });
-      console.log("pairing ping done", topic);
-    } else {
-      console.log("no session or pairing found", topic);
     }
   };
 
@@ -510,8 +506,6 @@ export class Engine extends IEngine {
         }
 
         const payload = await this.client.core.crypto.decode(topic, message);
-        // eslint-disable-next-line no-console
-        console.log("Relayer message", this.client.name, payload);
 
         if (isJsonRpcRequest(payload)) {
           this.client.core.history.set(topic, payload);

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -234,7 +234,10 @@ export class Engine extends IEngine {
     await this.setExpiry(sessionTopic, calcExpiry(SESSION_EXPIRY));
     return {
       topic: sessionTopic,
-      acknowledged: () => new Promise((resolve) => resolve(this.client.session.get(sessionTopic))),
+      acknowledged: () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve(this.client.session.get(sessionTopic)), 5_00),
+        ), // artificial delay to allow for the session to be processed by the peer
     };
   };
 

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -505,6 +505,8 @@ export class Engine extends IEngine {
         }
 
         const payload = await this.client.core.crypto.decode(topic, message);
+        // eslint-disable-next-line no-console
+        console.log("Relayer message", this.client.name, payload);
 
         if (isJsonRpcRequest(payload)) {
           this.client.core.history.set(topic, payload);

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { EXPIRER_EVENTS, RELAYER_DEFAULT_PROTOCOL, RELAYER_EVENTS } from "@walletconnect/core";
 
 import {

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -131,7 +131,7 @@ describe("Sign Client Integration", () => {
       );
       await deleteClients(clients);
     });
-    describe.only("pairing", () => {
+    describe("pairing", () => {
       describe("with existing pairing", () => {
         it("A pings B", async () => {
           const clients = await initTwoClients({ name: "dapp" }, { name: "wallet" });

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -131,10 +131,10 @@ describe("Sign Client Integration", () => {
       );
       await deleteClients(clients);
     });
-    describe("pairing", () => {
+    describe.only("pairing", () => {
       describe("with existing pairing", () => {
         it("A pings B", async () => {
-          const clients = await initTwoClients();
+          const clients = await initTwoClients({ name: "dapp" }, { name: "wallet" });
           const {
             pairingA: { topic },
           } = await testConnectMethod(clients);
@@ -142,7 +142,7 @@ describe("Sign Client Integration", () => {
           await deleteClients(clients);
         });
         it("B pings A", async () => {
-          const clients = await initTwoClients();
+          const clients = await initTwoClients({ name: "dapp" }, { name: "wallet" });
           const {
             pairingA: { topic },
           } = await testConnectMethod(clients);


### PR DESCRIPTION
## Description

Added 500ms delay on the optimistic session approval to avoid race conditions where the peer might have not finished processing the proposal while receiving requests resulting in `No matching key: session ..` exception on the peer side

- also removed `await` on paring ping request as the `ack` might be received before the event listener is initialized

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding
sending `session_event` immediately after `approve` resulting in the `no matching key: session ...` on the peer client
## Fixes/Resolves (Optional)

Please list any issues that are fixed by this PR in the format `#<issue number>`. If it fixes multiple issues, please put each issue in a separate line. If this Pull Request does not fix any issues, please delete this section.

Use this table template to show examples of your changes:

| Before       | After        |
| ------------ | ------------ |
| `No matching key: session ...` Error | No errors |

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
