### PR TITLE
fix: EthereumProvider: Appropriate try catch

### DIFF
--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -501,7 +501,8 @@ export class EthereumProvider implements IEthereumProvider {
             standaloneChains: this.rpc.chains,
             ...this.rpc.qrModalOptions,
           });
-        } catch {
+        } catch(e) {
+      this.signer.logger.error(e);
           throw new Error("Could not generate Web3Modal Instance");
         }
       }

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -501,8 +501,8 @@ export class EthereumProvider implements IEthereumProvider {
             standaloneChains: this.rpc.chains,
             ...this.rpc.qrModalOptions,
           });
-        } catch(e) {
-      this.signer.logger.error(e);
+        } catch (e) {
+          this.signer.logger.error(e);
           throw new Error("Could not generate Web3Modal Instance");
         }
       }

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -486,16 +486,26 @@ export class EthereumProvider implements IEthereumProvider {
     this.registerEventListeners();
     await this.loadPersistedSession();
     if (this.rpc.showQrModal) {
+      let Web3modalClass;
       try {
         const { Web3Modal } = await import("@web3modal/standalone");
-        this.modal = new Web3Modal({
-          walletConnectVersion: 2,
-          projectId: this.rpc.projectId,
-          standaloneChains: this.rpc.chains,
-          ...this.rpc.qrModalOptions,
-        });
+        Web3modalClass = Web3Modal;
       } catch {
         throw new Error("To use QR modal, please install @web3modal/standalone package");
+      }
+      if (Web3modalClass) {
+        try {
+          this.modal = new Web3modalClass({
+            walletConnectVersion: 2,
+            projectId: this.rpc.projectId,
+            standaloneChains: this.rpc.chains,
+            ...this.rpc.qrModalOptions,
+          });
+        } catch {
+          throw new Error(
+            "Could not generate Web3Modal Instance, something is likely wrong with your options.",
+          );
+        }
       }
     }
   }

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -502,9 +502,7 @@ export class EthereumProvider implements IEthereumProvider {
             ...this.rpc.qrModalOptions,
           });
         } catch {
-          throw new Error(
-            "Could not generate Web3Modal Instance, something is likely wrong with your options.",
-          );
+          throw new Error("Could not generate Web3Modal Instance");
         }
       }
     }


### PR DESCRIPTION
When calling initialize of EthereumProvider, we can get the error "To use QR modal, please install @web3modal/standalone package"

The error thrown naively assumes the issue is with importing `@web3modal/standalone` when the issue could be from instancing the modal.
This PR adds a new try catch to make it easier to debug issues.

## Description

Please include a brief summary of the change.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

This has not been tested however I could build the branch fine;

## Fixes/Resolves (Optional)

#2449

| Before       | After        |
| ------------ | ------------ |
| EthereumProvider.ts - Try catch| EthereumProvider.ts - one more Try catch |

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
