### PR TITLE
refactor: request queue

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -64,6 +64,7 @@ import {
   parseExpirerTarget,
   TYPE_1,
   handleDeeplinkRedirect,
+  MemoryStore,
 } from "@walletconnect/utils";
 import EventEmmiter from "events";
 import {
@@ -101,11 +102,6 @@ export class Engine extends IEngine {
     state: ENGINE_QUEUE_STATES.idle,
     queue: [],
   };
-
-  /**
-   * these requests must be processed in strict order to avoid inconsistent state between peers
-   */
-  private requestsProcessedInStrictOrder = ["wc_sessionUpdate", "wc_sessionEvent"];
 
   private requestQueueDelay = ONE_SECOND;
 
@@ -647,40 +643,26 @@ export class Engine extends IEngine {
 
   private onRelayEventRequest: EnginePrivate["onRelayEventRequest"] = async (event) => {
     this.requestQueue.queue.push(event);
+    await this.processRequestsQueue();
+  };
+
+  private processRequestsQueue = async () => {
     if (this.requestQueue.state === ENGINE_QUEUE_STATES.active) {
       this.client.logger.info(`Request queue already active, skipping...`);
       return;
     }
+
     this.client.logger.info(
       `Request queue starting with ${this.requestQueue.queue.length} requests`,
     );
-    // holds the last request id for each method
-    // so we can discard requests out of sync
-    const lastRequestMapping = {};
+
     while (this.requestQueue.queue.length > 0) {
       this.requestQueue.state = ENGINE_QUEUE_STATES.active;
       const request = this.requestQueue.queue.shift();
-      if (!request) {
-        continue;
-      }
-      const method = request.payload.method;
+      if (!request) continue;
 
-      // if the queue already processed a request with the same method in this cycle, check the timestamp from the IDs
-      // we want to process only the latest request for each method
-      // client <-> client rpc ID is timestamp + 3 random digits
-      if (
-        this.requestsProcessedInStrictOrder.includes(method) &&
-        lastRequestMapping[method] &&
-        parseInt(request.payload.id.toString().slice(0, -3)) <=
-          parseInt(lastRequestMapping[method].toString().slice(0, -3))
-      ) {
-        this.client.logger.info(`Discarding out of sync request - ${request.payload.id}`);
-        continue;
-      }
-
-      lastRequestMapping[method] = request.payload.id;
       try {
-        this.processRequestsQueue(request);
+        this.processRequest(request);
         // small delay to allow for any async tasks to complete
         await new Promise((resolve) => setTimeout(resolve, 300));
       } catch (error) {
@@ -690,7 +672,7 @@ export class Engine extends IEngine {
     this.requestQueue.state = ENGINE_QUEUE_STATES.idle;
   };
 
-  private processRequestsQueue: EnginePrivate["onRelayEventRequest"] = (event) => {
+  private processRequest: EnginePrivate["onRelayEventRequest"] = (event) => {
     const { topic, payload } = event;
     const reqMethod = payload.method as JsonRpcTypes.WcMethod;
     switch (reqMethod) {
@@ -877,14 +859,30 @@ export class Engine extends IEngine {
   ) => {
     const { params, id } = payload;
     try {
+      const memoryKey = `${topic}_session_update`;
+      // compare the current request id with the last processed session update
+      // we want to update only if the request is newer than the last processed one
+      const lastSessionUpdateId = MemoryStore.get<number>(memoryKey);
+      if (lastSessionUpdateId && this.isRequestOutOfSync(lastSessionUpdateId, id)) {
+        this.client.logger.info(`Discarding out of sync request - ${id}`);
+        return;
+      }
+
       this.isValidUpdate({ topic, ...params });
       await this.client.session.update(topic, { namespaces: params.namespaces });
       await this.sendResult<"wc_sessionUpdate">({ id, topic, result: true });
       this.client.events.emit("session_update", { id, topic, params });
+      MemoryStore.set(memoryKey, id);
     } catch (err: any) {
       await this.sendError(id, topic, err);
       this.client.logger.error(err);
     }
+  };
+
+  // compares the timestamp of the last processed request with the current request
+  // client <-> client rpc ID is timestamp + 3 random digits
+  private isRequestOutOfSync = (lastId: number, currentId: number) => {
+    return parseInt(currentId.toString().slice(0, -3)) <= parseInt(lastId.toString().slice(0, -3));
   };
 
   private onSessionUpdateResponse: EnginePrivate["onSessionUpdateResponse"] = (_topic, payload) => {
@@ -999,8 +997,20 @@ export class Engine extends IEngine {
   ) => {
     const { id, params } = payload;
     try {
+      // similar to session update, we want to discard out of sync requests
+      // additionally we have to check the event type as well e.g. chainChanged/accountsChanged
+      const memoryKey = `${topic}_session_event_${params.event.name}`;
+      // compare the current request id with the last processed session update
+      // we want to update only if the request is newer than the last processed one
+      const lastSessionUpdateId = MemoryStore.get<number>(memoryKey);
+      if (lastSessionUpdateId && this.isRequestOutOfSync(lastSessionUpdateId, id)) {
+        this.client.logger.info(`Discarding out of sync request - ${id}`);
+        return;
+      }
+
       this.isValidEmit({ topic, ...params });
       this.client.events.emit("session_event", { id, topic, params });
+      MemoryStore.set(memoryKey, id);
     } catch (err: any) {
       await this.sendError(id, topic, err);
       this.client.logger.error(err);

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -8,3 +8,4 @@ export * from "./validators";
 export * from "./errors";
 export * from "./namespaces";
 export * from "./network";
+export * from "./memoryStore";

--- a/packages/utils/src/memoryStore.ts
+++ b/packages/utils/src/memoryStore.ts
@@ -1,0 +1,15 @@
+const memoryStore = {};
+
+export abstract class MemoryStore {
+  static get<T = unknown>(key: string) {
+    return memoryStore[key] as T | undefined;
+  }
+
+  static set(key: string, value: unknown) {
+    memoryStore[key] = value;
+  }
+
+  static delete(key: string) {
+    delete memoryStore[key];
+  }
+}

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -358,7 +358,7 @@ export class UniversalProvider implements IUniversalProvider {
         // chainIds might differ between the request & payload - request is always in CAIP2 format, while payload might be string, number, CAIP2 or hex
         // take priority of the payload chainId
         const chainIdToProcess =
-          convertChainIdToNumber(requestChainId) !== payloadChainId
+          convertChainIdToNumber(requestChainId) !== convertChainIdToNumber(payloadChainId)
             ? `${namespace}:${convertChainIdToNumber(payloadChainId)}`
             : requestChainId;
         this.onChainChanged(chainIdToProcess);

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -3,6 +3,7 @@ import { SessionTypes } from "@walletconnect/types";
 import { getSdkError, isValidArray, parseNamespaceKey } from "@walletconnect/utils";
 import { getDefaultLoggerOptions, Logger, pino } from "@walletconnect/logger";
 import {
+  convertChainIdToNumber,
   getAccountsFromSession,
   getChainsFromApprovedSession,
   mergeRequiredOptionalNamespaces,
@@ -351,7 +352,16 @@ export class UniversalProvider implements IUniversalProvider {
         if (accounts && isValidArray(accounts))
           this.events.emit("accountsChanged", accounts.map(parseCaip10Account));
       } else if (event.name === "chainChanged") {
-        this.onChainChanged(params.chainId);
+        const requestChainId = params.chainId;
+        const payloadChainId = params.event.data as number;
+        const namespace = parseNamespaceKey(requestChainId);
+        // chainIds might differ between the request & payload - request is always in CAIP2 format, while payload might be string, number, CAIP2 or hex
+        // take priority of the payload chainId
+        const chainIdToProcess =
+          convertChainIdToNumber(requestChainId) !== payloadChainId
+            ? `${namespace}:${convertChainIdToNumber(payloadChainId)}`
+            : requestChainId;
+        this.onChainChanged(chainIdToProcess);
       } else {
         this.events.emit(event.name, event.data);
       }

--- a/providers/universal-provider/src/utils/misc.ts
+++ b/providers/universal-provider/src/utils/misc.ts
@@ -128,3 +128,11 @@ export function populateNamespacesChains(
   }
   return parsedNamespaces;
 }
+
+export function convertChainIdToNumber(chainId: string | number): number {
+  if (typeof chainId === "number") return chainId;
+  if (chainId.includes("0x")) {
+    return parseInt(chainId, 16);
+  }
+  return chainId.includes(":") ? Number(chainId.split(":")[1]) : Number(chainId);
+}


### PR DESCRIPTION
## Description

- Reworked requests queue to account for session events type and not just `rpcId` timestamp to avoid cases where proper requests might be out of sync but target different events
- also update `universal-provider` to use  payload chainId when handing `chainChanged` events  

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding
## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
