### PR TITLE
fix(react-native): detect RN OS via `global.Platform` binding

### DIFF
--- a/packages/react-native-compat/index.js
+++ b/packages/react-native-compat/index.js
@@ -17,3 +17,12 @@ if (typeof global?.Linking === "undefined") {
     console.error("react-native-compat: react-native.Linking is not available");
   }
 }
+
+if (typeof global?.Platform === "undefined") {
+  try {
+    global.Platform = require("react-native").Platform;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error("react-native-compat: react-native.Platform is not available");
+  }
+}

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -96,6 +96,12 @@ export function getRelayClientMetadata(protocol: string, version: number): Relay
 // -- rpcUrl ----------------------------------------------//
 
 export function getJavascriptOS() {
+  // global.Platform is set by react-native-compat
+  if (typeof (global as any)?.Platform !== "undefined") {
+    const { OS, Version } = (global as any).Platform;
+    return [OS, Version].join("-");
+  }
+
   const info = detect();
   if (info === null) return "unknown";
   const os = info.os ? info.os.replace(" ", "").toLowerCase() : "unknown";


### PR DESCRIPTION
## Description

- Towards #2573 
- Binds `react-native`'s `Platform` object to `global` so we can access it in an isomorphic way inside `getJavascriptOS`

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

- Canary: `2.8.1-0107ef6c`
- Validated in React Native via @ignaciosantise 
- Tested in web via sample wallet and dapp

## Fixes/Resolves (Optional)

- Fixes #2573 

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
