### PR TITLE
fix: make projectId a required prop

### DIFF
--- a/packages/types/src/core/core.ts
+++ b/packages/types/src/core/core.ts
@@ -12,7 +12,7 @@ import { Logger } from "@walletconnect/logger";
 import { IVerify } from "./verify";
 export declare namespace CoreTypes {
   interface Options {
-    projectId?: string;
+    projectId: string;
     name?: string;
     relayUrl?: string;
     logger?: string | Logger;
@@ -41,7 +41,7 @@ export abstract class ICore extends IEvents {
   public abstract readonly name: string;
   public abstract readonly context: string;
   public abstract readonly relayUrl?: string;
-  public abstract readonly projectId?: string;
+  public abstract readonly projectId: string;
 
   public abstract logger: Logger;
   public abstract heartbeat: IHeartBeat;

--- a/packages/types/src/core/relayer.ts
+++ b/packages/types/src/core/relayer.ts
@@ -51,7 +51,7 @@ export declare namespace RelayerTypes {
     auth: string;
     relayUrl: string;
     sdkVersion: string;
-    projectId?: string;
+    projectId: string;
     useOnCloseEvent?: boolean;
   }
 }
@@ -60,7 +60,7 @@ export interface RelayerOptions {
   core: ICore;
   logger?: string | Logger;
   relayUrl?: string;
-  projectId?: string;
+  projectId: string;
 }
 
 export interface RelayerClientMetadata {


### PR DESCRIPTION
According to documentation https://docs.walletconnect.com/2.0/advanced/migration-from-v1.x/overview#walletconnect-v10-vs-v20
in v2 projectId is a required prop, but the types are still optional