### PR TITLE
feat(relayer): implements failover logic to `relay.org`

### DIFF
--- a/packages/core/src/constants/relayer.ts
+++ b/packages/core/src/constants/relayer.ts
@@ -5,6 +5,7 @@ export const RELAYER_DEFAULT_PROTOCOL = "irn";
 export const RELAYER_DEFAULT_LOGGER = "error";
 
 export const RELAYER_DEFAULT_RELAY_URL = "wss://relay.walletconnect.com";
+export const RELAYER_FAILOVER_RELAY_URL = "wss://relay.walletconnect.org";
 
 export const RELAYER_CONTEXT = "relayer";
 

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -40,6 +40,7 @@ import {
   RELAYER_RECONNECT_TIMEOUT,
   RELAYER_SUBSCRIBER_SUFFIX,
   RELAYER_DEFAULT_RELAY_URL,
+  RELAYER_FAILOVER_RELAY_URL,
   SUBSCRIBER_EVENTS,
   RELAYER_TRANSPORT_CUTOFF,
 } from "../constants";
@@ -88,12 +89,20 @@ export class Relayer extends IRelayer {
   public async init() {
     this.logger.trace(`Initialized`);
     await this.createProvider();
-    await Promise.all([this.messages.init(), this.transportOpen(), this.subscriber.init()]);
+    await Promise.all([this.messages.init(), this.subscriber.init()]);
+    try {
+      await this.transportOpen();
+    } catch {
+      this.logger.warn(
+        `Connection via ${this.relayUrl} failed, attempting to connect via failover domain ${RELAYER_FAILOVER_RELAY_URL}...`,
+      );
+      await this.restartTransport(RELAYER_FAILOVER_RELAY_URL);
+    }
     this.registerEventListeners();
     this.initialized = true;
     setTimeout(async () => {
       if (this.subscriber.topics.length === 0) {
-        this.logger.info(`No topics subscribted to after init, closing transport`);
+        this.logger.info(`No topics subscribed to after init, closing transport`);
         await this.transportClose();
         this.transportExplicitlyClosed = false;
       }
@@ -203,7 +212,11 @@ export class Relayer extends IRelayer {
         }),
         await Promise.race([
           new Promise<void>(async (resolve, reject) => {
-            await createExpiringPromise(this.provider.connect(), 5_000, "socket stalled")
+            await createExpiringPromise(
+              this.provider.connect(),
+              5_000,
+              `Socket stalled when trying to connect to ${this.relayUrl}`,
+            )
               .catch((e) => reject(e))
               .then(() => resolve())
               .finally(() =>

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -1,3 +1,4 @@
+import { RELAYER_FAILOVER_RELAY_URL } from "./../src/constants/relayer";
 import { expect, describe, it, beforeEach, afterEach } from "vitest";
 import { getDefaultLoggerOptions, pino } from "@walletconnect/logger";
 import { JsonRpcProvider } from "@walletconnect/jsonrpc-provider";
@@ -281,6 +282,17 @@ describe("Relayer", () => {
         await relayer.subscriber.subscribe(topic);
         await throttle(RELAYER_TRANSPORT_CUTOFF + 1_000); // +1 sec buffer
         expect(relayer.connected).to.be.true;
+      });
+      it(`should fall back to ${RELAYER_FAILOVER_RELAY_URL} if the default relayUrl is not reachable`, async () => {
+        relayer = new Relayer({
+          core,
+          relayUrl: "wss://relay.blocked.not.real",
+          projectId: TEST_CORE_OPTIONS.projectId,
+        });
+        await relayer.init();
+        const wsConnection = relayer.provider.connection as unknown as WebSocket;
+        expect(relayer.connected).to.be.true;
+        expect(wsConnection.url.startsWith(RELAYER_FAILOVER_RELAY_URL)).to.be.true;
       });
     });
   });

--- a/packages/core/test/shared/ws.ts
+++ b/packages/core/test/shared/ws.ts
@@ -1,7 +1,7 @@
 import { IRelayer } from "@walletconnect/types";
 
 export async function disconnectSocket(relayer: IRelayer) {
-  if (relayer.connected) {
+  if (relayer && relayer.connected) {
     await relayer.transportClose();
   }
 }


### PR DESCRIPTION
## Description

- Implements logic to fall back to `relay.walletconnect.org` if the initial connection to `relay.walletconnect.com` fails
- Also:
	- Clearer error messaging for socket stalled (which connection did it stall on?)
	- Use warning on failover to avoid additional error noise

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

- `relayer.spec.ts`
- Testing of canary `2.8.5-3491a772` in sample wallet and dapp
	- Successful fallback to `.org` on immediate `provider.connect()` failure
	- Successful fallback to `.org` on socket stalled timeout

## Fixes/Resolves (Optional)

- https://github.com/rainbow-me/rainbowkit/issues/1333
- https://github.com/WalletConnect/walletconnect-monorepo/issues/2392


## Examples/Screenshots (Optional)

> From https://react-wallet-v2-3ivxa9mma-walletconnect1.vercel.app/ when blocking `relay.walletconnect.com` at DNS level
<img width="790" alt="Screenshot 2023-06-29 at 11 11 10" src="https://github.com/WalletConnect/walletconnect-monorepo/assets/8663099/ffe5f8a5-5cc3-4844-87d4-529a87b8cd57">

> From https://react-dapp-v2-le125cq9e-walletconnect1.vercel.app/ when blocking `relay.walletconnect.com` at DNS level

<img width="791" alt="Screenshot 2023-06-29 at 11 11 19" src="https://github.com/WalletConnect/walletconnect-monorepo/assets/8663099/abe87571-73ac-4b7c-accf-10acdbab89d3">


## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings - intended warning only in this case
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
