### PR TITLE
fix: `accountsChanged` CAIP-10 accounts in `universal-provider`

### DIFF
--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -6,6 +6,7 @@ import {
   getAccountsFromSession,
   getChainsFromApprovedSession,
   mergeRequiredOptionalNamespaces,
+  parseCaip10Account,
   setGlobal,
 } from "./utils";
 import PolkadotProvider from "./providers/polkadot";
@@ -337,7 +338,9 @@ export class UniversalProvider implements IUniversalProvider {
       const { params } = args;
       const { event } = params;
       if (event.name === "accountsChanged") {
-        this.events.emit("accountsChanged", event.data);
+        const accounts = event.data;
+        if (accounts && isValidArray(accounts))
+          this.events.emit("accountsChanged", accounts.map(parseCaip10Account));
       } else if (event.name === "chainChanged") {
         this.onChainChanged(params.chainId);
       } else {

--- a/providers/universal-provider/src/utils/misc.ts
+++ b/providers/universal-provider/src/utils/misc.ts
@@ -97,3 +97,7 @@ export function normalizeNamespaces(namespaces: NamespaceConfig): NamespaceConfi
   }
   return normalizedNamespaces;
 }
+
+export function parseCaip10Account(caip10Account: string): string {
+  return caip10Account.includes(":") ? caip10Account.split(":")[2] : caip10Account;
+}

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -133,7 +133,7 @@ describe("UniversalProvider", function () {
       });
     });
     describe("events", () => {
-      it("should emit caip15 parsed accountsChanged", async () => {
+      it("should emit CAIP-10 parsed accountsChanged", async () => {
         const caip10AccountToEmit = `eip155:${CHAIN_ID}:${walletAddress}`;
         const expectedParsedAccount = walletAddress;
         expect(caip10AccountToEmit).to.not.eql(expectedParsedAccount);

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -132,6 +132,30 @@ describe("UniversalProvider", function () {
         });
       });
     });
+    describe("events", () => {
+      it("should emit caip15 parsed accountsChanged", async () => {
+        const caip10AccountToEmit = `eip155:${CHAIN_ID}:${walletAddress}`;
+        const expectedParsedAccount = walletAddress;
+        expect(caip10AccountToEmit).to.not.eql(expectedParsedAccount);
+        await Promise.all([
+          new Promise<void>((resolve) => {
+            provider.on("accountsChanged", (accounts: string[]) => {
+              expect(accounts).to.be.an("array");
+              expect(accounts).to.include(expectedParsedAccount);
+              resolve();
+            });
+          }),
+          walletClient.client?.emit({
+            topic: provider.session?.topic || "",
+            event: {
+              name: "accountsChanged",
+              data: [caip10AccountToEmit],
+            },
+            chainId: `eip155:${CHAIN_ID}`,
+          }),
+        ]);
+      });
+    });
     describe("Web3", () => {
       let web3: Web3;
       beforeAll(() => {


### PR DESCRIPTION
## Description
Fixed an issue where the accounts emitted from `accountsChanged` in the `universal-provider` were CAIP-10 prefixed. 
Removed the prefi as per EIP-1193 spec

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests
dogfooding

| Before       | After        |
| ------------ | ------------ |
| `eip155:1:0x123...` | `0x123...` |

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
