### PR TITLE
fix: relayer subscribe

### DIFF
--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -125,7 +125,10 @@ export class Relayer extends IRelayer {
 
   public async subscribe(topic: string, opts?: RelayerTypes.SubscribeOptions) {
     this.isInitialized();
-    let id = "";
+    let id = this.subscriber.topicMap.get(topic)?.[0] || "";
+
+    if (id) return id;
+
     await Promise.all([
       new Promise<void>((resolve) => {
         this.subscriber.once(SUBSCRIBER_EVENTS.created, (subscription: SubscriberTypes.Active) => {
@@ -139,6 +142,7 @@ export class Relayer extends IRelayer {
         resolve();
       }),
     ]);
+
     return id;
   }
 

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -146,7 +146,7 @@ describe("Relayer", () => {
       expect(id).to.eq("mock-id");
     });
 
-    it("should subscribe a topic immediately after connect", async () => {
+    it("should be able to resubscribe on topic that already exists", async () => {
       const topic = generateRandomBytes32();
       const id = await relayer.subscribe(topic);
       const expectedId = hashMessage(topic + (await core.crypto.getClientId()));

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -16,7 +16,7 @@ import { disconnectSocket, TEST_CORE_OPTIONS, throttle } from "./shared";
 import { ICore, IRelayer } from "@walletconnect/types";
 import Sinon from "sinon";
 import { JsonRpcRequest } from "@walletconnect/jsonrpc-utils";
-import { generateRandomBytes32 } from "@walletconnect/utils";
+import { generateRandomBytes32, hashMessage } from "@walletconnect/utils";
 
 describe("Relayer", () => {
   const logger = pino(getDefaultLoggerOptions({ level: CORE_DEFAULT.logger }));
@@ -144,6 +144,22 @@ describe("Relayer", () => {
       // @ts-expect-error
       expect(spy.calledOnceWith("abc123")).to.be.true;
       expect(id).to.eq("mock-id");
+    });
+
+    it("should subscribe a topic immediately after connect", async () => {
+      const topic = generateRandomBytes32();
+      const id = await relayer.subscribe(topic);
+      const expectedId = hashMessage(topic + (await core.crypto.getClientId()));
+      const a = await relayer.subscribe(topic);
+      const b = await relayer.subscribe(topic);
+      const c = await relayer.subscribe(topic);
+      expect(a).to.equal(id);
+      expect(a).to.equal(b);
+      expect(b).to.equal(c);
+      expect(a).to.equal(expectedId);
+      expect(b).to.equal(expectedId);
+      expect(c).to.equal(expectedId);
+      expect(id).to.equal(expectedId);
     });
   });
 


### PR DESCRIPTION
## Description

Fixed a bug where if you resubscribe to a topic that already exists `relayer.subscribe` was hanging stuck as `SUBSCRIBER_EVENTS.created` is not emitted to release the promise.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests
## Fixes/Resolves (Optional)
https://github.com/WalletConnect/walletconnect-monorepo/issues/2498
## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
