### PR TITLE
feat:  providers to accept empty required chains/namespaces

### DIFF
--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -178,6 +178,12 @@ export function buildNamespaces(params: NamespacesParams): {
     optional: optionalChains.length ? optional : undefined,
   };
 }
+
+// helper type to force setting at least one value in an array
+type ArrayOneOrMore<T> = {
+  0: T;
+} & Array<T>;
+
 /**
  * @param {number[]} chains - The Chains your app intents to use and the peer MUST support. If the peer does not support these chains, the connection will be rejected.
  * @param {number[]} optionalChains - The Chains your app MAY attempt to use and the peer MAY support. If the peer does not support these chains, the connection will still be established.
@@ -185,12 +191,12 @@ export function buildNamespaces(params: NamespacesParams): {
  */
 export type ChainsProps =
   | {
-      chains: number[];
+      chains: ArrayOneOrMore<number>;
       optionalChains?: number[];
     }
   | {
       chains?: number[];
-      optionalChains: number[];
+      optionalChains: ArrayOneOrMore<number>;
     };
 
 export type EthereumProviderOptions = {
@@ -460,9 +466,11 @@ export class EthereumProvider implements IEthereumProvider {
   }
 
   protected getRpcConfig(opts: EthereumProviderOptions): EthereumRpcConfig {
-    const requiredChains = opts.chains || [];
-    const optionalChains = opts.optionalChains || [];
+    const requiredChains = opts?.chains ?? [];
+    const optionalChains = opts?.optionalChains ?? [];
     const allChains = requiredChains.concat(optionalChains);
+    if (!allChains.length)
+      throw new Error("No chains specified in either `chains` or `optionalChains`");
     const requiredMethods = requiredChains.length ? opts?.methods || REQUIRED_METHODS : [];
     const requiredEvents = requiredChains.length ? opts?.events || REQUIRED_EVENTS : [];
     const optionalMethods = opts?.optionalMethods || [];

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -10,7 +10,13 @@ import {
 import { Metadata, Namespace, UniversalProvider } from "@walletconnect/universal-provider";
 import type { WalletConnectModalConfig, WalletConnectModal } from "@walletconnect/modal";
 import { SessionTypes, SignClientTypes } from "@walletconnect/types";
-import { STORAGE_KEY, REQUIRED_METHODS, REQUIRED_EVENTS, RPC_URL } from "./constants";
+import {
+  STORAGE_KEY,
+  REQUIRED_METHODS,
+  REQUIRED_EVENTS,
+  RPC_URL,
+  OPTIONAL_METHODS,
+} from "./constants";
 
 export type QrModalOptions = Pick<
   WalletConnectModalConfig,
@@ -60,7 +66,7 @@ export interface SessionEvent {
 
 export interface EthereumRpcConfig {
   chains: string[];
-  optionalChains?: string[];
+  optionalChains: string[];
   methods: string[];
   optionalMethods?: string[];
   /**
@@ -103,7 +109,7 @@ export function toHexChainId(chainId: number): string {
 
 export type NamespacesParams = {
   chains: EthereumRpcConfig["chains"];
-  optionalChains?: EthereumRpcConfig["optionalChains"];
+  optionalChains: EthereumRpcConfig["optionalChains"];
   methods?: EthereumRpcConfig["methods"];
   optionalMethods?: EthereumRpcConfig["methods"];
   events?: EthereumRpcConfig["events"];
@@ -112,7 +118,7 @@ export type NamespacesParams = {
 };
 
 export function buildNamespaces(params: NamespacesParams): {
-  required: Namespace;
+  required?: Namespace;
   optional?: Namespace;
 } {
   const { chains, optionalChains, methods, optionalMethods, events, optionalEvents, rpcMap } =
@@ -121,18 +127,13 @@ export function buildNamespaces(params: NamespacesParams): {
     throw new Error("Invalid chains");
   }
 
-  const requiredChains = chains;
-  const requiredMethods = methods || REQUIRED_METHODS;
-  const requiredEvents = events || REQUIRED_EVENTS;
-  const requiredRpcMap = {
-    [getEthereumChainId(requiredChains)]: rpcMap[getEthereumChainId(requiredChains)],
-  };
-
   const required: Namespace = {
-    chains: requiredChains,
-    methods: requiredMethods,
-    events: requiredEvents,
-    rpcMap: requiredRpcMap,
+    chains,
+    methods: methods || REQUIRED_METHODS,
+    events: events || REQUIRED_EVENTS,
+    rpcMap: {
+      ...(chains.length && { [getEthereumChainId(chains)]: rpcMap[getEthereumChainId(chains)] }),
+    },
   };
 
   // make a list of events and methods that require additional permissions
@@ -147,7 +148,7 @@ export function buildNamespaces(params: NamespacesParams): {
     !eventsRequiringPermissions?.length &&
     !methodsRequiringPermissions?.length
   ) {
-    return { required };
+    return { required: chains ? required : undefined };
   }
 
   /*
@@ -160,31 +161,40 @@ export function buildNamespaces(params: NamespacesParams): {
   const optional: Namespace = {
     chains: [
       ...new Set(
-        shouldIncludeRequiredChains ? requiredChains.concat(optionalChains || []) : optionalChains,
+        shouldIncludeRequiredChains ? required.chains.concat(optionalChains || []) : optionalChains,
       ),
     ],
-    methods: [...new Set(requiredMethods.concat(optionalMethods || []))],
-    events: [...new Set(requiredEvents.concat(optionalEvents || []))],
+    methods: [
+      ...new Set(
+        required.methods.concat(optionalMethods?.length ? optionalMethods : OPTIONAL_METHODS),
+      ),
+    ],
+    events: [...new Set(required.events.concat(optionalEvents || []))],
     rpcMap,
   };
 
-  return { required, optional };
+  return {
+    required: chains.length ? required : undefined,
+    optional: optionalChains.length ? optional : undefined,
+  };
 }
+/**
+ * @param {number[]} chains - The Chains your app intents to use and the peer MUST support. If the peer does not support these chains, the connection will be rejected.
+ * @param {number[]} optionalChains - The Chains your app MAY attempt to use and the peer MAY support. If the peer does not support these chains, the connection will still be established.
+ * @description either chains or optionalChains must be provided
+ */
+export type ChainsProps =
+  | {
+      chains: number[];
+      optionalChains?: number[];
+    }
+  | {
+      chains?: number[];
+      optionalChains: number[];
+    };
 
-export interface EthereumProviderOptions {
+export type EthereumProviderOptions = {
   projectId: string;
-  /**
-   * @note Chains that your app intents to use and the peer MUST support. If the peer does not support these chains, the connection will be rejected.
-   * @default [1]
-   * @example [1, 3, 4, 5, 42]
-   */
-  chains: number[];
-  /**
-   * @note Optional chains that your app MAY attempt to use and the peer MAY support. If the peer does not support these chains, the connection will still be established.
-   * @default [1]
-   * @example [1, 3, 4, 5, 42]
-   */
-  optionalChains?: number[];
   /**
    * @note Methods that your app intents to use and the peer MUST support. If the peer does not support these methods, the connection will be rejected.
    * @default ["eth_sendTransaction", "personal_sign"]
@@ -203,7 +213,7 @@ export interface EthereumProviderOptions {
   disableProviderPing?: boolean;
   relayUrl?: string;
   storageOptions?: KeyValueStorageOptions;
-}
+} & ChainsProps;
 
 export class EthereumProvider implements IEthereumProvider {
   public events = new EventEmitter();
@@ -277,7 +287,9 @@ export class EthereumProvider implements IEthereumProvider {
           await this.signer
             .connect({
               namespaces: {
-                [this.namespace]: required,
+                ...(required && {
+                  [this.namespace]: required,
+                }),
               },
               ...(optional && {
                 optionalNamespaces: {
@@ -294,7 +306,6 @@ export class EthereumProvider implements IEthereumProvider {
             });
         },
       );
-
       if (!session) return;
       this.setChainIds(this.rpc.chains);
       const accounts = getAccountsFromNamespaces(session.namespaces, [this.namespace]);
@@ -449,20 +460,25 @@ export class EthereumProvider implements IEthereumProvider {
   }
 
   protected getRpcConfig(opts: EthereumProviderOptions): EthereumRpcConfig {
+    const requiredChains = opts.chains || [];
+    const optionalChains = opts.optionalChains || [];
+    const allChains = requiredChains.concat(optionalChains);
+    const requiredMethods = requiredChains.length ? opts?.methods || REQUIRED_METHODS : [];
+    const requiredEvents = requiredChains.length ? opts?.events || REQUIRED_EVENTS : [];
+    const optionalMethods = opts?.optionalMethods || [];
+    const optionalEvents = opts?.optionalEvents || [];
+    const rpcMap = opts?.rpcMap || this.buildRpcMap(allChains, opts.projectId);
+    const qrModalOptions = opts?.qrModalOptions || undefined;
     return {
-      chains: opts.chains?.map((chain) => this.formatChainId(chain)) || [`${this.namespace}:1`],
-      optionalChains: opts.optionalChains
-        ? opts.optionalChains.map((chain) => this.formatChainId(chain))
-        : undefined,
-      methods: opts?.methods || REQUIRED_METHODS,
-      events: opts?.events || REQUIRED_EVENTS,
-      optionalMethods: opts?.optionalMethods || [],
-      optionalEvents: opts?.optionalEvents || [],
-      rpcMap:
-        opts?.rpcMap ||
-        this.buildRpcMap(opts.chains.concat(opts.optionalChains || []), opts.projectId),
+      chains: requiredChains?.map((chain) => this.formatChainId(chain)),
+      optionalChains: optionalChains.map((chain) => this.formatChainId(chain)),
+      methods: requiredMethods,
+      events: requiredEvents,
+      optionalMethods,
+      optionalEvents,
+      rpcMap,
       showQrModal: Boolean(opts?.showQrModal),
-      qrModalOptions: opts?.qrModalOptions ?? undefined,
+      qrModalOptions,
       projectId: opts.projectId,
       metadata: opts.metadata,
     };
@@ -478,7 +494,9 @@ export class EthereumProvider implements IEthereumProvider {
 
   protected async initialize(opts: EthereumProviderOptions) {
     this.rpc = this.getRpcConfig(opts);
-    this.chainId = getEthereumChainId(this.rpc.chains);
+    this.chainId = this.rpc.chains.length
+      ? getEthereumChainId(this.rpc.chains)
+      : getEthereumChainId(this.rpc.optionalChains);
     this.signer = await UniversalProvider.init({
       projectId: this.rpc.projectId,
       metadata: this.rpc.metadata,

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -132,7 +132,9 @@ export function buildNamespaces(params: NamespacesParams): {
     methods: methods || REQUIRED_METHODS,
     events: events || REQUIRED_EVENTS,
     rpcMap: {
-      ...(chains.length && { [getEthereumChainId(chains)]: rpcMap[getEthereumChainId(chains)] }),
+      ...(chains.length
+        ? { [getEthereumChainId(chains)]: rpcMap[getEthereumChainId(chains)] }
+        : {}),
     },
   };
 

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -148,7 +148,7 @@ export function buildNamespaces(params: NamespacesParams): {
     !eventsRequiringPermissions?.length &&
     !methodsRequiringPermissions?.length
   ) {
-    return { required: chains ? required : undefined };
+    return { required: chains.length ? required : undefined };
   }
 
   /*

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -16,6 +16,7 @@ import {
   REQUIRED_EVENTS,
   RPC_URL,
   OPTIONAL_METHODS,
+  OPTIONAL_EVENTS,
 } from "./constants";
 
 export type QrModalOptions = Pick<
@@ -171,7 +172,7 @@ export function buildNamespaces(params: NamespacesParams): {
         required.methods.concat(optionalMethods?.length ? optionalMethods : OPTIONAL_METHODS),
       ),
     ],
-    events: [...new Set(required.events.concat(optionalEvents || []))],
+    events: [...new Set(required.events.concat(optionalEvents || OPTIONAL_EVENTS))],
     rpcMap,
   };
 

--- a/providers/ethereum-provider/test/index.spec.ts
+++ b/providers/ethereum-provider/test/index.spec.ts
@@ -23,6 +23,7 @@ import {
   TEST_ETHEREUM_METHODS_REQUIRED,
   TEST_ETHEREUM_METHODS_OPTIONAL,
 } from "./shared/constants";
+import { EthereumProviderOptions } from "../src/EthereumProvider";
 
 describe("EthereumProvider", function () {
   let testNetwork: TestNetwork;
@@ -323,7 +324,7 @@ describe("EthereumProvider", function () {
   });
   describe("persistence", () => {
     const db = "./test/tmp/test.db";
-    const initOptions = {
+    const initOptions: EthereumProviderOptions = {
       projectId: process.env.TEST_PROJECT_ID || "",
       chains: [CHAIN_ID],
       showQrModal: false,
@@ -430,7 +431,7 @@ describe("EthereumProvider", function () {
   });
   describe("required & optional chains", () => {
     it("should connect without any required chains", async () => {
-      const initOptions = {
+      const initOptions: EthereumProviderOptions = {
         projectId: process.env.TEST_PROJECT_ID || "",
         optionalChains: [CHAIN_ID, 137],
         showQrModal: false,
@@ -483,7 +484,7 @@ describe("EthereumProvider", function () {
       await walletClient.core.relayer.transportClose();
     });
     it("should connect without optional chains", async () => {
-      const initOptions = {
+      const initOptions: EthereumProviderOptions = {
         projectId: process.env.TEST_PROJECT_ID || "",
         chains: [CHAIN_ID],
         showQrModal: false,
@@ -522,6 +523,17 @@ describe("EthereumProvider", function () {
 
       await provider.signer.client.core.relayer.transportClose();
       await walletClient.core.relayer.transportClose();
+    });
+    it("should reject init with empty `chains` and `optionalChains`", async () => {
+      await expect(
+        // @ts-ignore
+        EthereumProvider.init({
+          projectId: process.env.TEST_PROJECT_ID || "",
+          chains: [],
+          optionalChains: [],
+          showQrModal: false,
+        }),
+      ).rejects.toThrowError("No chains specified in either `chains` or `optionalChains`");
     });
   });
 });

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -179,7 +179,6 @@ export class UniversalProvider implements IUniversalProvider {
           this.session = session;
           // assign namespaces from session if not already defined
           if (!this.namespaces) {
-            this.setNamespaces({ namespaces: session.namespaces as NamespaceConfig });
             this.namespaces = populateNamespacesChains(session.namespaces) as NamespaceConfig;
             this.persist("namespaces", this.namespaces);
           }

--- a/providers/universal-provider/src/types/misc.ts
+++ b/providers/universal-provider/src/types/misc.ts
@@ -50,7 +50,7 @@ export interface SessionNamespace extends Namespace {
 }
 
 export interface ConnectParams {
-  namespaces: NamespaceConfig;
+  namespaces?: NamespaceConfig;
   optionalNamespaces?: NamespaceConfig;
   sessionProperties?: ProposalTypes.Struct["sessionProperties"];
   pairingTopic?: string;

--- a/providers/universal-provider/src/utils/misc.ts
+++ b/providers/universal-provider/src/utils/misc.ts
@@ -53,7 +53,7 @@ export function getAccountsFromSession(namespace: string, session: SessionTypes.
 }
 
 export function mergeRequiredOptionalNamespaces(
-  required: NamespaceConfig,
+  required: NamespaceConfig = {},
   optional: NamespaceConfig = {},
 ) {
   const requiredNamespaces = normalizeNamespaces(required);

--- a/providers/universal-provider/src/utils/misc.ts
+++ b/providers/universal-provider/src/utils/misc.ts
@@ -101,3 +101,29 @@ export function normalizeNamespaces(namespaces: NamespaceConfig): NamespaceConfi
 export function parseCaip10Account(caip10Account: string): string {
   return caip10Account.includes(":") ? caip10Account.split(":")[2] : caip10Account;
 }
+
+/**
+ * Populates the chains array for each namespace with the chains extracted from the accounts if are otherwise missing
+ */
+export function populateNamespacesChains(
+  namespaces: SessionTypes.Namespaces,
+): Record<string, SessionTypes.Namespace> {
+  const parsedNamespaces: Record<string, SessionTypes.Namespace> = {};
+  for (const [key, values] of Object.entries(namespaces)) {
+    const methods = values.methods || [];
+    const events = values.events || [];
+    const accounts = values.accounts || [];
+    const chains = isCaipNamespace(key)
+      ? [key]
+      : values.chains
+      ? values.chains
+      : getChainsFromApprovedSession(values.accounts);
+    parsedNamespaces[key] = {
+      chains,
+      methods,
+      events,
+      accounts,
+    };
+  }
+  return parsedNamespaces;
+}

--- a/providers/universal-provider/src/utils/misc.ts
+++ b/providers/universal-provider/src/utils/misc.ts
@@ -113,6 +113,7 @@ export function populateNamespacesChains(
     const methods = values.methods || [];
     const events = values.events || [];
     const accounts = values.accounts || [];
+    // If the key includes a CAIP separator `:` we know it's a namespace + chainId (e.g. `eip155:1`)
     const chains = isCaipNamespace(key)
       ? [key]
       : values.chains

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -377,10 +377,27 @@ describe("UniversalProvider", function () {
           name: "wallet",
           storageOptions: { database: getDbName("walletDB") },
         });
-
+        const chains = [`eip155:${CHAIN_ID}`, `eip155:${CHAIN_ID_B}`];
         const {
           sessionA: { topic },
-        } = await testConnectMethod({ dapp, wallet });
+        } = await testConnectMethod(
+          {
+            dapp,
+            wallet,
+          },
+          {
+            requiredNamespaces: {},
+            optionalNamespaces: {},
+            namespaces: {
+              eip155: {
+                accounts: chains.map((chain) => `${chain}:${walletAddress}`),
+                chains,
+                methods,
+                events,
+              },
+            },
+          },
+        );
 
         await Promise.all([
           new Promise((resolve) => {

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -818,7 +818,8 @@ describe("UniversalProvider", function () {
             wallet,
           },
           {
-            requiredNamespaces: undefined,
+            requiredNamespaces: {},
+            optionalNamespaces: {},
             namespaces: {
               eip155: {
                 accounts: chains.map((chain) => `${chain}:${walletAddress}`),

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -54,6 +54,9 @@ describe("UniversalProvider", function () {
     expect(walletAddress).to.eql(ACCOUNTS.a.address);
     const providerAccounts = await provider.enable();
     expect(providerAccounts).to.eql([walletAddress]);
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 1000);
+    });
   });
   afterAll(async () => {
     // close test network
@@ -721,6 +724,41 @@ describe("UniversalProvider", function () {
                 events,
               },
             },
+            namespaces: {
+              eip155: {
+                accounts: chains.map((chain) => `${chain}:${walletAddress}`),
+                chains,
+                methods,
+                events,
+              },
+            },
+          },
+        );
+        await dapp.request({ method: "wallet_switchEthereumChain", params: [{ chainId: "0x2" }] });
+        await validateProvider({
+          provider: dapp,
+          chains,
+          addresses: [walletAddress],
+          expectedChainId: chains[1],
+        });
+      });
+      it("should connect with empty required namespaces", async () => {
+        const dapp = await UniversalProvider.init({
+          ...TEST_PROVIDER_OPTS,
+          name: "dapp",
+        });
+        const wallet = await UniversalProvider.init({
+          ...TEST_PROVIDER_OPTS,
+          name: "wallet",
+        });
+        const chains = ["eip155:1", "eip155:2"];
+        await testConnectMethod(
+          {
+            dapp,
+            wallet,
+          },
+          {
+            requiredNamespaces: undefined,
             namespaces: {
               eip155: {
                 accounts: chains.map((chain) => `${chain}:${walletAddress}`),

--- a/providers/universal-provider/test/shared/connect.ts
+++ b/providers/universal-provider/test/shared/connect.ts
@@ -17,6 +17,7 @@ import UniversalProvider from "../../src/UniversalProvider";
 
 export interface TestConnectParams {
   requiredNamespaces?: ProposalTypes.RequiredNamespaces;
+  optionalNamespaces?: ProposalTypes.optionalNamespaces;
   namespaces?: SessionTypes.Namespaces;
   relays?: RelayerTypes.ProtocolOptions[];
   pairingTopic?: string;
@@ -29,12 +30,12 @@ export async function testConnectMethod(
 ) {
   const start = Date.now();
   const { dapp, wallet } = providers;
-  const dappClient = dapp.client;
+  const dappClient = dapp;
   const walletClient = wallet.client;
 
   const connectParams: EngineTypes.ConnectParams = {
     requiredNamespaces: params?.requiredNamespaces || TEST_REQUIRED_NAMESPACES,
-    optionalNamespaces: TEST_OPTIONAL_NAMESPACES,
+    optionalNamespaces: params?.optionalNamespaces || TEST_OPTIONAL_NAMESPACES,
     relays: params?.relays || undefined,
     pairingTopic: params?.pairingTopic || undefined,
   };
@@ -89,7 +90,7 @@ export async function testConnectMethod(
         dapp.on("display_uri", async (uri: string) => {
           const uriParams = parseUri(uri);
 
-          pairingA = dappClient.pairing.get(uriParams.topic);
+          pairingA = dappClient.client?.pairing.get(uriParams.topic);
           expect(pairingA.topic).to.eql(uriParams.topic);
           expect(pairingA.relay).to.eql(uriParams.relay);
 
@@ -114,8 +115,8 @@ export async function testConnectMethod(
         const namespaces = connectParams.requiredNamespaces;
         const optionalNamespaces = connectParams.optionalNamespaces;
         const session = await dapp.connect({
-          namespaces: namespaces || ({} as any),
-          optionalNamespaces: optionalNamespaces || ({} as any),
+          namespaces,
+          optionalNamespaces,
         });
         if (!session) throw new Error();
         const lastKeyIndex = dapp.client.session.keys.length - 1;


### PR DESCRIPTION
## Description
Implemented the following updates
- `universal-provider` -> to accept empty `namespaces` & `optionalNamespaces`
- `ethereum-provider` -> to accept empty `chains` OR `optionalChains` i.e. one of the params must be defined

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests
canary -> `2.8.7-canary.8`
## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
