### PR TITLE
fix: duplicate pairings clean up

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -367,7 +367,8 @@ export class Engine extends IEngine {
       const duplicates = allPairings.filter(
         (p) =>
           p.peerMetadata?.url &&
-          p.peerMetadata?.url === session.self.metadata.url &&
+          p.peerMetadata?.url === session.peer.metadata.url &&
+          p.topic &&
           p.topic !== pairing.topic,
       );
       if (duplicates.length === 0) return;

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -60,6 +60,19 @@ describe("Sign Client Integration", () => {
       });
       await deleteClients(clients);
     });
+    it("should remove duplicate pairing", async () => {
+      const clients = await initTwoClients();
+      await testConnectMethod(clients);
+      const { A, B } = clients;
+      expect(A.pairing.keys).to.eql(B.pairing.keys);
+      expect(A.pairing.keys.length).to.eql(1);
+      await throttle(200);
+      await testConnectMethod(clients);
+      await throttle(200);
+      expect(A.pairing.keys).to.eql(B.pairing.keys);
+      expect(A.pairing.keys.length).to.eql(1);
+      await deleteClients(clients);
+    });
     it("should receive session acknowledge", async () => {
       const clients = await initTwoClients();
       const {

--- a/packages/sign-client/test/shared/values.ts
+++ b/packages/sign-client/test/shared/values.ts
@@ -66,7 +66,7 @@ export const TEST_SIGN_CLIENT_NAME_A = "client_a";
 export const TEST_APP_METADATA_A: SignClientTypes.Metadata = {
   name: "App A (Proposer)",
   description: "Description of Proposer App run by client A",
-  url: "https://walletconnect.com",
+  url: "https://app.a.walletconnect.com",
   icons: ["https://avatars.githubusercontent.com/u/37784886"],
   redirect: {
     universal: "App A (Proposer)",
@@ -78,7 +78,7 @@ export const TEST_SIGN_CLIENT_NAME_B = "client_b";
 export const TEST_APP_METADATA_B: SignClientTypes.Metadata = {
   name: "App B (Responder)",
   description: "Description of Responder App run by client B",
-  url: "https://walletconnect.com",
+  url: "https://app.b.walletconnect.com",
   icons: ["https://avatars.githubusercontent.com/u/37784886"],
   redirect: {
     universal: "App B (Responder)",


### PR DESCRIPTION
## Description
Fixed bug where incorrect url comparison was done between `peerMetadata.url` and `session.self.metadata.url`instead of the correct `peerMetadata.url === session.peer.metadata.url`

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding
tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules