### PR TITLE
fix: namespace chains validation

### DIFF
--- a/packages/sign-client/test/sdk/validation.spec.ts
+++ b/packages/sign-client/test/sdk/validation.spec.ts
@@ -82,6 +82,45 @@ describe("Sign Client Validation", () => {
         "Missing or invalid. connect(), optionalNamespaces should be an object with data",
       );
     });
+    it("throws when no chains are specified within requiredNamespaces", async () => {
+      await expect(
+        clients.A.connect({
+          requiredNamespaces: {
+            eip155: {
+              chains: [],
+            },
+          },
+        }),
+      ).rejects.toThrowError(
+        `Unsupported chains. connect() requiredNamespaces, chains must be defined as "namespace:chainId" e.g. "eip155:1": {...} in the namespace key OR as an array of caip2 chainIds e.g. eip155: { chains: ["eip155:1", "eip155:5"] }`,
+      );
+    });
+    it("throws when no chains are specified within optionalNamespaces", async () => {
+      await expect(
+        clients.A.connect({
+          optionalNamespaces: {
+            eip155: {
+              chains: [],
+            },
+          },
+        }),
+      ).rejects.toThrowError(
+        `Unsupported chains. connect() optionalNamespaces, chains must be defined as "namespace:chainId" e.g. "eip155:1": {...} in the namespace key OR as an array of caip2 chainIds e.g. eip155: { chains: ["eip155:1", "eip155:5"] }`,
+      );
+    });
+    it("should create pairing with inline defined chain", async () => {
+      const connect = await clients.A.connect({
+        optionalNamespaces: {
+          "eip155:1": {
+            methods: [],
+            events: [],
+          },
+        },
+      });
+      expect(connect).toBeDefined();
+      expect(connect).toHaveProperty("uri");
+      expect(connect.uri).to.be.string;
+    });
   });
 
   describe("approve", () => {

--- a/packages/sign-client/test/sdk/validation.spec.ts
+++ b/packages/sign-client/test/sdk/validation.spec.ts
@@ -92,7 +92,7 @@ describe("Sign Client Validation", () => {
           },
         }),
       ).rejects.toThrowError(
-        `Unsupported chains. connect() requiredNamespaces, chains must be defined as "namespace:chainId" e.g. "eip155:1": {...} in the namespace key OR as an array of caip2 chainIds e.g. eip155: { chains: ["eip155:1", "eip155:5"] }`,
+        `Unsupported chains. connect() requiredNamespaces, chains must be defined as "namespace:chainId" e.g. "eip155:1": {...} in the namespace key OR as an array of CAIP-2 chainIds e.g. eip155: { chains: ["eip155:1", "eip155:5"] }`,
       );
     });
     it("throws when no chains are specified within optionalNamespaces", async () => {
@@ -105,7 +105,7 @@ describe("Sign Client Validation", () => {
           },
         }),
       ).rejects.toThrowError(
-        `Unsupported chains. connect() optionalNamespaces, chains must be defined as "namespace:chainId" e.g. "eip155:1": {...} in the namespace key OR as an array of caip2 chainIds e.g. eip155: { chains: ["eip155:1", "eip155:5"] }`,
+        `Unsupported chains. connect() optionalNamespaces, chains must be defined as "namespace:chainId" e.g. "eip155:1": {...} in the namespace key OR as an array of CAIP-2 chainIds e.g. eip155: { chains: ["eip155:1", "eip155:5"] }`,
       );
     });
     it("should create pairing with inline defined chain", async () => {

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -137,34 +137,35 @@ export function isValidNamespaceMethodsOrEvents(input: any): input is string {
 
 export function isValidChains(key: string, chains: any, context: string) {
   let error: ErrorObject = null;
-  if (isValidArray(chains)) {
+
+  if (isValidArray(chains) && chains.length) {
     chains.forEach((chain: any) => {
       if (error) return;
-      if (!isValidChainId(chain) || !chain.includes(key)) {
+      if (!isValidChainId(chain)) {
         error = getSdkError(
           "UNSUPPORTED_CHAINS",
           `${context}, chain ${chain} should be a string and conform to "namespace:chainId" format`,
         );
       }
     });
-  } else {
+  } else if (!isValidChainId(key)) {
     error = getSdkError(
       "UNSUPPORTED_CHAINS",
-      `${context}, chains ${chains} should be an array of strings conforming to "namespace:chainId" format`,
+      `${context}, chains must be defined as "namespace:chainId" e.g. "eip155:1": {...} in the namespace key OR as an array of caip2 chainIds e.g. eip155: { chains: ["eip155:1", "eip155:5"] }`,
     );
   }
 
   return error;
 }
 
-export function isValidNamespaceChains(namespaces: any, method: string) {
+export function isValidNamespaceChains(namespaces: any, method: string, type: string) {
   let error: ErrorObject = null;
   Object.entries(namespaces).forEach(([key, namespace]: [string, any]) => {
     if (error) return;
     const validChainsError = isValidChains(
       key,
       getChainsFromNamespace(key, namespace),
-      `${method} requiredNamespace`,
+      `${method} ${type}`,
     );
     if (validChainsError) {
       error = validChainsError;
@@ -246,7 +247,7 @@ export function isValidRequiredNamespaces(input: any, method: string, type: stri
     if (validActionsError) {
       error = validActionsError;
     }
-    const validChainsError = isValidNamespaceChains(input, method);
+    const validChainsError = isValidNamespaceChains(input, method, type);
     if (validChainsError) {
       error = validChainsError;
     }

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -151,7 +151,7 @@ export function isValidChains(key: string, chains: any, context: string) {
   } else if (!isValidChainId(key)) {
     error = getSdkError(
       "UNSUPPORTED_CHAINS",
-      `${context}, chains must be defined as "namespace:chainId" e.g. "eip155:1": {...} in the namespace key OR as an array of caip2 chainIds e.g. eip155: { chains: ["eip155:1", "eip155:5"] }`,
+      `${context}, chains must be defined as "namespace:chainId" e.g. "eip155:1": {...} in the namespace key OR as an array of CAIP-2 chainIds e.g. eip155: { chains: ["eip155:1", "eip155:5"] }`,
     );
   }
 

--- a/packages/utils/test/validators.spec.ts
+++ b/packages/utils/test/validators.spec.ts
@@ -302,7 +302,7 @@ describe("Validators", () => {
     expect(error).to.throw;
   });
 
-  it("should throw on CAIP2 namespace not including that CAIP2 in accouns", () => {
+  it("should throw on CAIP-2 namespace not including that CAIP-2 in accouns", () => {
     const required = {
       eip155: {
         chains: ["eip155:1", "eip155:2"],


### PR DESCRIPTION
## Description
Fixed an issue where namespace (required & optional) validation was not catching missing chains.
Chains must be defined inline in the namespace key e.g. `"eip155:1": {...}` or as an caip-2 array 
```
eip155: { chains: ['eip155:1'] }
```

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
