### PR TITLE
fix(universal-provider): expose storage option at provider level

### DIFF
--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -255,6 +255,7 @@ export class UniversalProvider implements IUniversalProvider {
         projectId: this.providerOpts.projectId,
         metadata: this.providerOpts.metadata, // fetch metadata automatically if not provided?
         storageOptions: this.providerOpts.storageOptions,
+        storage: this.providerOpts.storage,
         name: this.providerOpts.name,
       }));
 

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -253,7 +253,7 @@ export class UniversalProvider implements IUniversalProvider {
         logger: this.providerOpts.logger || LOGGER,
         relayUrl: this.providerOpts.relayUrl || RELAY_URL,
         projectId: this.providerOpts.projectId,
-        metadata: this.providerOpts.metadata, // fetch metadata automatically if not provided?
+        metadata: this.providerOpts.metadata,
         storageOptions: this.providerOpts.storageOptions,
         storage: this.providerOpts.storage,
         name: this.providerOpts.name,

--- a/providers/universal-provider/src/types/misc.ts
+++ b/providers/universal-provider/src/types/misc.ts
@@ -1,7 +1,7 @@
 import SignClient from "@walletconnect/sign-client";
 import { SignClientTypes, ProposalTypes } from "@walletconnect/types";
 import { JsonRpcProvider } from "@walletconnect/jsonrpc-provider";
-import { KeyValueStorageOptions } from "@walletconnect/keyvaluestorage";
+import { KeyValueStorageOptions, IKeyValueStorage } from "@walletconnect/keyvaluestorage";
 import { IEvents } from "@walletconnect/events";
 
 import { IProvider } from "./providers";
@@ -13,6 +13,7 @@ export interface UniversalProviderOpts {
   client?: SignClient;
   relayUrl?: string;
   storageOptions?: KeyValueStorageOptions;
+  storage?: IKeyValueStorage;
   name?: string;
   disableProviderPing?: boolean;
 }


### PR DESCRIPTION
## Description

- Resolves #2493 
- Forward `providerOpts.storage` in `UniversalProvider` to the `SignClient` it initiates in the default case.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
- Unit tests
- Canary: `2.9.0-929ffe53`

## Checklist
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules