### PR TITLE
fix(utils): ensures RN-only `Platform` polyfill has exhaustive guard

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -96,8 +96,13 @@ export function getRelayClientMetadata(protocol: string, version: number): Relay
 // -- rpcUrl ----------------------------------------------//
 
 export function getJavascriptOS() {
+  const env = getEnvironment();
   // global.Platform is set by react-native-compat
-  if (typeof (global as any)?.Platform !== "undefined") {
+  if (
+    env === ENV_MAP.reactNative &&
+    typeof global !== "undefined" &&
+    typeof (global as any)?.Platform !== "undefined"
+  ) {
     const { OS, Version } = (global as any).Platform;
     return [OS, Version].join("-");
   }


### PR DESCRIPTION
## Description

- The RN polyfill fix for accessing `Platform` shipped in https://github.com/WalletConnect/walletconnect-monorepo/pull/2724 attempts to access `global` in an unsafe way for some build envs (e.g. Vite)
- This fix ensures we add additional guard statements before a possible access on `global` is attempted to ensure it only ever happens in a RN env and if defined.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

- Unit tests
- Dogfooding web3wallet canary (see below) in a Vite setup
- Canaries:
	- `@walletconnect/core@2.8.6-409b14d4`
	- `@walletconnect/web3wallet@1.8.5-409b14d4`

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
