### PR TITLE
refactor: verify - silent POST to loading iframe

### DIFF
--- a/packages/core/src/controllers/verify.ts
+++ b/packages/core/src/controllers/verify.ts
@@ -35,9 +35,10 @@ export class Verify extends IVerify {
     }
 
     if (!this.iframe) return;
-
-    this.iframe.contentWindow?.postMessage(params.attestationId, this.verifyUrl);
-    this.logger.info(`postMessage sent: ${params.attestationId} ${this.verifyUrl}`);
+    try {
+      this.iframe.contentWindow?.postMessage(params.attestationId, this.verifyUrl);
+      this.logger.info(`postMessage sent: ${params.attestationId} ${this.verifyUrl}`);
+    } catch (e) {} // fail silently to avoid logging `Failed to execute 'postMessage' on 'DOMWindow': The target origin provided...` while the iframe is still loading
   };
 
   public resolve: IVerify["resolve"] = async (params) => {


### PR DESCRIPTION
## Description
Added `try/catch` around verify POST to avoid logging `Failed …to execute 'postMessage' on 'DOMWindow': The target origin provided...` error message while the iframe is still loading. 
Browsers have a built-in retry policy that handle the case


## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding
## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
