### PR TITLE
feat: ethereum-provider open modal on eth_requestAccounts

### DIFF
--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -228,6 +228,7 @@ export class EthereumProvider implements IEthereumProvider {
   }
 
   public async request<T = unknown>(args: RequestArguments): Promise<T> {
+    if(args.method === "eth_requestAccounts" && !this.session) await this.connect();
     return await this.signer.request(args, this.formatChainId(this.chainId));
   }
 
@@ -250,7 +251,7 @@ export class EthereumProvider implements IEthereumProvider {
 
   public async enable(): Promise<ProviderAccounts> {
     if (!this.session) await this.connect();
-    const accounts = await this.request({ method: "eth_requestAccounts" });
+    const accounts = await this.request({ method: "eth_accounts" });
     return accounts as ProviderAccounts;
   }
 


### PR DESCRIPTION
> Creating a release? Please use the [Release PR Template](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/.github/pr_template_release.md) instead.

## Description

Open modal on ethereum-provider when requesting "eth_requestAccounts" if session is closed.
The motivation behind is that wallet extensions use this method to trigger/popup a connection request to the user.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Somehow I'm getting typescript errors/warnings on the code (without even touching anything).

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
