### PR TITLE
fix: deeplinks cleanup

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -441,6 +441,11 @@ export class Engine extends IEngine {
       await this.client.core.crypto.deleteSymKey(topic);
     }
     if (!expirerHasDeleted) this.client.core.expirer.del(topic);
+    // remove any deeplinks from storage after the session is deleted
+    // to avoid navigating to incorrect deeplink later on
+    this.client.core.storage
+      .removeItem(WALLETCONNECT_DEEPLINK_CHOICE)
+      .catch((e) => this.client.logger.warn(e));
   };
 
   private deleteProposal: EnginePrivate["deleteProposal"] = async (id, expirerHasDeleted) => {

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -7,7 +7,7 @@ import {
 import { RelayerTypes } from "@walletconnect/types";
 import { getSdkError } from "@walletconnect/utils";
 import { expect, describe, it, vi } from "vitest";
-import SignClient from "../../src";
+import SignClient, { WALLETCONNECT_DEEPLINK_CHOICE } from "../../src";
 import {
   initTwoClients,
   testConnectMethod,
@@ -153,6 +153,20 @@ describe("Sign Client Integration", () => {
         expect(clients.A.core.crypto.keychain.has(self.publicKey)).to.be.false;
         expect(clients.B.core.crypto.keychain.has(topic)).to.be.false;
         expect(clients.B.core.crypto.keychain.has(selfB.publicKey)).to.be.false;
+        await deleteClients(clients);
+      });
+    });
+    describe("deeplinks", () => {
+      it("should clear `WALLETCONNECT_DEEPLINK_CHOICE` from storage on disconnect", async () => {
+        const clients = await initTwoClients();
+        const {
+          sessionA: { topic, self },
+        } = await testConnectMethod(clients);
+        const deepLink = "dummy deep link";
+        await clients.A.core.storage.setItem(WALLETCONNECT_DEEPLINK_CHOICE, deepLink);
+        expect(await clients.A.core.storage.getItem(WALLETCONNECT_DEEPLINK_CHOICE)).to.eq(deepLink);
+        await clients.A.disconnect({ topic, reason: getSdkError("USER_DISCONNECTED") });
+        expect(await clients.A.core.storage.getItem(WALLETCONNECT_DEEPLINK_CHOICE)).to.be.undefined;
         await deleteClients(clients);
       });
     });


### PR DESCRIPTION
## Description

Added cleanup of `WALLETCONNECT_DEEPLINK_CHOICE` after a session is deleted to fix possible cases where incorrect deeplink might be used

more context:
https://walletconnect.slack.com/archives/C03RVH94K5K/p1690270341430459  

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
