### PR TITLE
fix: compares `metadata.url` origin to verify attestation origin

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -1,4 +1,9 @@
-import { EXPIRER_EVENTS, RELAYER_DEFAULT_PROTOCOL, RELAYER_EVENTS } from "@walletconnect/core";
+import {
+  EXPIRER_EVENTS,
+  RELAYER_DEFAULT_PROTOCOL,
+  RELAYER_EVENTS,
+  VERIFY_SERVER,
+} from "@walletconnect/core";
 
 import {
   JsonRpcPayload,
@@ -1288,7 +1293,7 @@ export class Engine extends IEngine {
   private getVerifyContext = async (hash: string, metadata: CoreTypes.Metadata) => {
     const context: Verify.Context = {
       verified: {
-        verifyUrl: metadata.verifyUrl || "",
+        verifyUrl: metadata.verifyUrl || VERIFY_SERVER,
         validation: "UNKNOWN",
         origin: metadata.url || "",
       },
@@ -1301,7 +1306,7 @@ export class Engine extends IEngine {
       });
       if (origin) {
         context.verified.origin = origin;
-        context.verified.validation = origin === metadata.url ? "VALID" : "INVALID";
+        context.verified.validation = origin === new URL(metadata.url).origin ? "VALID" : "INVALID";
       }
     } catch (e) {
       this.client.logger.error(e);


### PR DESCRIPTION
## Description
Fixed an issue where metadata URL was compared to Verify's origin "as is" and not just against the origin of the URL. This could cause false-positive validations when the metadata URL is set with additional routes/paths/params etc

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding 

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
