### PR TITLE
feat(scripts): automatically update `RELAYER_SDK_VERSION` from lerna.json

### DIFF
--- a/scripts/update_relayer_sdk_version.sh
+++ b/scripts/update_relayer_sdk_version.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
+# Context: https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+set -Eeuo pipefail
 
 file_location="packages/core/src/constants/relayer.ts"
 regex="RELAYER_SDK_VERSION = \".*\""
 
-# Get the next version from user input.
-echo "Enter new Relayer SDK version (should match the packages): "
-read next_version
+# Get the next version from lerna.json.
+lerna_file="lerna.json"
+next_version=$(grep -E '"version": "(.*)"' $lerna_file | sed -E 's/"version": "(.*)"/\1/' | sed 's/^[[:space:]]*//')
 
 # Define the replace value
 new_value="RELAYER_SDK_VERSION = \"$next_version\""
@@ -19,6 +21,5 @@ if [ "$(uname)" = "Darwin" ]; then
 else
   sed -i "s/${regex}/${new_value}/g" $file_location
 fi
-
 
 echo "[SCRIPT] ...Done!"


### PR DESCRIPTION
## Description

- No more manual relayer version entry on pre-release.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

- Tested by running `npm run new-version` locally

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

