### PR TITLE
chore: prep for `2.8.2` release

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
     "providers/*"
   ],
   "useWorkspaces": true,
-  "version": "2.8.1"
+  "version": "2.8.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25524,7 +25524,7 @@
     },
     "packages/core": {
       "name": "@walletconnect/core",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
@@ -25538,8 +25538,8 @@
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.8.1",
-        "@walletconnect/utils": "2.8.1",
+        "@walletconnect/types": "2.8.2",
+        "@walletconnect/utils": "2.8.2",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "^3.1.0"
@@ -25568,7 +25568,7 @@
     },
     "packages/react-native-compat": {
       "name": "@walletconnect/react-native-compat",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "events": "3.3.0",
@@ -25581,17 +25581,17 @@
     },
     "packages/sign-client": {
       "name": "@walletconnect/sign-client",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@walletconnect/core": "2.8.1",
+        "@walletconnect/core": "2.8.2",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.8.1",
-        "@walletconnect/utils": "2.8.1",
+        "@walletconnect/types": "2.8.2",
+        "@walletconnect/utils": "2.8.2",
         "events": "^3.3.0"
       },
       "devDependencies": {
@@ -25604,7 +25604,7 @@
     },
     "packages/types": {
       "name": "@walletconnect/types",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
@@ -25617,7 +25617,7 @@
     },
     "packages/utils": {
       "name": "@walletconnect/utils",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
@@ -25628,7 +25628,7 @@
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.8.1",
+        "@walletconnect/types": "2.8.2",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -25641,17 +25641,17 @@
     },
     "packages/web3wallet": {
       "name": "@walletconnect/web3wallet",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/auth-client": "2.1.0",
-        "@walletconnect/core": "2.8.1",
+        "@walletconnect/core": "2.8.2",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.0.1",
-        "@walletconnect/sign-client": "2.8.1",
-        "@walletconnect/types": "2.8.1",
-        "@walletconnect/utils": "2.8.1"
+        "@walletconnect/sign-client": "2.8.2",
+        "@walletconnect/types": "2.8.2",
+        "@walletconnect/utils": "2.8.2"
       },
       "devDependencies": {
         "@ethersproject/wallet": "^5.7.0",
@@ -25660,17 +25660,17 @@
     },
     "providers/ethereum-provider": {
       "name": "@walletconnect/ethereum-provider",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
         "@walletconnect/jsonrpc-provider": "^1.0.13",
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
-        "@walletconnect/sign-client": "2.8.1",
-        "@walletconnect/types": "2.8.1",
-        "@walletconnect/universal-provider": "2.8.1",
-        "@walletconnect/utils": "2.8.1",
+        "@walletconnect/sign-client": "2.8.2",
+        "@walletconnect/types": "2.8.2",
+        "@walletconnect/universal-provider": "2.8.2",
+        "@walletconnect/utils": "2.8.2",
         "events": "^3.3.0"
       },
       "devDependencies": {
@@ -25691,21 +25691,21 @@
     },
     "providers/signer-connection": {
       "name": "@walletconnect/signer-connection",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
-        "@walletconnect/sign-client": "2.8.1",
-        "@walletconnect/types": "2.8.1",
-        "@walletconnect/utils": "2.8.1",
+        "@walletconnect/sign-client": "2.8.2",
+        "@walletconnect/types": "2.8.2",
+        "@walletconnect/utils": "2.8.2",
         "events": "^3.3.0",
         "uint8arrays": "^3.1.0"
       }
     },
     "providers/universal-provider": {
       "name": "@walletconnect/universal-provider",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
@@ -25713,9 +25713,9 @@
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sign-client": "2.8.1",
-        "@walletconnect/types": "2.8.1",
-        "@walletconnect/utils": "2.8.1",
+        "@walletconnect/sign-client": "2.8.2",
+        "@walletconnect/types": "2.8.2",
+        "@walletconnect/utils": "2.8.2",
         "events": "^3.3.0"
       },
       "devDependencies": {
@@ -30929,8 +30929,8 @@
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.8.1",
-        "@walletconnect/utils": "2.8.1",
+        "@walletconnect/types": "2.8.2",
+        "@walletconnect/utils": "2.8.2",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "node-fetch": "^3.3.0",
@@ -30967,10 +30967,10 @@
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/modal": "^2.4.3",
-        "@walletconnect/sign-client": "2.8.1",
-        "@walletconnect/types": "2.8.1",
-        "@walletconnect/universal-provider": "2.8.1",
-        "@walletconnect/utils": "2.8.1",
+        "@walletconnect/sign-client": "2.8.2",
+        "@walletconnect/types": "2.8.2",
+        "@walletconnect/universal-provider": "2.8.2",
+        "@walletconnect/utils": "2.8.2",
         "ethereum-test-network": "0.1.6",
         "ethers": "5.6.9",
         "events": "^3.3.0",
@@ -31212,7 +31212,7 @@
     "@walletconnect/sign-client": {
       "version": "file:packages/sign-client",
       "requires": {
-        "@walletconnect/core": "2.8.1",
+        "@walletconnect/core": "2.8.2",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "^1.0.13",
@@ -31221,8 +31221,8 @@
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.8.1",
-        "@walletconnect/utils": "2.8.1",
+        "@walletconnect/types": "2.8.2",
+        "@walletconnect/utils": "2.8.2",
         "aws-sdk": "2.1194.0",
         "events": "^3.3.0",
         "lokijs": "^1.5.12"
@@ -31233,9 +31233,9 @@
       "requires": {
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
-        "@walletconnect/sign-client": "2.8.1",
-        "@walletconnect/types": "2.8.1",
-        "@walletconnect/utils": "2.8.1",
+        "@walletconnect/sign-client": "2.8.2",
+        "@walletconnect/types": "2.8.2",
+        "@walletconnect/utils": "2.8.2",
         "events": "^3.3.0",
         "uint8arrays": "^3.1.0"
       }
@@ -31270,9 +31270,9 @@
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sign-client": "2.8.1",
-        "@walletconnect/types": "2.8.1",
-        "@walletconnect/utils": "2.8.1",
+        "@walletconnect/sign-client": "2.8.2",
+        "@walletconnect/types": "2.8.2",
+        "@walletconnect/utils": "2.8.2",
         "cosmos-wallet": "^1.2.0",
         "ethereum-test-network": "0.1.6",
         "ethers": "5.7.0",
@@ -31452,7 +31452,7 @@
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.8.1",
+        "@walletconnect/types": "2.8.2",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -31465,13 +31465,13 @@
       "requires": {
         "@ethersproject/wallet": "^5.7.0",
         "@walletconnect/auth-client": "2.1.0",
-        "@walletconnect/core": "2.8.1",
+        "@walletconnect/core": "2.8.2",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.0.1",
-        "@walletconnect/sign-client": "2.8.1",
-        "@walletconnect/types": "2.8.1",
-        "@walletconnect/utils": "2.8.1",
+        "@walletconnect/sign-client": "2.8.2",
+        "@walletconnect/types": "2.8.2",
+        "@walletconnect/utils": "2.8.2",
         "lokijs": "^1.5.12"
       }
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/core",
   "description": "Core for WalletConnect Protocol",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -41,8 +41,8 @@
     "@walletconnect/relay-auth": "^1.0.4",
     "@walletconnect/safe-json": "^1.0.2",
     "@walletconnect/time": "^1.0.2",
-    "@walletconnect/types": "2.8.1",
-    "@walletconnect/utils": "2.8.1",
+    "@walletconnect/types": "2.8.2",
+    "@walletconnect/utils": "2.8.2",
     "events": "^3.3.0",
     "lodash.isequal": "4.5.0",
     "uint8arrays": "^3.1.0"

--- a/packages/core/src/constants/relayer.ts
+++ b/packages/core/src/constants/relayer.ts
@@ -36,7 +36,7 @@ export const RELAYER_STORAGE_OPTIONS = {
 
 // Updated automatically via `new-version` npm script.
 
-export const RELAYER_SDK_VERSION = "2.8.1";
+export const RELAYER_SDK_VERSION = "2.8.2";
 
 // delay to wait before closing the transport connection after init if not active
 export const RELAYER_TRANSPORT_CUTOFF = 10_000;

--- a/packages/react-native-compat/package.json
+++ b/packages/react-native-compat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/react-native-compat",
   "description": "Shims for WalletConnect Protocol in React Native Projects",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/sign-client",
   "description": "Sign Client for WalletConnect Protocol",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -38,14 +38,14 @@
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },
   "dependencies": {
-    "@walletconnect/core": "2.8.1",
+    "@walletconnect/core": "2.8.2",
     "@walletconnect/events": "^1.0.1",
     "@walletconnect/heartbeat": "1.2.1",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/logger": "^2.0.1",
     "@walletconnect/time": "^1.0.2",
-    "@walletconnect/types": "2.8.1",
-    "@walletconnect/utils": "2.8.1",
+    "@walletconnect/types": "2.8.2",
+    "@walletconnect/utils": "2.8.2",
     "events": "^3.3.0"
   },
   "devDependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/types",
   "description": "Typings for WalletConnect Protocol",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/utils",
   "description": "Utilities for WalletConnect Protocol",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -38,7 +38,7 @@
     "@walletconnect/relay-api": "^1.0.9",
     "@walletconnect/safe-json": "^1.0.2",
     "@walletconnect/time": "^1.0.2",
-    "@walletconnect/types": "2.8.1",
+    "@walletconnect/types": "2.8.2",
     "@walletconnect/window-getters": "^1.0.1",
     "@walletconnect/window-metadata": "^1.0.1",
     "detect-browser": "5.3.0",

--- a/packages/web3wallet/package.json
+++ b/packages/web3wallet/package.json
@@ -2,7 +2,7 @@
   "name": "@walletconnect/web3wallet",
   "description": "Web3Wallet for WalletConnect Protocol",
   "private": true,
-  "version": "1.8.1",
+  "version": "1.8.2",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -30,12 +30,12 @@
   },
   "dependencies": {
     "@walletconnect/auth-client": "2.1.0",
-    "@walletconnect/core": "2.8.1",
+    "@walletconnect/core": "2.8.2",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/logger": "2.0.1",
-    "@walletconnect/sign-client": "2.8.1",
-    "@walletconnect/types": "2.8.1",
-    "@walletconnect/utils": "2.8.1",
+    "@walletconnect/sign-client": "2.8.2",
+    "@walletconnect/types": "2.8.2",
+    "@walletconnect/utils": "2.8.2",
     "@walletconnect/jsonrpc-provider": "1.0.13"
   },
   "devDependencies": {

--- a/providers/ethereum-provider/package.json
+++ b/providers/ethereum-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/ethereum-provider",
   "description": "Ethereum Provider for WalletConnect Protocol",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {
@@ -47,10 +47,10 @@
     "@walletconnect/jsonrpc-provider": "^1.0.13",
     "@walletconnect/jsonrpc-types": "^1.0.3",
     "@walletconnect/jsonrpc-utils": "^1.0.8",
-    "@walletconnect/sign-client": "2.8.1",
-    "@walletconnect/types": "2.8.1",
-    "@walletconnect/universal-provider": "2.8.1",
-    "@walletconnect/utils": "2.8.1",
+    "@walletconnect/sign-client": "2.8.2",
+    "@walletconnect/types": "2.8.2",
+    "@walletconnect/universal-provider": "2.8.2",
+    "@walletconnect/utils": "2.8.2",
     "events": "^3.3.0"
   },
   "devDependencies": {

--- a/providers/signer-connection/package.json
+++ b/providers/signer-connection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/signer-connection",
   "description": "Signer Connection for WalletConnect Protocol",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -39,9 +39,9 @@
   "dependencies": {
     "@walletconnect/jsonrpc-types": "^1.0.3",
     "@walletconnect/jsonrpc-utils": "^1.0.8",
-    "@walletconnect/sign-client": "2.8.1",
-    "@walletconnect/types": "2.8.1",
-    "@walletconnect/utils": "2.8.1",
+    "@walletconnect/sign-client": "2.8.2",
+    "@walletconnect/types": "2.8.2",
+    "@walletconnect/utils": "2.8.2",
     "events": "^3.3.0",
     "uint8arrays": "^3.1.0"
   }

--- a/providers/universal-provider/package.json
+++ b/providers/universal-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/universal-provider",
   "description": "Universal Provider for WalletConnect Protocol",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {
@@ -45,9 +45,9 @@
     "@walletconnect/jsonrpc-types": "^1.0.2",
     "@walletconnect/jsonrpc-utils": "^1.0.7",
     "@walletconnect/logger": "^2.0.1",
-    "@walletconnect/sign-client": "2.8.1",
-    "@walletconnect/types": "2.8.1",
-    "@walletconnect/utils": "2.8.1",
+    "@walletconnect/sign-client": "2.8.2",
+    "@walletconnect/types": "2.8.2",
+    "@walletconnect/utils": "2.8.2",
     "events": "^3.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Release Checklist

- [x] **Canary Version QA**

  - [x] I have thoroughly tested the release using a canary version: `2.8.2-canary.0`
  - [x] The canary version has been verified to work as expected.
  - [x] All major features and changes have been tested and validated.

- [ ] **Web3Modal Team QA**

  - [ ] The Web3Modal team has tested the release for compatibility and functionality.
  - [ ] The release is backwards compatible with Web3Modal.
  - [ ] Any reported issues or bugs have been addressed or documented.

- [x] **React Native Team QA**

  - [x] The React Native team has tested the release for compatibility and functionality (if relevant).
  - [x] The release works correctly in React Native environments and is backwards compatible with Web3Modal React Native.
  - [ ] Any reported issues or bugs have been addressed or documented.

## Description
* chore(deps): update node.js to v20 by @renovate in https://github.com/WalletConnect/walletconnect-monorepo/pull/2666
* chore: web3wallet@1.8.1 by @bkrem in https://github.com/WalletConnect/walletconnect-monorepo/pull/2678
* fix: `pairingTopic undefined` by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/2684
* remove deprecated eip1193-provider dependency by @pedrouid in https://github.com/WalletConnect/walletconnect-monorepo/pull/2647
* fix: ethereum provider persisted session with inline chain declaration by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/2706
* refactor: verify - silent POST to loading iframe by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/2719
* chore(relayer): clarify error message for `rejectTransportOpen` by @bkrem in https://github.com/WalletConnect/walletconnect-monorepo/pull/2644
* fix(react-native): detect RN OS via `global.Platform` binding by @bkrem in https://github.com/WalletConnect/walletconnect-monorepo/pull/2724
* fix: reconnection on stalled payload by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/2679

## Definition of Done

- [x] The release has been tested using a canary version.
- [ ] The release has been reviewed and approved by the Web3Modal team (if relevant).
- [ ] The release has been reviewed and approved by the React Native team (if relevant).
- [x] All necessary documentation, including API changes or new features, has been updated.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] All tests (unit, integration, etc.) pass successfully.
- [x] The release has been properly versioned and tagged.
- [x] The release notes and changelog have been updated to reflect the changes made.

Please ensure that all the items on the checklist have been completed before merging the release.