### PR TITLE
fix(relayer): prevents forwarding empty/invalid message payloads to clients

### DIFF
--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -240,10 +240,11 @@ export class Pairing implements IPairing {
     this.core.relayer.on(RELAYER_EVENTS.message, async (event: RelayerTypes.MessageEvent) => {
       const { topic, message } = event;
 
+      // Do not handle if the topic is not related to known pairing topics.
+      if (!this.pairings.keys.includes(topic)) return;
+
       // messages of certain types should be ignored as they are handled by their respective SDKs
-      if (this.ignoredPayloadTypes.includes(this.core.crypto.getPayloadType(message))) {
-        return;
-      }
+      if (this.ignoredPayloadTypes.includes(this.core.crypto.getPayloadType(message))) return;
 
       const payload = await this.core.crypto.decode(topic, message);
       if (isJsonRpcRequest(payload)) {
@@ -261,8 +262,6 @@ export class Pairing implements IPairing {
     const { topic, payload } = event;
     const reqMethod = payload.method as PairingJsonRpcTypes.WcMethod;
 
-    if (!this.pairings.keys.includes(topic)) return;
-
     switch (reqMethod) {
       case "wc_pairingPing":
         return this.onPairingPingRequest(topic, payload);
@@ -277,8 +276,6 @@ export class Pairing implements IPairing {
     const { topic, payload } = event;
     const record = await this.core.history.get(topic, payload.id);
     const resMethod = record.request.method as PairingJsonRpcTypes.WcMethod;
-
-    if (!this.pairings.keys.includes(topic)) return;
 
     switch (resMethod) {
       case "wc_pairingPing":

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -298,13 +298,22 @@ export class Relayer extends IRelayer {
     const { topic, message } = messageEvent;
 
     // Ignore if incoming `message` is clearly invalid.
-    if (!message || message.length === 0) return true;
+    if (!message || message.length === 0) {
+      this.logger.debug(`Ignoring invalid/empty message: ${message}`);
+      return true;
+    }
 
     // Ignore if `topic` is not subscribed to.
-    if (!(await this.subscriber.isSubscribed(topic))) return true;
+    if (!(await this.subscriber.isSubscribed(topic))) {
+      this.logger.debug(`Ignoring message for non-subscribed topic ${topic}`);
+      return true;
+    }
 
     // Ignore if `message` is a duplicate.
     const exists = this.messages.has(topic, message);
+    if (exists) {
+      this.logger.debug(`Ignoring duplicate message: ${message}`);
+    }
     return exists;
   }
 

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -292,9 +292,18 @@ export class Relayer extends IRelayer {
     await this.messages.set(topic, message);
   }
 
-  private async shouldIgnoreMessageEvent(messageEvent: RelayerTypes.MessageEvent) {
+  private async shouldIgnoreMessageEvent(
+    messageEvent: RelayerTypes.MessageEvent,
+  ): Promise<boolean> {
     const { topic, message } = messageEvent;
+
+    // Ignore if incoming `message` is clearly invalid.
+    if (!message || message.length === 0) return true;
+
+    // Ignore if `topic` is not subscribed to.
     if (!(await this.subscriber.isSubscribed(topic))) return true;
+
+    // Ignore if `message` is a duplicate.
     const exists = this.messages.has(topic, message);
     return exists;
   }


### PR DESCRIPTION
## Description

- Pairing: ignores non-pairing topics earlier on incoming provider message to avoid redundant controller work
- Relayer: Ensures we don't emit invalid/empty/garbage messages to clients
- Context: https://walletconnect.slack.com/archives/C03RWGSBCUU/p1689247549066609

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

- Unit tests
- Canary (`2.9.0-e4636394`)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
