### PR TITLE
fix: namespace builder optional chains match

### DIFF
--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -167,7 +167,7 @@ export function buildApprovedNamespaces(
     const accountsToAdd = chainsToAdd
       ?.map((chain: string) =>
         supportedNamespaces[optionalNamespace].accounts.filter((account: string) =>
-          account.includes(chain),
+          account.includes(`${chain}:`),
         ),
       )
       .flat();

--- a/packages/utils/test/validators.spec.ts
+++ b/packages/utils/test/validators.spec.ts
@@ -868,13 +868,13 @@ describe("buildApprovedNamespaces (validators)", () => {
       },
     };
 
-    const chains = ["eip155:1", "eip155:2", "eip155:4"];
+    const chains = ["eip155:1", "eip155:2", "eip155:11"];
     const methods = ["personal_sign", "eth_sendTransaction", "eth_signTransaction"];
     const events = ["chainChanged", "accountsChanged"];
     const accounts = [
       "eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
       "eip155:2:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
-      "eip155:4:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+      "eip155:11:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
     ];
 
     const approvedNamespaces = buildApprovedNamespaces({


### PR DESCRIPTION
## Description
Fixed a bug where optional chains were incorrectly matched with accounts when the chain overlaps e.g. `eip155:1` with `eip155:137`

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests
## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
