### PR TITLE
feat: add `eth_signTypedData_v4` to required methods

### DIFF
--- a/providers/ethereum-provider/src/constants/rpc.ts
+++ b/providers/ethereum-provider/src/constants/rpc.ts
@@ -1,4 +1,4 @@
-export const REQUIRED_METHODS = ["eth_sendTransaction", "personal_sign"];
+export const REQUIRED_METHODS = ["eth_sendTransaction", "personal_sign", "eth_signTypedData_v4"];
 export const OPTIONAL_METHODS = [
   "eth_accounts",
   "eth_requestAccounts",
@@ -9,7 +9,6 @@ export const OPTIONAL_METHODS = [
   "eth_signTransaction",
   "eth_signTypedData",
   "eth_signTypedData_v3",
-  "eth_signTypedData_v4",
   "wallet_switchEthereumChain",
   "wallet_addEthereumChain",
   "wallet_getPermissions",


### PR DESCRIPTION
Should `eth_signTypedData_v4` should be required? 