### PR TITLE
refactor: disable retry on fatal errors

### DIFF
--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -373,6 +373,11 @@ export class Relayer extends IRelayer {
   private onProviderErrorHandler = (error: Error) => {
     this.logger.error(error);
     this.events.emit(RELAYER_EVENTS.error, error);
+
+    // close the transport when a fatal error is received as there's no way to recover from it
+    // usual cases are missing/invalid projectId, expired jwt token, invalid origin etc
+    this.logger.info("Fatal socket error received, closing transport");
+    this.transportClose();
   };
 
   private registerProviderListeners = () => {


### PR DESCRIPTION
## Description
Disabled reconnection attempts when a fatal connection error is received as recovery is not really possible with current configuration. Most often fatal errors are caused by 
- Invalid relay URL
- missing/invalid `projectId`
- expired jwt token
- invalid origin

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding 

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
