### PR TITLE
build: remove useless rollup conf

### DIFF
--- a/providers/ethereum-provider/rollup.config.js
+++ b/providers/ethereum-provider/rollup.config.js
@@ -1,10 +1,6 @@
 import { name, dependencies, peerDependencies } from "./package.json";
 import createConfig from "../../rollup.config";
 // @walletconnect/modal has dynamic imports, so we need to enable inlineDynamicImports
-export default createConfig(
-  name,
-  Object.keys({ ...dependencies, ...peerDependencies }),
-  { inlineDynamicImports: true },
-  { inlineDynamicImports: true },
-  { inlineDynamicImports: true },
-);
+export default createConfig(name, Object.keys({ ...dependencies, ...peerDependencies }), {
+  inlineDynamicImports: true,
+});


### PR DESCRIPTION
> Creating a release? Please use the [Release PR Template](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/.github/pr_template_release.md) instead.

## Description
The @walletconnect/modal package is already declared as an external dependency when the packaging product is in cjs and es format. So setting inlineDynamicImports: true has no effect. https://github.com/WalletConnect/walletconnect-monorepo/blob/06ca6bbf5aa26e869a4e1bfd83b5cca38eae7960/rollup.config.js#L41

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your configuration.

## Fixes/Resolves (Optional)

Please list any issues that are fixed by this PR in the format `#<issue number>`. If it fixes multiple issues, please put each issue in a separate line. If this Pull Request does not fix any issues, please delete this section.

## Examples/Screenshots (Optional)

Please attach a screenshot or screen recording of features/fixes you've implemented to verify your changes. Please also note any relevant details for your configuration. If your changes do not affect the UI, please delete this section.

Use this table template to show examples of your changes:

| Before       | After        |
| ------------ | ------------ |
| Content Cell | Content Cell |
| Content Cell | Content Cell |

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
