### PR TITLE
fix: auto namespaces builder

### DIFF
--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -118,6 +118,7 @@ export function buildApprovedNamespaces(
 
   const approvedNamespaces = {};
 
+  // if both required & optional namespaces are empty, return all supported namespaces by the wallet
   if (!Object.keys(requiredNamespaces).length && !Object.keys(optionalNamespaces).length)
     return namespaces;
 

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -98,6 +98,12 @@ export function buildApprovedNamespaces(
     const supportedEvents = supportedNamespaces[namespace].events;
     const supportedAccounts = supportedNamespaces[namespace].accounts;
 
+    supportedChains.forEach((chain) => {
+      if (!supportedAccounts.some((account) => account.includes(chain))) {
+        throw new Error(`No accounts provided for chain ${chain} in namespace ${namespace}`);
+      }
+    });
+
     namespaces[namespace] = {
       chains: supportedChains,
       methods: supportedMethods,
@@ -111,6 +117,9 @@ export function buildApprovedNamespaces(
   if (err) throw new Error(err.message);
 
   const approvedNamespaces = {};
+
+  if (!Object.keys(requiredNamespaces).length && !Object.keys(optionalNamespaces).length)
+    return namespaces;
 
   // assign accounts for the required namespaces
   Object.keys(normalizedRequired).forEach((requiredNamespace) => {

--- a/packages/utils/test/validators.spec.ts
+++ b/packages/utils/test/validators.spec.ts
@@ -366,8 +366,11 @@ describe("buildApprovedNamespaces (validators)", () => {
     const chains = ["eip155:1", "eip155:2", "eip155:3"];
     const methods = ["personal_sign", "eth_sendTransaction", "eth_signTransaction"];
     const events = ["chainChanged"];
-    const accounts = ["eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"];
-
+    const accounts = [
+      "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:3:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+    ];
     const approvedNamespaces = buildApprovedNamespaces({
       proposal: {
         ...TEST_PROPOSAL,
@@ -389,7 +392,7 @@ describe("buildApprovedNamespaces (validators)", () => {
         chains: ["eip155:1"],
         methods: ["personal_sign", "eth_sendTransaction"],
         events,
-        accounts,
+        accounts: [accounts[0]],
       },
     };
     expect(approvedNamespaces).to.deep.equal(expected);
@@ -416,6 +419,7 @@ describe("buildApprovedNamespaces (validators)", () => {
     const accounts = [
       "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
       "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:3:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
     ];
 
     const approvedNamespaces = buildApprovedNamespaces({
@@ -439,7 +443,7 @@ describe("buildApprovedNamespaces (validators)", () => {
         chains: ["eip155:1", "eip155:2"],
         methods: ["personal_sign", "eth_sendTransaction"],
         events,
-        accounts,
+        accounts: [accounts[0], accounts[1]],
       },
     };
     expect(approvedNamespaces).to.deep.eq(expected);
@@ -465,6 +469,7 @@ describe("buildApprovedNamespaces (validators)", () => {
     const accounts = [
       "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
       "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:3:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
     ];
 
     const approvedNamespaces = buildApprovedNamespaces({
@@ -488,7 +493,7 @@ describe("buildApprovedNamespaces (validators)", () => {
         chains: ["eip155:1", "eip155:2"],
         methods: ["personal_sign", "eth_sendTransaction"],
         events,
-        accounts,
+        accounts: [accounts[0], accounts[1]],
       },
     };
     expect(approvedNamespaces).to.deep.eq(expected);
@@ -751,6 +756,7 @@ describe("buildApprovedNamespaces (validators)", () => {
     const accounts = [
       "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
       "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:4:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
     ];
 
     const approvedNamespaces = buildApprovedNamespaces({
@@ -774,7 +780,7 @@ describe("buildApprovedNamespaces (validators)", () => {
         chains: ["eip155:1", "eip155:2"],
         methods: ["personal_sign", "eth_sendTransaction", "eth_signTransaction"],
         events,
-        accounts,
+        accounts: [accounts[0], accounts[1]],
       },
     };
     expect(approvedNamespaces).to.deep.eq(expected);
@@ -809,6 +815,7 @@ describe("buildApprovedNamespaces (validators)", () => {
     const accounts = [
       "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
       "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:4:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
     ];
 
     const approvedNamespaces = buildApprovedNamespaces({
@@ -832,7 +839,7 @@ describe("buildApprovedNamespaces (validators)", () => {
         chains: ["eip155:1", "eip155:2"],
         methods: ["personal_sign", "eth_sendTransaction", "eth_signTransaction"],
         events,
-        accounts,
+        accounts: [accounts[0], accounts[1]],
       },
     };
     expect(approvedNamespaces).to.deep.eq(expected);
@@ -1021,6 +1028,44 @@ describe("buildApprovedNamespaces (validators)", () => {
       },
     };
     expect(approvedNamespaces).to.deep.eq(expected);
+  });
+  it("should build namespaces (config 13 - required & optional empty)", () => {
+    const required = {};
+    const optional = {};
+
+    const chains = ["eip155:1", "eip155:2", "eip155:3"];
+    const methods = ["personal_sign", "eth_sendTransaction", "eth_signTransaction"];
+    const events = ["chainChanged"];
+    const accounts = [
+      "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:3:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+    ];
+
+    const approvedNamespaces = buildApprovedNamespaces({
+      proposal: {
+        ...TEST_PROPOSAL,
+        requiredNamespaces: required,
+        optionalNamespaces: optional,
+      },
+      supportedNamespaces: {
+        eip155: {
+          chains,
+          methods,
+          events,
+          accounts,
+        },
+      },
+    });
+    const expected = {
+      eip155: {
+        chains,
+        methods,
+        events,
+        accounts,
+      },
+    };
+    expect(approvedNamespaces).to.deep.equal(expected);
   });
 
   it.fails(


### PR DESCRIPTION
## Description
- When both required & optional namespaces were empty, the builder returned approved empty instead of all supported by the wallet
- Added a check that all supported chains have corresponding accounts

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests 

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
