### PR TITLE
refactor: adds `eth_sendTransaction` & `personal_sign` to default opt…

### DIFF
--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -172,7 +172,9 @@ export function buildNamespaces(params: NamespacesParams): {
         required.methods.concat(optionalMethods?.length ? optionalMethods : OPTIONAL_METHODS),
       ),
     ],
-    events: [...new Set(required.events.concat(optionalEvents || OPTIONAL_EVENTS))],
+    events: [
+      ...new Set(required.events.concat(optionalEvents?.length ? optionalEvents : OPTIONAL_EVENTS)),
+    ],
     rpcMap,
   };
 

--- a/providers/ethereum-provider/src/constants/rpc.ts
+++ b/providers/ethereum-provider/src/constants/rpc.ts
@@ -19,4 +19,10 @@ export const OPTIONAL_METHODS = [
   "wallet_scanQRCode",
 ];
 export const REQUIRED_EVENTS = ["chainChanged", "accountsChanged"];
-export const OPTIONAL_EVENTS = ["message", "disconnect", "connect"];
+export const OPTIONAL_EVENTS = [
+  "chainChanged",
+  "accountsChanged",
+  "message",
+  "disconnect",
+  "connect",
+];

--- a/providers/ethereum-provider/src/constants/rpc.ts
+++ b/providers/ethereum-provider/src/constants/rpc.ts
@@ -8,6 +8,8 @@ export const OPTIONAL_METHODS = [
   "eth_signTypedData",
   "eth_signTypedData_v3",
   "eth_signTypedData_v4",
+  "eth_sendTransaction",
+  "personal_sign",
   "wallet_switchEthereumChain",
   "wallet_addEthereumChain",
   "wallet_getPermissions",

--- a/providers/ethereum-provider/test/index.spec.ts
+++ b/providers/ethereum-provider/test/index.spec.ts
@@ -11,7 +11,7 @@ import {
   _bytecode,
 } from "ethereum-test-network/lib/utils/ERC20Token__factory";
 import { WalletClient } from "./shared";
-import EthereumProvider from "../src";
+import EthereumProvider, { OPTIONAL_METHODS } from "../src";
 import {
   CHAIN_ID,
   PORT,
@@ -444,6 +444,7 @@ describe("EthereumProvider", function () {
       await Promise.all([
         new Promise<void>((resolve) => {
           walletClient.on("session_proposal", async (proposal) => {
+            expect(proposal.params.optionalNamespaces.eip155.methods).to.eql(OPTIONAL_METHODS);
             await walletClient.approve({
               id: proposal.id,
               namespaces: {

--- a/providers/ethereum-provider/test/index.spec.ts
+++ b/providers/ethereum-provider/test/index.spec.ts
@@ -11,7 +11,7 @@ import {
   _bytecode,
 } from "ethereum-test-network/lib/utils/ERC20Token__factory";
 import { WalletClient } from "./shared";
-import EthereumProvider, { OPTIONAL_METHODS } from "../src";
+import EthereumProvider, { OPTIONAL_EVENTS, OPTIONAL_METHODS } from "../src";
 import {
   CHAIN_ID,
   PORT,
@@ -445,6 +445,8 @@ describe("EthereumProvider", function () {
         new Promise<void>((resolve) => {
           walletClient.on("session_proposal", async (proposal) => {
             expect(proposal.params.optionalNamespaces.eip155.methods).to.eql(OPTIONAL_METHODS);
+            expect(proposal.params.optionalNamespaces.eip155.events).to.eql(OPTIONAL_EVENTS);
+
             await walletClient.approve({
               id: proposal.id,
               namespaces: {

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -8,7 +8,13 @@ import {
   _abi,
   _bytecode,
 } from "ethereum-test-network/lib/utils/ERC20Token__factory";
-import { deleteProviders, disconnectSocket, testConnectMethod, WalletClient } from "./shared";
+import {
+  deleteProviders,
+  disconnectSocket,
+  testConnectMethod,
+  throttle,
+  WalletClient,
+} from "./shared";
 import UniversalProvider from "../src";
 import {
   CHAIN_ID,
@@ -72,7 +78,7 @@ describe("UniversalProvider", function () {
       }),
     ]);
     expect(walletClient.client?.session.values.length).to.eql(0);
-
+    await throttle(1_000);
     await provider.client.core.relayer.transportClose();
     await walletClient.client?.core.relayer.transportClose();
   });


### PR DESCRIPTION
## Description

- added `eth_sendTransaction` & `personal_sign` to the default list of optional methods because when only optionalChains are set, these methods are omitted from the proposal
- added `chainChanged` & `accountsChanged` to the default optional events list
- fixed a bug where default optional events weren't used due to incorrect check

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding, tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
