### PR TITLE
fix: ethereum provider persisted session with inline chain declaration

### DIFF
--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -397,7 +397,7 @@ export class EthereumProvider implements IEthereumProvider {
     });
   }
 
-  protected setHttpProvider(chainId: number): void {
+  protected switchEthereumChain(chainId: number): void {
     this.request({
       method: "wallet_switchEthereumChain",
       params: [{ chainId: chainId.toString(16) }],
@@ -430,7 +430,7 @@ export class EthereumProvider implements IEthereumProvider {
     if (this.isCompatibleChainId(chain)) {
       const chainId = this.parseChainId(chain);
       this.chainId = chainId;
-      this.setHttpProvider(chainId);
+      this.switchEthereumChain(chainId);
     }
   }
 

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "events";
 import { getAccountsFromNamespaces, getSdkError, isValidArray } from "@walletconnect/utils";
+import { KeyValueStorageOptions } from "@walletconnect/keyvaluestorage";
 import {
   IEthereumProvider as IProvider,
   IEthereumProviderEvents,
@@ -202,6 +203,8 @@ export interface EthereumProviderOptions {
   showQrModal: boolean;
   qrModalOptions?: QrModalOptions;
   disableProviderPing?: boolean;
+  relayUrl?: string;
+  storageOptions?: KeyValueStorageOptions;
 }
 
 export class EthereumProvider implements IEthereumProvider {
@@ -482,6 +485,8 @@ export class EthereumProvider implements IEthereumProvider {
       projectId: this.rpc.projectId,
       metadata: this.rpc.metadata,
       disableProviderPing: opts.disableProviderPing,
+      relayUrl: opts.relayUrl,
+      storageOptions: opts.storageOptions,
     });
     this.registerEventListeners();
     await this.loadPersistedSession();

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -545,9 +545,9 @@ export class EthereumProvider implements IEthereumProvider {
     const chainId = await this.signer.client.core.storage.getItem(`${this.STORAGE_KEY}/chainId`);
 
     // cater to both inline & nested namespace formats
-    const namespace = this.session.namespaces[this.namespace]
-      ? this.session.namespaces[this.namespace]
-      : this.session.namespaces[`${this.namespace}:${chainId}`];
+    const namespace = this.session.namespaces[`${this.namespace}:${chainId}`]
+      ? this.session.namespaces[`${this.namespace}:${chainId}`]
+      : this.session.namespaces[this.namespace];
 
     this.setChainIds(chainId ? [this.formatChainId(chainId)] : namespace?.accounts);
     this.setAccounts(namespace?.accounts);

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -543,10 +543,14 @@ export class EthereumProvider implements IEthereumProvider {
   protected async loadPersistedSession() {
     if (!this.session) return;
     const chainId = await this.signer.client.core.storage.getItem(`${this.STORAGE_KEY}/chainId`);
-    this.setChainIds(
-      chainId ? [this.formatChainId(chainId)] : this.session.namespaces[this.namespace].accounts,
-    );
-    this.setAccounts(this.session.namespaces[this.namespace].accounts);
+
+    // cater to both inline & nested namespace formats
+    const namespace = this.session.namespaces[this.namespace]
+      ? this.session.namespaces[this.namespace]
+      : this.session.namespaces[`${this.namespace}:${chainId}`];
+
+    this.setChainIds(chainId ? [this.formatChainId(chainId)] : namespace?.accounts);
+    this.setAccounts(namespace?.accounts);
   }
 
   protected reset() {


### PR DESCRIPTION
## Description
Fixed an issue where `loadPersistedSession` fx was not catering to inline chain declared namespaces e.g. `eip155:1`
additionally
- Added `relayUrl` to init params
- Added `storageOptions` to init params
- Renamed `setHttpProvider` fx to `switchEthereumChain` as its more appropriate name for what it does

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Fixes/Resolves (Optional)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
