### PR TITLE
fix: verify api queue

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -935,7 +935,9 @@ export class Engine extends IEngine {
 
     try {
       const { id, topic, params } = request;
-      const hash = hashMessage(JSON.stringify({ id, params }));
+      const hash = hashMessage(
+        JSON.stringify(formatJsonRpcRequest("wc_sessionRequest", params, id)),
+      );
       const session = this.client.session.get(topic);
       const verifyContext = await this.getVerifyContext(hash, session.peer.metadata);
       this.requestQueue.state = REQUEST_QUEUE_STATES.active;


### PR DESCRIPTION
## Description

- Implemented queue mechanism that is used during Verify iframe loading to ensure all payloads are POSTed after iframe is ready to receive payloads
- Added ability to update iframe server url by calling `init` with new server url
- fixes bug where resolve attestation was hashing incomplete payload (missing jsonrpc & method props) resulting in the wrong attestation id - regression introduced in the requests queue update

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding
canary - `2.9.2-canary.1`

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
