### PR TITLE
fix: avoid starting new connection if one is already being started

### DIFF
--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -230,7 +230,7 @@ export class Relayer extends IRelayer {
   }
 
   public async restartTransport(relayUrl?: string) {
-    if (this.transportExplicitlyClosed) return;
+    if (this.transportExplicitlyClosed || this.reconnecting) return;
     this.relayUrl = relayUrl || this.relayUrl;
     if (this.connected) {
       await Promise.all([


### PR DESCRIPTION
## Description
Receiving multiple disconnect events was causing a connection to be established for each event. Added fix where we avoid starting new connection if one is being started already   

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding
canary `2.7.8-canary-2`

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
