### PR TITLE
feat(Canary): do not report latency of failed runs

### DIFF
--- a/packages/sign-client/test/shared/metrics.ts
+++ b/packages/sign-client/test/shared/metrics.ts
@@ -44,7 +44,10 @@ export const uploadCanaryResultsToCloudWatch = async (
       Value: isTestPassed ? 0 : 1,
       Timestamp: ts,
     },
-    {
+  ];
+
+  if (isTestPassed) {
+    metrics.push({
       MetricName: `${metricsPrefix}.latency`,
       Dimensions: [
         {
@@ -59,8 +62,8 @@ export const uploadCanaryResultsToCloudWatch = async (
       Unit: "Milliseconds",
       Value: testDurationMs,
       Timestamp: ts,
-    },
-  ];
+    });
+  }
 
   const latencies = otherLatencies.map((metric) => {
     const metricName = Object.keys(metric)[0];


### PR DESCRIPTION
> Creating a release? Please use the [Release PR Template](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/.github/pr_template_release.md) instead.

## Description

We have alarms for when the Canary fails. If the Canary fails often the latency is also spiking. In that case we get two alarms. This risks us investigating the wrong alarm.

A good solution is for the Canary to only report latency when the tests succeed as that is what the metric/alarms are designed to track.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your configuration.

## Fixes/Resolves (Optional)

Please list any issues that are fixed by this PR in the format `#<issue number>`. If it fixes multiple issues, please put each issue in a separate line. If this Pull Request does not fix any issues, please delete this section.

## Examples/Screenshots (Optional)

Please attach a screenshot or screen recording of features/fixes you've implemented to verify your changes. Please also note any relevant details for your configuration. If your changes do not affect the UI, please delete this section.

Use this table template to show examples of your changes:

| Before       | After        |
| ------------ | ------------ |
| Content Cell | Content Cell |
| Content Cell | Content Cell |

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
