### PR TITLE
fix: handling multiple requests from mailbox

### DIFF
--- a/packages/sign-client/src/constants/engine.ts
+++ b/packages/sign-client/src/constants/engine.ts
@@ -108,7 +108,7 @@ export const SESSION_REQUEST_EXPIRY_BOUNDARIES = {
   max: SEVEN_DAYS,
 };
 
-export const REQUEST_QUEUE_STATES: { idle: string; active: string } = {
-  idle: "idle",
-  active: "active",
+export const ENGINE_QUEUE_STATES: { idle: "IDLE"; active: "ACTIVE" } = {
+  idle: "IDLE",
+  active: "ACTIVE",
 };

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -128,6 +128,11 @@ export declare namespace EngineTypes {
   }
 
   type RpcOptsMap = Record<JsonRpcTypes.WcMethod, RpcOpts>;
+
+  type EngineQueue<T> = {
+    state: "IDLE" | "ACTIVE";
+    queue: T[];
+  };
 }
 
 export abstract class IEngineEvents extends EventEmitter {


### PR DESCRIPTION
## Description
Implemented queue on all incoming requests specially targeting `session_update` & `session_event` methods that require processing in strict order. 
After client init, all requests stored in the mailbox will be received at the same time, and processing them must be done one by one & in order to avoid conflicting states between peers 
## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding 
integration test


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
