### PR TITLE
fix: history records expiry

### DIFF
--- a/packages/core/src/controllers/history.ts
+++ b/packages/core/src/controllers/history.ts
@@ -220,7 +220,7 @@ export class JsonRpcHistory extends IJsonRpcHistory {
   private cleanup() {
     try {
       this.records.forEach((record: JsonRpcRecord) => {
-        if (!record.expiry || record.expiry < Date.now()) {
+        if (!record.expiry || record.expiry <= Date.now()) {
           this.logger.info(`Deleting expired history log: ${record.id}`);
           this.delete(record.topic, record.id);
         }

--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -251,7 +251,8 @@ export class Pairing implements IPairing {
         this.onRelayEventRequest({ topic, payload });
       } else if (isJsonRpcResponse(payload)) {
         await this.core.history.resolve(payload);
-        this.onRelayEventResponse({ topic, payload });
+        await this.onRelayEventResponse({ topic, payload });
+        this.core.history.delete(topic, payload.id);
       }
     });
   }

--- a/packages/core/test/history.spec.ts
+++ b/packages/core/test/history.spec.ts
@@ -4,7 +4,7 @@ import { calcExpiry } from "@walletconnect/utils";
 import { Core, HISTORY_EVENTS } from "../src";
 import { disconnectSocket, TEST_CORE_OPTIONS } from "./shared";
 import { ICore, JsonRpcRecord } from "@walletconnect/types";
-import { THIRTY_DAYS } from "@walletconnect/time";
+import { THIRTY_DAYS, toMiliseconds, fromMiliseconds } from "@walletconnect/time";
 
 describe("history", () => {
   let core: ICore;
@@ -36,10 +36,10 @@ describe("history", () => {
     expect(record).to.not.be.undefined;
     expect(record?.expiry).to.not.be.undefined;
     expect(record?.expiry).to.be.greaterThan(0);
-    expect(record?.expiry).to.be.approximately(Date.now() + calcExpiry(THIRTY_DAYS), 10); // delta ~10ms execution variance
+    expect(record?.expiry).to.be.approximately(calcExpiry(THIRTY_DAYS), 10); // delta ~10ms execution variance
 
     vi.useFakeTimers();
-    vi.advanceTimersByTime(calcExpiry(THIRTY_DAYS));
+    vi.advanceTimersByTime(toMiliseconds(calcExpiry(THIRTY_DAYS)));
     // move time forward to force expiry and wait for heartbeat to delete the record
     await new Promise<void>((resolve) => {
       core.history.on(HISTORY_EVENTS.deleted, (record: JsonRpcRecord) => {

--- a/packages/core/test/history.spec.ts
+++ b/packages/core/test/history.spec.ts
@@ -1,0 +1,57 @@
+import { vi, expect, describe, it, beforeEach, afterEach } from "vitest";
+import { calcExpiry } from "@walletconnect/utils";
+
+import { Core, HISTORY_EVENTS } from "../src";
+import { disconnectSocket, TEST_CORE_OPTIONS } from "./shared";
+import { ICore, JsonRpcRecord } from "@walletconnect/types";
+import { THIRTY_DAYS } from "@walletconnect/time";
+
+describe("history", () => {
+  let core: ICore;
+  beforeEach(async () => {
+    core = new Core(TEST_CORE_OPTIONS);
+    await core.start();
+  });
+  it("should set a record expiry", async () => {
+    expect(core.history.records.size).to.eq(0);
+    const request = {
+      id: 1687958477400360,
+      topic: "24fd0e137c4ccc655ca9e1b9d0e2481bb3d028dc307edc62d2a5190bb081c1b9",
+      jsonrpc: "2.0",
+      method: "test",
+      params: {
+        request: {
+          method: "personal_sign",
+          params: [
+            "0x4d7920656d61696c206973206a6f686e40646f652e636f6d202d2031363837393538343737333838",
+            "0x7770471b86c6dd889a6D81DA53Fb7eeE1F9a2ba7",
+          ],
+        },
+        chainId: "eip155:5",
+      },
+    };
+    core.history.set(request.topic, request);
+    expect(core.history.records.size).to.eq(1);
+    const record = core.history.records.get(request.id);
+    expect(record).to.not.be.undefined;
+    expect(record?.expiry).to.not.be.undefined;
+    expect(record?.expiry).to.be.greaterThan(0);
+    expect(record?.expiry).to.be.approximately(Date.now() + calcExpiry(THIRTY_DAYS), 10); // delta ~10ms execution variance
+
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(calcExpiry(THIRTY_DAYS));
+    // move time forward to force expiry and wait for heartbeat to delete the record
+    await new Promise<void>((resolve) => {
+      core.history.on(HISTORY_EVENTS.deleted, (record: JsonRpcRecord) => {
+        expect(record).to.not.be.undefined;
+        expect(record.id).to.eq(request.id);
+        resolve();
+      });
+    });
+    vi.useRealTimers();
+    expect(core.history.records.size).to.eq(0);
+  });
+  afterEach(async () => {
+    await disconnectSocket(core.relayer);
+  });
+});

--- a/packages/core/test/history.spec.ts
+++ b/packages/core/test/history.spec.ts
@@ -36,7 +36,10 @@ describe("history", () => {
     expect(record).to.not.be.undefined;
     expect(record?.expiry).to.not.be.undefined;
     expect(record?.expiry).to.be.greaterThan(0);
-    expect(record?.expiry).to.be.approximately(calcExpiry(THIRTY_DAYS), 10); // delta ~10ms execution variance
+    expect(toMiliseconds(record?.expiry || 0)).to.be.approximately(
+      toMiliseconds(calcExpiry(THIRTY_DAYS)),
+      10,
+    ); // delta ~10ms execution variance
 
     vi.useFakeTimers();
     vi.advanceTimersByTime(toMiliseconds(calcExpiry(THIRTY_DAYS)));

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -549,7 +549,8 @@ export class Engine extends IEngine {
           this.onRelayEventRequest({ topic, payload });
         } else if (isJsonRpcResponse(payload)) {
           await this.client.core.history.resolve(payload);
-          this.onRelayEventResponse({ topic, payload });
+          await this.onRelayEventResponse({ topic, payload });
+          this.client.core.history.delete(topic, payload.id);
         } else {
           this.onRelayEventUnknownPayload({ topic, payload });
         }
@@ -587,7 +588,6 @@ export class Engine extends IEngine {
     const { topic, payload } = event;
     const record = await this.client.core.history.get(topic, payload.id);
     const resMethod = record.request.method as JsonRpcTypes.WcMethod;
-
     switch (resMethod) {
       case "wc_sessionPropose":
         return this.onSessionProposeResponse(topic, payload);

--- a/packages/types/src/core/history.ts
+++ b/packages/types/src/core/history.ts
@@ -15,6 +15,7 @@ export interface JsonRpcRecord {
   request: RequestArguments;
   chainId?: string;
   response?: { result: any } | { error: ErrorResponse };
+  expiry?: number;
 }
 
 export interface RequestEvent {


### PR DESCRIPTION
## Description
Implemented a default expiry of history records of 30 days. 
Additionally, history records are removed on request-response after they're no longer needed.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests
dogfooding

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
