### PR TITLE
feat: Generic EngineTypes.RequestParams

### DIFF
--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -83,11 +83,11 @@ export declare namespace EngineTypes {
     topic: string;
   }
 
-  interface RequestParams {
+  interface RequestParams<T = any> {
     topic: string;
     request: {
       method: string;
-      params: any;
+      params: T;
     };
     chainId: string;
     expiry?: number;


### PR DESCRIPTION
## Description

When creating session request payload, it would be nice to let the developer create strongly typed `RequestParams`. This can easily be done be converting the existing `EngineTypes.RequestParams` to a TypeScript generic, with a default type parameter value of `any`. The default value makes the type parameter optional so that any existing usage of the type will not change, but gives the developer the option to add more specific params types if they want to.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Ran the build command in the root repo successfully.

## Examples/Screenshots (Optional)

```ts
import { EngineTypes } from "@walletconnect/types";

type TransactionParams = {
  transaction: {
    type: string;
    bytes: string;
  };
};

type DefaultRequestParams = EngineTypes.RequestParams;
type TypedRequestParams = EngineTypes.RequestParams<TransactionParams>;

const untypedParamsPayload: DefaultRequestParams = {
  chainId: "foo:testnet",
  topic: session!.topic,
  request: {
    method: "testMethod",
    params: { // by default, params are `any` type, so anything could go here
      untyped: {
        data: "isDangerous",
      },
    },
  },
};

const typedParamsPayload: TypedRequestParams = {
  chainId: "foo:testnet",
  topic: session!.topic,
  request: {
    method: "testMethod",
    params: { // using the generic type parameter forces the params to adhere to a specific interface
      transaction: {
        type: "CryptoTransfer",
        bytes: "Cxf0d...",
      },
    },
  },
};
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

For reference, I wanted to have a "TypedRequestParams" type when adding the Hedera example to the web-examples/dapps/react-dapp-v2, and this is how that can be accomplished with the fixed `EngineTypes.RequestParams` as a base type. Definitely not as readable/friendly as making that type generic:
```ts
type TypedRequestParams<T> = Omit<EngineTypes.RequestParams, "request"> & {
  request: Omit<EngineTypes.RequestParams["request"], "params"> & {
    params: T;
  };
};
```
