### PR TITLE
fix: try/catch around crypto.decode

### DIFF
--- a/packages/core/src/controllers/crypto.ts
+++ b/packages/core/src/controllers/crypto.ts
@@ -126,10 +126,17 @@ export class Crypto implements ICrypto {
       const peerPublicKey = params.senderPublicKey;
       topic = await this.generateSharedKey(selfPublicKey, peerPublicKey);
     }
-    const symKey = this.getSymKey(topic);
-    const message = decrypt({ symKey, encoded });
-    const payload = safeJsonParse(message);
-    return payload;
+    try {
+      const symKey = this.getSymKey(topic);
+      const message = decrypt({ symKey, encoded });
+      const payload = safeJsonParse(message);
+      return payload;
+    } catch (error) {
+      this.logger.error(
+        `Failed to decode message from topic: '${topic}', clientId: '${await this.getClientId()}'`,
+      );
+      this.logger.error(error);
+    }
   };
 
   public getPayloadType: ICrypto["getPayloadType"] = (encoded) => {

--- a/packages/core/test/crypto.spec.ts
+++ b/packages/core/test/crypto.spec.ts
@@ -160,5 +160,9 @@ describe("Crypto", () => {
       const decoded = await crypto.decode(topic, encoded);
       expect(decoded).to.eql(payload);
     });
+    it("should not throw on failed decrypt", async () => {
+      const decoded = await crypto.decode("non-existent-topic", "dummymessage");
+      expect(decoded).to.eql(undefined);
+    });
   });
 });


### PR DESCRIPTION
## Description
Added `try/catch` around `crypto.decode` as having an error at this point is not actionable by the user.
Now on error, `undefined` is returned instead of a decoded payload

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
