### PR TITLE
fix(deps): explicitly set `jsonrpc-ws-connection` to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25533,7 +25533,7 @@
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-types": "1.0.3",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/jsonrpc-ws-connection": "^1.0.12",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.12",
         "@walletconnect/keyvaluestorage": "^1.0.2",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
@@ -25598,7 +25598,7 @@
       },
       "devDependencies": {
         "@walletconnect/jsonrpc-provider": "^1.0.13",
-        "@walletconnect/jsonrpc-ws-connection": "^1.0.11",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.12",
         "@walletconnect/relay-api": "^1.0.9",
         "aws-sdk": "2.1194.0",
         "lokijs": "^1.5.12"
@@ -31223,7 +31223,7 @@
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "^1.0.13",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/jsonrpc-ws-connection": "^1.0.11",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.12",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/time": "^1.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
     "@walletconnect/jsonrpc-provider": "1.0.13",
     "@walletconnect/jsonrpc-types": "1.0.3",
     "@walletconnect/jsonrpc-utils": "1.0.8",
-    "@walletconnect/jsonrpc-ws-connection": "^1.0.11",
+    "@walletconnect/jsonrpc-ws-connection": "1.0.12",
     "@walletconnect/keyvaluestorage": "^1.0.2",
     "@walletconnect/logger": "^2.0.1",
     "@walletconnect/relay-api": "^1.0.9",

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@walletconnect/jsonrpc-provider": "^1.0.13",
-    "@walletconnect/jsonrpc-ws-connection": "^1.0.11",
+    "@walletconnect/jsonrpc-ws-connection": "1.0.12",
     "@walletconnect/relay-api": "^1.0.9",
     "aws-sdk": "2.1194.0",
     "lokijs": "^1.5.12"


### PR DESCRIPTION
## Description

- RenovatBot only updated the lockfile here: https://github.com/WalletConnect/walletconnect-monorepo/pull/2908
- Making sure we explicitly use `jsonrpc-ws-connection@1.0.12` as a minimum going forward

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

- Unit tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

- Relates to:
	- https://github.com/WalletConnect/walletconnect-monorepo/pull/2908
	- https://github.com/WalletConnect/walletconnect-utils/pull/114
