### PR TITLE
feat: verify fallback

### DIFF
--- a/packages/core/src/constants/verify.ts
+++ b/packages/core/src/constants/verify.ts
@@ -1,3 +1,5 @@
 export const VERIFY_CONTEXT = "verify-api";
 
 export const VERIFY_SERVER = "https://verify.walletconnect.com";
+
+export const VERIFY_FALLBACK_SERVER = "https://verify.walletconnect.org";

--- a/packages/core/src/controllers/verify.ts
+++ b/packages/core/src/controllers/verify.ts
@@ -71,13 +71,13 @@ export class Verify extends IVerify {
     const mainUrl = params?.verifyUrl || VERIFY_SERVER;
     let result = "";
     try {
-      result = await this.fetch(params.attestationId, mainUrl);
+      result = await this.fetchAttestation(params.attestationId, mainUrl);
     } catch (error) {
       this.logger.warn(
         `failed to resolve attestation: ${params.attestationId} from url: ${mainUrl}`,
       );
       this.logger.warn(error);
-      result = await this.fetch(params.attestationId, VERIFY_FALLBACK_SERVER);
+      result = await this.fetchAttestation(params.attestationId, VERIFY_FALLBACK_SERVER);
     }
     return result;
   };
@@ -86,7 +86,7 @@ export class Verify extends IVerify {
     return getLoggerContext(this.logger);
   }
 
-  private fetch = async (attestationId: string, url: string) => {
+  private fetchAttestation = async (attestationId: string, url: string) => {
     this.logger.info(`resolving attestation: ${attestationId} from url: ${url}`);
     // set artificial timeout to prevent hanging
     const timeout = this.startAbortTimer(ONE_SECOND * 2);

--- a/packages/core/src/controllers/verify.ts
+++ b/packages/core/src/controllers/verify.ts
@@ -142,7 +142,7 @@ export class Verify extends IVerify {
       new Promise((_, reject) =>
         setTimeout(() => {
           window.removeEventListener("message", onMessage);
-          reject("iframe load timeout");
+          reject("verify iframe load timeout");
         }, toMiliseconds(FIVE_SECONDS)),
       ),
     ]);

--- a/packages/core/src/controllers/verify.ts
+++ b/packages/core/src/controllers/verify.ts
@@ -39,22 +39,26 @@ export class Verify extends IVerify {
     }
     this.verifyUrl = verifyUrl;
 
-    await this.createIframe().catch((error) => {
+    try {
+      await this.createIframe();
+    } catch (error) {
       this.logger.warn(`Verify iframe failed to load: ${this.verifyUrl}`);
       this.logger.warn(error);
-    });
+    }
 
     if (this.initialized) return;
 
     this.removeIframe();
     this.verifyUrl = VERIFY_FALLBACK_SERVER;
 
-    await this.createIframe().catch((error) => {
+    try {
+      await this.createIframe();
+    } catch (error) {
       this.logger.error(`Verify iframe failed to load: ${this.verifyUrl}`);
       this.logger.error(error);
       // if the fallback url fails to load as well, disable verify
       this.verifyDisabled = true;
-    });
+    }
   };
 
   public register: IVerify["register"] = async (params) => {

--- a/packages/core/src/controllers/verify.ts
+++ b/packages/core/src/controllers/verify.ts
@@ -1,7 +1,7 @@
 import { generateChildLogger, getLoggerContext, Logger } from "@walletconnect/logger";
 import { IVerify } from "@walletconnect/types";
 import { isBrowser, isNode, isReactNative } from "@walletconnect/utils";
-import { ONE_SECOND, toMiliseconds } from "@walletconnect/time";
+import { FIVE_SECONDS, ONE_SECOND, toMiliseconds } from "@walletconnect/time";
 
 import { VERIFY_CONTEXT, VERIFY_FALLBACK_SERVER, VERIFY_SERVER } from "../constants";
 
@@ -136,7 +136,7 @@ export class Verify extends IVerify {
         setTimeout(() => {
           window.removeEventListener("message", onMessage);
           reject("iframe load timeout");
-        }, toMiliseconds(ONE_SECOND)),
+        }, toMiliseconds(FIVE_SECONDS)),
       ),
     ]);
   };

--- a/packages/core/src/controllers/verify.ts
+++ b/packages/core/src/controllers/verify.ts
@@ -40,8 +40,8 @@ export class Verify extends IVerify {
     this.verifyUrl = verifyUrl;
 
     await this.createIframe().catch((error) => {
-      this.logger.error(`Verify iframe failed to load: ${this.verifyUrl}`);
-      this.logger.error(error);
+      this.logger.warn(`Verify iframe failed to load: ${this.verifyUrl}`);
+      this.logger.warn(error);
     });
 
     if (this.initialized) return;

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -522,7 +522,7 @@ export class Engine extends IEngine {
     const payload = formatJsonRpcRequest(method, params, clientRpcId);
     if (isBrowser() && METHODS_TO_VERIFY.includes(method)) {
       const hash = hashMessage(JSON.stringify(payload));
-      await this.client.core.verify.register({ attestationId: hash });
+      this.client.core.verify.register({ attestationId: hash });
     }
     const message = await this.client.core.crypto.encode(topic, payload);
     const opts = ENGINE_RPC_OPTS[method].req;


### PR DESCRIPTION
## Description
Implemented fallback to `.org` on Verify Iframe & Attestation resolve.

Additionally, updated iframe `onload` behavior to be triggered by a message ping by the enclave JS instead of relaying on iframe `onload/onerror` events.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding on Chome/Mozilla/Safari

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
