### PR TITLE
Add sideEffects field to ethereum-provider

### DIFF
--- a/providers/ethereum-provider/package.json
+++ b/providers/ethereum-provider/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.es.js",
   "unpkg": "dist/index.umd.js",
   "types": "dist/types/index.d.ts",
+  "sideEffects": "false",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
> Creating a release? Please use the [Release PR Template](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/.github/pr_template_release.md) instead.

## Description

We've been asked by partners (wagmi) to add `sideEffects: false` field in package.json of ethereum-provider. More context on it here https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free in essence this field helps bundlers like webpack / viem to tree shake dead code in libs that are not pure esm modules.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

- Automated tests

## Fixes/Resolves (Optional)

N/A

## Examples/Screenshots (Optional)

N/A

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

N/A
