### PR TITLE
chore: prep for `2.9.1` release

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,8 @@
 {
   "npmClient": "npm",
-  "packages": ["packages/*", "providers/*"],
-  "version": "2.9.0"
+  "packages": [
+    "packages/*",
+    "providers/*"
+  ],
+  "version": "2.9.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25756,23 +25756,6 @@
         "lokijs": "^1.5.12"
       }
     },
-    "packages/web3wallet/node_modules/@walletconnect/jsonrpc-ws-connection": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.12.tgz",
-      "integrity": "sha512-HAcadga3Qjt1Cqy+qXEW6zjaCs8uJGdGQrqltzl3OjiK4epGZRdvSzTe63P+t/3z+D2wG+ffEPn0GVcDozmN1w==",
-      "dependencies": {
-        "@walletconnect/jsonrpc-utils": "^1.0.6",
-        "@walletconnect/safe-json": "^1.0.2",
-        "events": "^3.3.0",
-        "tslib": "1.14.1",
-        "ws": "^7.5.1"
-      }
-    },
-    "packages/web3wallet/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "providers/ethereum-provider": {
       "name": "@walletconnect/ethereum-provider",
       "version": "2.9.1",
@@ -31154,24 +31137,6 @@
         "@walletconnect/types": "2.9.1",
         "@walletconnect/utils": "2.9.1",
         "lokijs": "^1.5.12"
-      },
-      "dependencies": {
-        "@walletconnect/jsonrpc-ws-connection": {
-          "version": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.12.tgz",
-          "integrity": "sha512-HAcadga3Qjt1Cqy+qXEW6zjaCs8uJGdGQrqltzl3OjiK4epGZRdvSzTe63P+t/3z+D2wG+ffEPn0GVcDozmN1w==",
-          "requires": {
-            "@walletconnect/jsonrpc-utils": "^1.0.6",
-            "@walletconnect/safe-json": "^1.0.2",
-            "events": "^3.3.0",
-            "tslib": "1.14.1",
-            "ws": "^7.5.1"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
       }
     },
     "@walletconnect/window-getters": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25603,7 +25603,7 @@
     },
     "packages/core": {
       "name": "@walletconnect/core",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
@@ -25617,8 +25617,8 @@
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.9.0",
-        "@walletconnect/utils": "2.9.0",
+        "@walletconnect/types": "2.9.1",
+        "@walletconnect/utils": "2.9.1",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "^3.1.0"
@@ -25647,7 +25647,7 @@
     },
     "packages/react-native-compat": {
       "name": "@walletconnect/react-native-compat",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "events": "3.3.0",
@@ -25660,17 +25660,17 @@
     },
     "packages/sign-client": {
       "name": "@walletconnect/sign-client",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@walletconnect/core": "2.9.0",
+        "@walletconnect/core": "2.9.1",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.9.0",
-        "@walletconnect/utils": "2.9.0",
+        "@walletconnect/types": "2.9.1",
+        "@walletconnect/utils": "2.9.1",
         "events": "^3.3.0"
       },
       "devDependencies": {
@@ -25702,7 +25702,7 @@
     },
     "packages/types": {
       "name": "@walletconnect/types",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
@@ -25715,7 +25715,7 @@
     },
     "packages/utils": {
       "name": "@walletconnect/utils",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
@@ -25726,7 +25726,7 @@
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.9.0",
+        "@walletconnect/types": "2.9.1",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -25739,36 +25739,53 @@
     },
     "packages/web3wallet": {
       "name": "@walletconnect/web3wallet",
-      "version": "1.8.6",
+      "version": "1.8.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/auth-client": "2.1.1",
-        "@walletconnect/core": "2.9.0",
+        "@walletconnect/core": "2.9.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.0.1",
-        "@walletconnect/sign-client": "2.9.0",
-        "@walletconnect/types": "2.9.0",
-        "@walletconnect/utils": "2.9.0"
+        "@walletconnect/sign-client": "2.9.1",
+        "@walletconnect/types": "2.9.1",
+        "@walletconnect/utils": "2.9.1"
       },
       "devDependencies": {
         "@ethersproject/wallet": "^5.7.0",
         "lokijs": "^1.5.12"
       }
     },
+    "packages/web3wallet/node_modules/@walletconnect/jsonrpc-ws-connection": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.12.tgz",
+      "integrity": "sha512-HAcadga3Qjt1Cqy+qXEW6zjaCs8uJGdGQrqltzl3OjiK4epGZRdvSzTe63P+t/3z+D2wG+ffEPn0GVcDozmN1w==",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0",
+        "tslib": "1.14.1",
+        "ws": "^7.5.1"
+      }
+    },
+    "packages/web3wallet/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "providers/ethereum-provider": {
       "name": "@walletconnect/ethereum-provider",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
         "@walletconnect/jsonrpc-provider": "^1.0.13",
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
-        "@walletconnect/sign-client": "2.9.0",
-        "@walletconnect/types": "2.9.0",
-        "@walletconnect/universal-provider": "2.9.0",
-        "@walletconnect/utils": "2.9.0",
+        "@walletconnect/sign-client": "2.9.1",
+        "@walletconnect/types": "2.9.1",
+        "@walletconnect/universal-provider": "2.9.1",
+        "@walletconnect/utils": "2.9.1",
         "events": "^3.3.0"
       },
       "devDependencies": {
@@ -25789,21 +25806,21 @@
     },
     "providers/signer-connection": {
       "name": "@walletconnect/signer-connection",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
-        "@walletconnect/sign-client": "2.9.0",
-        "@walletconnect/types": "2.9.0",
-        "@walletconnect/utils": "2.9.0",
+        "@walletconnect/sign-client": "2.9.1",
+        "@walletconnect/types": "2.9.1",
+        "@walletconnect/utils": "2.9.1",
         "events": "^3.3.0",
         "uint8arrays": "^3.1.0"
       }
     },
     "providers/universal-provider": {
       "name": "@walletconnect/universal-provider",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
@@ -25811,9 +25828,9 @@
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sign-client": "2.9.0",
-        "@walletconnect/types": "2.9.0",
-        "@walletconnect/utils": "2.9.0",
+        "@walletconnect/sign-client": "2.9.1",
+        "@walletconnect/types": "2.9.1",
+        "@walletconnect/utils": "2.9.1",
         "events": "^3.3.0"
       },
       "devDependencies": {
@@ -30568,8 +30585,8 @@
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.9.0",
-        "@walletconnect/utils": "2.9.0",
+        "@walletconnect/types": "2.9.1",
+        "@walletconnect/utils": "2.9.1",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "node-fetch": "^3.3.0",
@@ -30606,10 +30623,10 @@
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/modal": "^2.4.3",
-        "@walletconnect/sign-client": "2.9.0",
-        "@walletconnect/types": "2.9.0",
-        "@walletconnect/universal-provider": "2.9.0",
-        "@walletconnect/utils": "2.9.0",
+        "@walletconnect/sign-client": "2.9.1",
+        "@walletconnect/types": "2.9.1",
+        "@walletconnect/universal-provider": "2.9.1",
+        "@walletconnect/utils": "2.9.1",
         "ethereum-test-network": "0.1.6",
         "ethers": "5.6.9",
         "events": "^3.3.0",
@@ -30855,7 +30872,7 @@
     "@walletconnect/sign-client": {
       "version": "file:packages/sign-client",
       "requires": {
-        "@walletconnect/core": "2.9.0",
+        "@walletconnect/core": "2.9.1",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "^1.0.13",
@@ -30864,8 +30881,8 @@
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.9.0",
-        "@walletconnect/utils": "2.9.0",
+        "@walletconnect/types": "2.9.1",
+        "@walletconnect/utils": "2.9.1",
         "aws-sdk": "2.1194.0",
         "events": "^3.3.0",
         "lokijs": "^1.5.12"
@@ -30897,9 +30914,9 @@
       "requires": {
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
-        "@walletconnect/sign-client": "2.9.0",
-        "@walletconnect/types": "2.9.0",
-        "@walletconnect/utils": "2.9.0",
+        "@walletconnect/sign-client": "2.9.1",
+        "@walletconnect/types": "2.9.1",
+        "@walletconnect/utils": "2.9.1",
         "events": "^3.3.0",
         "uint8arrays": "^3.1.0"
       }
@@ -30934,9 +30951,9 @@
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sign-client": "2.9.0",
-        "@walletconnect/types": "2.9.0",
-        "@walletconnect/utils": "2.9.0",
+        "@walletconnect/sign-client": "2.9.1",
+        "@walletconnect/types": "2.9.1",
+        "@walletconnect/utils": "2.9.1",
         "cosmos-wallet": "^1.2.0",
         "ethereum-test-network": "0.1.6",
         "ethers": "5.7.0",
@@ -31116,7 +31133,7 @@
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.9.0",
+        "@walletconnect/types": "2.9.1",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -31129,14 +31146,32 @@
       "requires": {
         "@ethersproject/wallet": "^5.7.0",
         "@walletconnect/auth-client": "2.1.1",
-        "@walletconnect/core": "2.9.0",
+        "@walletconnect/core": "2.9.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.0.1",
-        "@walletconnect/sign-client": "2.9.0",
-        "@walletconnect/types": "2.9.0",
-        "@walletconnect/utils": "2.9.0",
+        "@walletconnect/sign-client": "2.9.1",
+        "@walletconnect/types": "2.9.1",
+        "@walletconnect/utils": "2.9.1",
         "lokijs": "^1.5.12"
+      },
+      "dependencies": {
+        "@walletconnect/jsonrpc-ws-connection": {
+          "version": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.12.tgz",
+          "integrity": "sha512-HAcadga3Qjt1Cqy+qXEW6zjaCs8uJGdGQrqltzl3OjiK4epGZRdvSzTe63P+t/3z+D2wG+ffEPn0GVcDozmN1w==",
+          "requires": {
+            "@walletconnect/jsonrpc-utils": "^1.0.6",
+            "@walletconnect/safe-json": "^1.0.2",
+            "events": "^3.3.0",
+            "tslib": "1.14.1",
+            "ws": "^7.5.1"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@walletconnect/window-getters": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/core",
   "description": "Core for WalletConnect Protocol",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -42,8 +42,8 @@
     "@walletconnect/relay-auth": "^1.0.4",
     "@walletconnect/safe-json": "^1.0.2",
     "@walletconnect/time": "^1.0.2",
-    "@walletconnect/types": "2.9.0",
-    "@walletconnect/utils": "2.9.0",
+    "@walletconnect/types": "2.9.1",
+    "@walletconnect/utils": "2.9.1",
     "events": "^3.3.0",
     "lodash.isequal": "4.5.0",
     "uint8arrays": "^3.1.0"

--- a/packages/core/src/constants/relayer.ts
+++ b/packages/core/src/constants/relayer.ts
@@ -37,7 +37,7 @@ export const RELAYER_STORAGE_OPTIONS = {
 
 // Updated automatically via `new-version` npm script.
 
-export const RELAYER_SDK_VERSION = "2.9.0";
+export const RELAYER_SDK_VERSION = "2.9.1";
 
 // delay to wait before closing the transport connection after init if not active
 export const RELAYER_TRANSPORT_CUTOFF = 10_000;

--- a/packages/react-native-compat/package.json
+++ b/packages/react-native-compat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/react-native-compat",
   "description": "Shims for WalletConnect Protocol in React Native Projects",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/sign-client",
   "description": "Sign Client for WalletConnect Protocol",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -38,14 +38,14 @@
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },
   "dependencies": {
-    "@walletconnect/core": "2.9.0",
+    "@walletconnect/core": "2.9.1",
     "@walletconnect/events": "^1.0.1",
     "@walletconnect/heartbeat": "1.2.1",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/logger": "^2.0.1",
     "@walletconnect/time": "^1.0.2",
-    "@walletconnect/types": "2.9.0",
-    "@walletconnect/utils": "2.9.0",
+    "@walletconnect/types": "2.9.1",
+    "@walletconnect/utils": "2.9.1",
     "events": "^3.3.0"
   },
   "devDependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/types",
   "description": "Typings for WalletConnect Protocol",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/utils",
   "description": "Utilities for WalletConnect Protocol",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -39,7 +39,7 @@
     "@walletconnect/relay-api": "^1.0.9",
     "@walletconnect/safe-json": "^1.0.2",
     "@walletconnect/time": "^1.0.2",
-    "@walletconnect/types": "2.9.0",
+    "@walletconnect/types": "2.9.1",
     "@walletconnect/window-getters": "^1.0.1",
     "@walletconnect/window-metadata": "^1.0.1",
     "detect-browser": "5.3.0",

--- a/packages/web3wallet/package.json
+++ b/packages/web3wallet/package.json
@@ -2,7 +2,7 @@
   "name": "@walletconnect/web3wallet",
   "description": "Web3Wallet for WalletConnect Protocol",
   "private": true,
-  "version": "1.8.6",
+  "version": "1.8.7",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -30,12 +30,12 @@
   },
   "dependencies": {
     "@walletconnect/auth-client": "2.1.1",
-    "@walletconnect/core": "2.9.0",
+    "@walletconnect/core": "2.9.1",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/logger": "2.0.1",
-    "@walletconnect/sign-client": "2.9.0",
-    "@walletconnect/types": "2.9.0",
-    "@walletconnect/utils": "2.9.0",
+    "@walletconnect/sign-client": "2.9.1",
+    "@walletconnect/types": "2.9.1",
+    "@walletconnect/utils": "2.9.1",
     "@walletconnect/jsonrpc-provider": "1.0.13"
   },
   "devDependencies": {

--- a/providers/ethereum-provider/package.json
+++ b/providers/ethereum-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/ethereum-provider",
   "description": "Ethereum Provider for WalletConnect Protocol",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {
@@ -47,10 +47,10 @@
     "@walletconnect/jsonrpc-provider": "^1.0.13",
     "@walletconnect/jsonrpc-types": "^1.0.3",
     "@walletconnect/jsonrpc-utils": "^1.0.8",
-    "@walletconnect/sign-client": "2.9.0",
-    "@walletconnect/types": "2.9.0",
-    "@walletconnect/universal-provider": "2.9.0",
-    "@walletconnect/utils": "2.9.0",
+    "@walletconnect/sign-client": "2.9.1",
+    "@walletconnect/types": "2.9.1",
+    "@walletconnect/universal-provider": "2.9.1",
+    "@walletconnect/utils": "2.9.1",
     "events": "^3.3.0"
   },
   "devDependencies": {

--- a/providers/signer-connection/package.json
+++ b/providers/signer-connection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/signer-connection",
   "description": "Signer Connection for WalletConnect Protocol",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -39,9 +39,9 @@
   "dependencies": {
     "@walletconnect/jsonrpc-types": "^1.0.3",
     "@walletconnect/jsonrpc-utils": "^1.0.8",
-    "@walletconnect/sign-client": "2.9.0",
-    "@walletconnect/types": "2.9.0",
-    "@walletconnect/utils": "2.9.0",
+    "@walletconnect/sign-client": "2.9.1",
+    "@walletconnect/types": "2.9.1",
+    "@walletconnect/utils": "2.9.1",
     "events": "^3.3.0",
     "uint8arrays": "^3.1.0"
   }

--- a/providers/universal-provider/package.json
+++ b/providers/universal-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/universal-provider",
   "description": "Universal Provider for WalletConnect Protocol",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {
@@ -45,9 +45,9 @@
     "@walletconnect/jsonrpc-types": "^1.0.2",
     "@walletconnect/jsonrpc-utils": "^1.0.7",
     "@walletconnect/logger": "^2.0.1",
-    "@walletconnect/sign-client": "2.9.0",
-    "@walletconnect/types": "2.9.0",
-    "@walletconnect/utils": "2.9.0",
+    "@walletconnect/sign-client": "2.9.1",
+    "@walletconnect/types": "2.9.1",
+    "@walletconnect/utils": "2.9.1",
     "events": "^3.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Release Checklist

- [x] **Canary Version QA**

  - [x] I have thoroughly tested the release using a canary version: `2.9.1-rc-e8b829`
  - [x] The canary version has been verified to work as expected.
  - [x] All major features and changes have been tested and validated.

- [ ] **Web3Modal Team QA**

  - [ ] The Web3Modal team has tested the release for compatibility and functionality.
  - [ ] The release is backwards compatible with Web3Modal.
  - [ ] Any reported issues or bugs have been addressed or documented.

- [ ] **React Native Team QA**

  - [x] The React Native team has tested the release for compatibility and functionality (if relevant).
  - [x] The release works correctly in React Native environments and is backwards compatible with Web3Modal React Native.
  - [ ] Any reported issues or bugs have been addressed or documented.

## Description

* chore: prep for `2.9.0` release by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/3017
* fix(deps): update dependency @walletconnect/jsonrpc-ws-connection to v1.0.13 by @renovate in https://github.com/WalletConnect/walletconnect-monorepo/pull/3035
* feat(scripts): automatically update `RELAYER_SDK_VERSION` from lerna.json by @bkrem in https://github.com/WalletConnect/walletconnect-monorepo/pull/3095
* chore: skip verify suite until CSRF tokens are handled/mocked by @bkrem in https://github.com/WalletConnect/walletconnect-monorepo/pull/3139
* fix(relayer): prevents forwarding empty/invalid message payloads to clients by @bkrem in https://github.com/WalletConnect/walletconnect-monorepo/pull/3137
* fix: auto namespaces builder by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/3169
* fix(deps): update dependency @walletconnect/auth-client to v2.1.1 by @renovate in https://github.com/WalletConnect/walletconnect-monorepo/pull/3177
* fix: try/catch around crypto.decode by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/3211
* chore(deps-dev): bump word-wrap from 1.2.3 to 1.2.4 by @dependabot in https://github.com/WalletConnect/walletconnect-monorepo/pull/3204
* Up the timeout to 10 seconds rather than 5 seconds by @kdenhartog in https://github.com/WalletConnect/walletconnect-monorepo/pull/3230
* fix(universal-provider): expose storage option at provider level by @bkrem in https://github.com/WalletConnect/walletconnect-monorepo/pull/3222
* chore(deps): updates lerna to latest major by @bkrem in https://github.com/WalletConnect/walletconnect-monorepo/pull/3224
* feat: session requests queue by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/3220


## Definition of Done

- [x] The release has been tested using a canary version.
- [ ] The release has been reviewed and approved by the Web3Modal team (if relevant).
- [ ] The release has been reviewed and approved by the React Native team (if relevant).
- [x] All necessary documentation, including API changes or new features, has been updated.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] All tests (unit, integration, etc.) pass successfully.
- [x] The release has been properly versioned and tagged.
- [x] The release notes and changelog have been updated to reflect the changes made.

Please ensure that all the items on the checklist have been completed before merging the release.