### PR TITLE
fix: `pairingTopic undefined`

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -391,6 +391,9 @@ export class Engine extends IEngine {
   private cleanupDuplicatePairings: EnginePrivate["cleanupDuplicatePairings"] = async (
     session: SessionTypes.Struct,
   ) => {
+    // older SDK versions are missing the `pairingTopic` prop thus we need to check for it
+    if (!session.pairingTopic) return;
+
     try {
       const pairing = this.client.core.pairing.pairings.get(session.pairingTopic);
       const allPairings = this.client.core.pairing.pairings.getAll();


### PR DESCRIPTION
## Description
Added a check that `session.pairingTopic` exists before attempting to clean up duplicate pairings as older SDK versions do not have this prop

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding
tests
## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
