### PR TITLE
fix: disconnect exceptions

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -390,12 +390,14 @@ export class Engine extends IEngine {
     const { self } = this.client.session.get(topic);
     // Await the unsubscribe first to avoid deleting the symKey too early below.
     await this.client.core.relayer.unsubscribe(topic);
-    await Promise.all([
-      this.client.session.delete(topic, getSdkError("USER_DISCONNECTED")),
-      this.client.core.crypto.deleteKeyPair(self.publicKey),
-      this.client.core.crypto.deleteSymKey(topic),
-      expirerHasDeleted ? Promise.resolve() : this.client.core.expirer.del(topic),
-    ]);
+    this.client.session.delete(topic, getSdkError("USER_DISCONNECTED"));
+    if (this.client.core.crypto.keychain.has(topic)) {
+      await this.client.core.crypto.deleteKeyPair(self.publicKey);
+    }
+    if (this.client.core.crypto.keychain.has(topic)) {
+      await this.client.core.crypto.deleteSymKey(topic);
+    }
+    if (!expirerHasDeleted) this.client.core.expirer.del(topic);
   };
 
   private deleteProposal: EnginePrivate["deleteProposal"] = async (id, expirerHasDeleted) => {

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -801,7 +801,6 @@ export class Engine extends IEngine {
       ]);
       this.client.events.emit("session_delete", { id, topic });
     } catch (err: any) {
-      await this.sendError(id, topic, err);
       this.client.logger.error(err);
     }
   };

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -417,7 +417,7 @@ export class Engine extends IEngine {
     // Await the unsubscribe first to avoid deleting the symKey too early below.
     await this.client.core.relayer.unsubscribe(topic);
     this.client.session.delete(topic, getSdkError("USER_DISCONNECTED"));
-    if (this.client.core.crypto.keychain.has(topic)) {
+    if (this.client.core.crypto.keychain.has(self.publicKey)) {
       await this.client.core.crypto.deleteKeyPair(self.publicKey);
     }
     if (this.client.core.crypto.keychain.has(topic)) {

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -144,7 +144,7 @@ describe("Sign Client Integration", () => {
         await expect(promise).rejects.toThrowError(
           `No matching key. session or pairing topic doesn't exist: ${topic}`,
         );
-        await throttle(5_000);
+        await throttle(2_000);
         expect(clients.A.core.crypto.keychain.has(topic)).to.be.false;
         expect(clients.A.core.crypto.keychain.has(self.publicKey)).to.be.false;
         expect(clients.B.core.crypto.keychain.has(topic)).to.be.false;
@@ -321,7 +321,7 @@ describe("Sign Client Integration", () => {
             RELAYER_EVENTS.publish,
             (payload: RelayerTypes.PublishPayload) => {
               // ttl of the request should match the expiry
-              expect(payload?.opts?.ttl).toEqual(expiry);
+              // expect(payload?.opts?.ttl).toEqual(expiry);
               resolve();
             },
           );

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -144,7 +144,7 @@ describe("Sign Client Integration", () => {
         await expect(promise).rejects.toThrowError(
           `No matching key. session or pairing topic doesn't exist: ${topic}`,
         );
-        await throttle(1_000);
+        await throttle(5_000);
         expect(clients.A.core.crypto.keychain.has(topic)).to.be.false;
         expect(clients.A.core.crypto.keychain.has(self.publicKey)).to.be.false;
         expect(clients.B.core.crypto.keychain.has(topic)).to.be.false;

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -310,9 +310,8 @@ describe("Sign Client Integration", () => {
           clients.A.core.relayer.once(
             RELAYER_EVENTS.publish,
             (payload: RelayerTypes.PublishPayload) => {
-              console.log("expiry payload", payload.opts?.ttl, expiry);
               // ttl of the request should match the expiry
-              // expect(payload?.opts?.ttl).toEqual(expiry);
+              expect(payload?.opts?.ttl).toEqual(expiry);
               resolve();
             },
           );

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -154,6 +154,7 @@ export interface EnginePrivate {
     method: M,
     params: JsonRpcTypes.RequestParams[M],
     expiry?: number,
+    id?: number,
   ): Promise<number>;
 
   sendResult<M extends JsonRpcTypes.WcMethod>(


### PR DESCRIPTION
## Description
In rare cases when session disconnect is initiated from both peers could result in an invalid state where the session is active while keychain has been deleted. This blocks the client from deleting the session via `disconnect` method.

- Added checks for each data type before deleting as if such an invalid state is reached, the session is unusable anyway so we shouldn't prevent deletion.
- Removed redundant error response on session disconnect
- Added an await for relay ACK on the disconnect request before deleting the respective data
- Added optional ID parameter to `sendRequest`

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests already covering disconnect functionality
dogfooding in example apps

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
