### PR TITLE
fix: undefined accountsChanged emitted after connection

### DIFF
--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -316,8 +316,10 @@ export class EthereumProvider implements IEthereumProvider {
         },
       );
       if (!session) return;
-      this.setChainIds(this.rpc.chains);
+
       const accounts = getAccountsFromNamespaces(session.namespaces, [this.namespace]);
+      // if no required chains are set, use the approved accounts to fetch chainIds
+      this.setChainIds(this.rpc.chains.length ? this.rpc.chains : accounts);
       this.setAccounts(accounts);
       this.events.emit("connect", { chainId: toHexChainId(this.chainId) });
     } catch (error) {

--- a/providers/ethereum-provider/test/index.spec.ts
+++ b/providers/ethereum-provider/test/index.spec.ts
@@ -24,6 +24,7 @@ import {
   TEST_ETHEREUM_METHODS_OPTIONAL,
 } from "./shared/constants";
 import { EthereumProviderOptions } from "../src/EthereumProvider";
+import { parseChainId } from "@walletconnect/utils";
 
 describe("EthereumProvider", function () {
   let testNetwork: TestNetwork;
@@ -479,7 +480,6 @@ describe("EthereumProvider", function () {
       expect(Object.keys(httpProviders).map((chain) => parseInt(chain))).to.eql(
         initOptions.optionalChains,
       );
-
       await provider.signer.client.core.relayer.transportClose();
       await walletClient.core.relayer.transportClose();
     });
@@ -534,6 +534,72 @@ describe("EthereumProvider", function () {
           showQrModal: false,
         }),
       ).rejects.toThrowError("No chains specified in either `chains` or `optionalChains`");
+    });
+    it("should connect when none of the optional chains are approved", async () => {
+      const initOptions: EthereumProviderOptions = {
+        projectId: process.env.TEST_PROJECT_ID || "",
+        optionalChains: [CHAIN_ID],
+        showQrModal: false,
+      };
+      const provider = await EthereumProvider.init(initOptions);
+      const walletClient = await SignClient.init({
+        projectId: initOptions.projectId,
+      });
+      const chainToApprove = "eip155:137";
+
+      expect(parseInt(parseChainId(chainToApprove).reference)).to.not.eql(CHAIN_ID);
+
+      await Promise.all([
+        new Promise<void>((resolve) => {
+          walletClient.on("session_proposal", async (proposal) => {
+            await walletClient.approve({
+              id: proposal.id,
+              namespaces: {
+                eip155: {
+                  chains: [chainToApprove],
+                  accounts: [`${chainToApprove}:${walletAddress}`],
+                  methods: proposal.params.optionalNamespaces.eip155.methods,
+                  events: proposal.params.optionalNamespaces.eip155.events,
+                },
+              },
+            });
+            resolve();
+          });
+        }),
+        new Promise<void>((resolve) => {
+          provider.on("display_uri", (uri) => {
+            walletClient.pair({ uri });
+            resolve();
+          });
+        }),
+        new Promise<void>((resolve) => {
+          provider.on("accountsChanged", (accounts) => {
+            expect(accounts[0]).to.include(walletAddress);
+            expect(accounts.length).to.eql(1);
+            resolve();
+          });
+        }),
+        new Promise<void>((resolve) => {
+          provider.on("chainChanged", (chain) => {
+            expect(parseInt(chain, 16)).to.eql(parseInt(parseChainId(chainToApprove).reference));
+            resolve();
+          });
+        }),
+        provider.connect(),
+      ]);
+      const accounts = (await provider.request({ method: "eth_accounts" })) as string[];
+      expect(accounts[0]).to.include(walletAddress);
+      expect(accounts.length).to.eql(1);
+
+      const httpProviders = provider.signer.rpcProviders.eip155.httpProviders;
+      expect(httpProviders).to.exist;
+      expect(httpProviders).to.be.an("object");
+      expect(Object.keys(httpProviders).length).to.eql(1);
+      expect(Object.keys(httpProviders).map((chain) => parseInt(chain))).to.eql([
+        parseInt(parseChainId(chainToApprove).reference),
+      ]);
+      await provider.signer.client.core.relayer.transportClose();
+      await walletClient.core.relayer.transportClose();
     });
   });
 });


### PR DESCRIPTION
## Description
Resolved a bug where `accountsChanged` was emitted with `undefined` payload after session creation when required chains are left empty

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding
integration tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
