### PR TITLE
feat: `wallet_switchEthereumChain` handling if supported by the wallet

### DIFF
--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -54,6 +54,9 @@ describe("UniversalProvider", function () {
     expect(walletAddress).to.eql(ACCOUNTS.a.address);
     const providerAccounts = await provider.enable();
     expect(providerAccounts).to.eql([walletAddress]);
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 500);
+    });
   });
   afterAll(async () => {
     // close test network
@@ -92,6 +95,41 @@ describe("UniversalProvider", function () {
         expect(chainIdB).to.eql(CHAIN_ID_B);
 
         provider.setDefaultChain(`eip155:${CHAIN_ID}`);
+      });
+      it("should send `wallet_switchEthereumChain` request when chain is not approved", async () => {
+        const currentApprovedChains = provider.session?.namespaces.eip155.chains;
+        const chainToSwith = "eip155:1";
+        const chainToSwitchParsed = parseInt(chainToSwith.split(":")[1]);
+        // confirm that chain is not approved
+        expect(currentApprovedChains).to.not.include(chainToSwith);
+
+        const activeChain = await web3.eth.getChainId();
+        expect(activeChain).to.not.eql(chainToSwitchParsed);
+        expect(activeChain).to.eql(CHAIN_ID);
+
+        // when we send the wallet_switchEthereumChain request
+        // the wallet should receive & update the session with the new chain
+        await Promise.all([
+          new Promise<void>((resolve) => {
+            provider.on("session_update", (args: any) => {
+              expect(args.params.namespaces.eip155.chains).to.include(chainToSwith);
+              resolve();
+            });
+          }),
+          provider.request({
+            method: "wallet_switchEthereumChain",
+            params: [{ chainId: `0x${chainToSwith.split(":")[1]}` }],
+          }),
+        ]);
+
+        const activeChainAfterSwitch = await web3.eth.getChainId();
+        expect(activeChainAfterSwitch).to.eql(chainToSwitchParsed);
+
+        // revert back to the original chain
+        await provider.request({
+          method: "wallet_switchEthereumChain",
+          params: [{ chainId: `0x${CHAIN_ID.toString(16)}` }],
+        });
       });
     });
     describe("Web3", () => {

--- a/providers/universal-provider/test/shared/constants.ts
+++ b/providers/universal-provider/test/shared/constants.ts
@@ -71,6 +71,7 @@ export const EIP155_TEST_METHODS = [
   "eth_signTransaction",
   "personal_sign",
   "eth_signTypedData",
+  "wallet_switchEthereumChain",
 ];
 
 export const COSMOS_TEST_METHODS = ["cosmos_signDirect", "cosmos_signAmino"];


### PR DESCRIPTION
## Description
Implemented switching chain flow within `universal-provider` that utilizes `wallet_switchEthereumChain`
1. if the chain is already approved by the wallet -> switch locally
2. if the wallet approved `wallet_switchEthereumChain` -> request the chain change
3. if both of the previous conditions fail, throw

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding - canary - `2.8.3-canary-2`
integration tests

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
