### PR TITLE
fix: parse pairing topic

### DIFF
--- a/packages/utils/src/uri.ts
+++ b/packages/utils/src/uri.ts
@@ -26,12 +26,16 @@ export function parseUri(str: string): EngineTypes.UriParameters {
   const queryParams = qs.parse(queryString);
   const result = {
     protocol,
-    topic: requiredValues[0],
+    topic: parseTopic(requiredValues[0]),
     version: parseInt(requiredValues[1], 10),
     symKey: queryParams.symKey as string,
     relay: parseRelayParams(queryParams),
   };
   return result;
+}
+
+export function parseTopic(topic: string): string {
+  return topic.startsWith("//") ? topic.substring(2) : topic;
 }
 
 export function formatRelayParams(relay: RelayerTypes.ProtocolOptions, delimiter = "-") {

--- a/packages/utils/test/uri.spec.ts
+++ b/packages/utils/test/uri.spec.ts
@@ -1,6 +1,6 @@
 import { EngineTypes } from "@walletconnect/types";
 import { expect, describe, it } from "vitest";
-import { formatUri, parseUri } from "../src";
+import { formatUri, generateRandomBytes32, parseUri } from "../src";
 import { TEST_PAIRING_TOPIC, TEST_RELAY_OPTIONS, TEST_SYM_KEY } from "./shared";
 
 const TEST_URI_PARAMS: EngineTypes.UriParameters = {
@@ -25,5 +25,13 @@ describe("URI", () => {
     expect(uriParams.symKey).to.eql(TEST_URI_PARAMS.symKey);
     expect(uriParams.relay.data).to.eql(TEST_URI_PARAMS.relay.data);
     expect(uriParams.relay.protocol).to.eql(TEST_URI_PARAMS.relay.protocol);
+  });
+  it("parseTopic", () => {
+    const topic = generateRandomBytes32();
+    const androidSchemaTopic = `//${topic}`;
+    TEST_URI_PARAMS.topic = androidSchemaTopic;
+    expect(parseUri(formatUri(TEST_URI_PARAMS)).topic).to.not.eql(androidSchemaTopic);
+    expect(parseUri(formatUri(TEST_URI_PARAMS)).topic).to.eql(topic);
+    expect(parseUri(formatUri(TEST_URI_PARAMS)).topic.startsWith("//")).to.be.false;
   });
 });


### PR DESCRIPTION
## Description
Added `parseTopic` util that strips prefixed `//` from pairing topics coming from android deep links

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests
dogfooding
## Fixes/Resolves (Optional)

Please list any issues that are fixed by this PR in the format `#<issue number>`. If it fixes multiple issues, please put each issue in a separate line. If this Pull Request does not fix any issues, please delete this section.

## Examples/Screenshots (Optional)

Please attach a screenshot or screen recording of features/fixes you've implemented to verify your changes. Please also note any relevant details for your configuration. If your changes do not affect the UI, please delete this section.

Use this table template to show examples of your changes:

| Before       | After        |
| ------------ | ------------ |
| topic: `//xyz...` | topic `xyz...` |

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
