### PR TITLE
fix(ethereum-provider): removes non-signer/non-wallet optionalMethods

### DIFF
--- a/providers/ethereum-provider/src/constants/rpc.ts
+++ b/providers/ethereum-provider/src/constants/rpc.ts
@@ -2,8 +2,6 @@ export const REQUIRED_METHODS = ["eth_sendTransaction", "personal_sign"];
 export const OPTIONAL_METHODS = [
   "eth_accounts",
   "eth_requestAccounts",
-  "eth_call",
-  "eth_getBalance",
   "eth_sendRawTransaction",
   "eth_sign",
   "eth_signTransaction",


### PR DESCRIPTION
> Creating a release? Please use the [Release PR Template](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/.github/pr_template_release.md) instead.

## Description

- Relates to https://github.com/orgs/WalletConnect/discussions/2534, #2636
- The presence of `eth_call` and `eth_getBalance` as part of the default `OPTIONAL_METHODS` was causing wagmi to route these two calls to the wallet/signer via WalletConnect, rather than towards HTTP RPC.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your configuration.

## Fixes/Resolves (Optional)

- Fixes #2636

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

- Will require an update on wagmi's end once this is published
