### PR TITLE
fix: default rpc provider url

### DIFF
--- a/providers/universal-provider/src/constants/values.ts
+++ b/providers/universal-provider/src/constants/values.ts
@@ -8,4 +8,4 @@ export const CONTEXT = "universal_provider";
 
 export const STORAGE = `${PROTOCOL}@${WC_VERSION}:${CONTEXT}:`;
 
-export const RPC_URL = "https://rpc.walletconnect.com/v1";
+export const RPC_URL = "https://rpc.walletconnect.com/v1/";

--- a/providers/universal-provider/src/providers/cardano.ts
+++ b/providers/universal-provider/src/providers/cardano.ts
@@ -55,16 +55,11 @@ class CardanoProvider implements IProvider {
   }
 
   public setDefaultChain(chainId: string, rpcUrl?: string | undefined) {
-    this.chainId = chainId;
     // http provider exists so just set the chainId
     if (!this.httpProviders[chainId]) {
-      const rpc = rpcUrl || this.getCardanoRPCUrl(chainId);
-      if (!rpc) {
-        throw new Error(`No RPC url provided for chainId: ${chainId}`);
-      }
-      this.setHttpProvider(chainId, rpc);
+      this.setHttpProvider(chainId, rpcUrl);
     }
-
+    this.chainId = chainId;
     this.events.emit(PROVIDER_EVENTS.DEFAULT_CHAIN_CHANGED, `${this.name}:${this.chainId}`);
   }
 
@@ -123,7 +118,9 @@ class CardanoProvider implements IProvider {
     rpcUrl?: string | undefined,
   ): JsonRpcProvider | undefined {
     const rpc = rpcUrl || this.getCardanoRPCUrl(chainId);
-    if (typeof rpc === "undefined") return undefined;
+    if (!rpc) {
+      throw new Error(`No RPC url provided for chainId: ${chainId}`);
+    }
     const http = new JsonRpcProvider(new HttpConnection(rpc, getGlobal("disableProviderPing")));
     return http;
   }

--- a/providers/universal-provider/src/providers/cardano.ts
+++ b/providers/universal-provider/src/providers/cardano.ts
@@ -11,7 +11,7 @@ import {
   SessionNamespace,
   SubProviderOpts,
 } from "../types";
-import { getGlobal } from "../utils";
+import { getChainId, getGlobal } from "../utils";
 
 class CardanoProvider implements IProvider {
   public name = "cip34";
@@ -86,7 +86,8 @@ class CardanoProvider implements IProvider {
     const http = {};
     this.namespace.chains.forEach((chain) => {
       const rpcURL = this.getCardanoRPCUrl(chain);
-      http[chain] = this.createHttpProvider(chain, rpcURL);
+      const parsedChain = getChainId(chain);
+      http[parsedChain] = this.createHttpProvider(parsedChain, rpcURL);
     });
     return http;
   }

--- a/providers/universal-provider/src/providers/cosmos.ts
+++ b/providers/universal-provider/src/providers/cosmos.ts
@@ -11,7 +11,7 @@ import {
   SessionNamespace,
   SubProviderOpts,
 } from "../types";
-import { getGlobal, getRpcUrl } from "../utils";
+import { getChainId, getGlobal, getRpcUrl } from "../utils";
 
 class CosmosProvider implements IProvider {
   public name = "cosmos";
@@ -86,7 +86,8 @@ class CosmosProvider implements IProvider {
   private createHttpProviders(): RpcProvidersMap {
     const http = {};
     this.namespace.chains.forEach((chain) => {
-      http[chain] = this.createHttpProvider(chain, this.namespace.rpcMap?.[chain]);
+      const parsedChainId = getChainId(chain);
+      http[parsedChainId] = this.createHttpProvider(parsedChainId, this.namespace.rpcMap?.[chain]);
     });
     return http;
   }

--- a/providers/universal-provider/src/providers/cosmos.ts
+++ b/providers/universal-provider/src/providers/cosmos.ts
@@ -56,17 +56,11 @@ class CosmosProvider implements IProvider {
   }
 
   public setDefaultChain(chainId: string, rpcUrl?: string | undefined) {
-    this.chainId = chainId;
     // http provider exists so just set the chainId
     if (!this.httpProviders[chainId]) {
-      const rpc =
-        rpcUrl || getRpcUrl(`${this.name}:${chainId}`, this.namespace, this.client.core.projectId);
-      if (!rpc) {
-        throw new Error(`No RPC url provided for chainId: ${chainId}`);
-      }
-      this.setHttpProvider(chainId, rpc);
+      this.setHttpProvider(chainId, rpcUrl);
     }
-
+    this.chainId = chainId;
     this.events.emit(PROVIDER_EVENTS.DEFAULT_CHAIN_CHANGED, `${this.name}:${this.chainId}`);
   }
 
@@ -118,7 +112,9 @@ class CosmosProvider implements IProvider {
     rpcUrl?: string | undefined,
   ): JsonRpcProvider | undefined {
     const rpc = rpcUrl || getRpcUrl(chainId, this.namespace, this.client.core.projectId);
-    if (typeof rpc === "undefined") return undefined;
+    if (!rpc) {
+      throw new Error(`No RPC url provided for chainId: ${chainId}`);
+    }
     const http = new JsonRpcProvider(new HttpConnection(rpc, getGlobal("disableProviderPing")));
     return http;
   }

--- a/providers/universal-provider/src/providers/eip155.ts
+++ b/providers/universal-provider/src/providers/eip155.ts
@@ -104,7 +104,7 @@ class Eip155Provider implements IProvider {
   private createHttpProviders(): RpcProvidersMap {
     const http = {};
     this.namespace.chains.forEach((chain) => {
-      const parsedChain = getChainId(chain);
+      const parsedChain = parseInt(getChainId(chain));
       http[parsedChain] = this.createHttpProvider(parsedChain, this.namespace.rpcMap?.[chain]);
     });
     return http;

--- a/providers/universal-provider/src/providers/eip155.ts
+++ b/providers/universal-provider/src/providers/eip155.ts
@@ -57,19 +57,12 @@ class Eip155Provider implements IProvider {
   }
 
   public setDefaultChain(chainId: string, rpcUrl?: string | undefined) {
-    const parsedChain = getChainId(chainId);
     // http provider exists so just set the chainId
-    if (!this.httpProviders[parsedChain]) {
-      const rpc =
-        rpcUrl ||
-        getRpcUrl(`${this.name}:${parsedChain}`, this.namespace, this.client.core.projectId);
-      if (!rpc) {
-        throw new Error(`No RPC url provided for chainId: ${parsedChain}`);
-      }
-      this.setHttpProvider(parsedChain, rpc);
+    if (!this.httpProviders[chainId]) {
+      this.setHttpProvider(parseInt(chainId), rpcUrl);
     }
-    this.chainId = parsedChain;
-    this.events.emit(PROVIDER_EVENTS.DEFAULT_CHAIN_CHANGED, `${this.name}:${parsedChain}`);
+    this.chainId = parseInt(chainId);
+    this.events.emit(PROVIDER_EVENTS.DEFAULT_CHAIN_CHANGED, `${this.name}:${chainId}`);
   }
 
   public requestAccounts(): string[] {
@@ -94,7 +87,9 @@ class Eip155Provider implements IProvider {
   ): JsonRpcProvider | undefined {
     const rpc =
       rpcUrl || getRpcUrl(`${this.name}:${chainId}`, this.namespace, this.client.core.projectId);
-    if (typeof rpc === "undefined") return undefined;
+    if (!rpc) {
+      throw new Error(`No RPC url provided for chainId: ${chainId}`);
+    }
     const http = new JsonRpcProvider(new HttpConnection(rpc, getGlobal("disableProviderPing")));
     return http;
   }

--- a/providers/universal-provider/src/providers/elrond.ts
+++ b/providers/universal-provider/src/providers/elrond.ts
@@ -11,7 +11,7 @@ import {
   SessionNamespace,
   SubProviderOpts,
 } from "../types";
-import { getGlobal, getRpcUrl } from "../utils";
+import { getChainId, getGlobal, getRpcUrl } from "../utils";
 
 // Old wallet connect provider for Elrond
 class ElrondProvider implements IProvider {
@@ -86,7 +86,8 @@ class ElrondProvider implements IProvider {
   private createHttpProviders(): RpcProvidersMap {
     const http = {};
     this.namespace.chains.forEach((chain) => {
-      http[chain] = this.createHttpProvider(chain, this.namespace.rpcMap?.[chain]);
+      const parsedChainId = getChainId(chain);
+      http[parsedChainId] = this.createHttpProvider(parsedChainId, this.namespace.rpcMap?.[chain]);
     });
     return http;
   }

--- a/providers/universal-provider/src/providers/elrond.ts
+++ b/providers/universal-provider/src/providers/elrond.ts
@@ -48,15 +48,10 @@ class ElrondProvider implements IProvider {
   public setDefaultChain(chainId: string, rpcUrl?: string | undefined) {
     // http provider exists so just set the chainId
     if (!this.httpProviders[chainId]) {
-      const rpc =
-        rpcUrl || getRpcUrl(`${this.name}:${chainId}`, this.namespace, this.client.core.projectId);
-      if (!rpc) {
-        throw new Error(`No RPC url provided for chainId: ${chainId}`);
-      }
-      this.setHttpProvider(chainId, rpc);
+      this.setHttpProvider(chainId, rpcUrl);
     }
     this.chainId = chainId;
-    this.events.emit(PROVIDER_EVENTS.DEFAULT_CHAIN_CHANGED, `${this.name}:${this.chainId}`);
+    this.events.emit(PROVIDER_EVENTS.DEFAULT_CHAIN_CHANGED, `${this.name}:${chainId}`);
   }
 
   public getDefaultChain(): string {
@@ -117,7 +112,9 @@ class ElrondProvider implements IProvider {
     rpcUrl?: string | undefined,
   ): JsonRpcProvider | undefined {
     const rpc = rpcUrl || getRpcUrl(chainId, this.namespace, this.client.core.projectId);
-    if (typeof rpc === "undefined") return undefined;
+    if (!rpc) {
+      throw new Error(`No RPC url provided for chainId: ${chainId}`);
+    }
     const http = new JsonRpcProvider(new HttpConnection(rpc, getGlobal("disableProviderPing")));
     return http;
   }

--- a/providers/universal-provider/src/providers/multiversx.ts
+++ b/providers/universal-provider/src/providers/multiversx.ts
@@ -47,15 +47,10 @@ class MultiversXProvider implements IProvider {
   public setDefaultChain(chainId: string, rpcUrl?: string | undefined) {
     // http provider exists so just set the chainId
     if (!this.httpProviders[chainId]) {
-      const rpc =
-        rpcUrl || getRpcUrl(`${this.name}:${chainId}`, this.namespace, this.client.core.projectId);
-      if (!rpc) {
-        throw new Error(`No RPC url provided for chainId: ${chainId}`);
-      }
-      this.setHttpProvider(chainId, rpc);
+      this.setHttpProvider(chainId, rpcUrl);
     }
     this.chainId = chainId;
-    this.events.emit(PROVIDER_EVENTS.DEFAULT_CHAIN_CHANGED, `${this.name}:${this.chainId}`);
+    this.events.emit(PROVIDER_EVENTS.DEFAULT_CHAIN_CHANGED, `${this.name}:${chainId}`);
   }
 
   public getDefaultChain(): string {
@@ -116,7 +111,9 @@ class MultiversXProvider implements IProvider {
     rpcUrl?: string | undefined,
   ): JsonRpcProvider | undefined {
     const rpc = rpcUrl || getRpcUrl(chainId, this.namespace, this.client.core.projectId);
-    if (typeof rpc === "undefined") return undefined;
+    if (!rpc) {
+      throw new Error(`No RPC url provided for chainId: ${chainId}`);
+    }
     const http = new JsonRpcProvider(new HttpConnection(rpc, getGlobal("disableProviderPing")));
     return http;
   }

--- a/providers/universal-provider/src/providers/multiversx.ts
+++ b/providers/universal-provider/src/providers/multiversx.ts
@@ -11,7 +11,7 @@ import {
   SessionNamespace,
   SubProviderOpts,
 } from "../types";
-import { getGlobal, getRpcUrl } from "../utils";
+import { getChainId, getGlobal, getRpcUrl } from "../utils";
 
 class MultiversXProvider implements IProvider {
   public name = "multiversx";
@@ -85,7 +85,8 @@ class MultiversXProvider implements IProvider {
   private createHttpProviders(): RpcProvidersMap {
     const http = {};
     this.namespace.chains.forEach((chain) => {
-      http[chain] = this.createHttpProvider(chain, this.namespace.rpcMap?.[chain]);
+      const parsedChainId = getChainId(chain);
+      http[parsedChainId] = this.createHttpProvider(parsedChainId, this.namespace.rpcMap?.[chain]);
     });
     return http;
   }

--- a/providers/universal-provider/src/providers/polkadot.ts
+++ b/providers/universal-provider/src/providers/polkadot.ts
@@ -57,17 +57,12 @@ class PolkadotProvider implements IProvider {
   }
 
   public setDefaultChain(chainId: string, rpcUrl?: string | undefined) {
-    this.chainId = chainId;
     // http provider exists so just set the chainId
     if (!this.httpProviders[chainId]) {
-      const rpc = rpcUrl || getRpcUrl(`${this.name}:${chainId}`, this.namespace);
-      if (!rpc) {
-        throw new Error(`No RPC url provided for chainId: ${chainId}`);
-      }
-      this.setHttpProvider(chainId, rpc);
+      this.setHttpProvider(chainId, rpcUrl);
     }
-
-    this.events.emit(PROVIDER_EVENTS.DEFAULT_CHAIN_CHANGED, `${this.name}:${this.chainId}`);
+    this.chainId = chainId;
+    this.events.emit(PROVIDER_EVENTS.DEFAULT_CHAIN_CHANGED, `${this.name}:${chainId}`);
   }
 
   // ---------------- PRIVATE ---------------- //
@@ -115,8 +110,10 @@ class PolkadotProvider implements IProvider {
     chainId: string,
     rpcUrl?: string | undefined,
   ): JsonRpcProvider | undefined {
-    const rpc = rpcUrl || getRpcUrl(chainId, this.namespace);
-    if (typeof rpc === "undefined") return undefined;
+    const rpc = rpcUrl || getRpcUrl(chainId, this.namespace, this.client.core.projectId);
+    if (!rpc) {
+      throw new Error(`No RPC url provided for chainId: ${chainId}`);
+    }
     const http = new JsonRpcProvider(new HttpConnection(rpc, getGlobal("disableProviderPing")));
     return http;
   }

--- a/providers/universal-provider/src/providers/polkadot.ts
+++ b/providers/universal-provider/src/providers/polkadot.ts
@@ -12,7 +12,7 @@ import {
   SubProviderOpts,
 } from "../types";
 
-import { getGlobal, getRpcUrl } from "../utils";
+import { getChainId, getGlobal, getRpcUrl } from "../utils";
 
 class PolkadotProvider implements IProvider {
   public name = "polkadot";
@@ -85,7 +85,8 @@ class PolkadotProvider implements IProvider {
   private createHttpProviders(): RpcProvidersMap {
     const http = {};
     this.namespace.chains.forEach((chain) => {
-      http[chain] = this.createHttpProvider(chain, this.namespace.rpcMap?.[chain]);
+      const parsedChainId = getChainId(chain);
+      http[parsedChainId] = this.createHttpProvider(parsedChainId, this.namespace.rpcMap?.[chain]);
     });
     return http;
   }

--- a/providers/universal-provider/src/providers/solana.ts
+++ b/providers/universal-provider/src/providers/solana.ts
@@ -111,8 +111,6 @@ class SolanaProvider implements IProvider {
     chainId: string,
     rpcUrl?: string | undefined,
   ): JsonRpcProvider | undefined {
-    console.log("createHttpProvider", chainId, rpcUrl);
-
     const rpc = rpcUrl || getRpcUrl(chainId, this.namespace, this.client.core.projectId);
     if (!rpc) {
       throw new Error(`No RPC url provided for chainId: ${chainId}`);

--- a/providers/universal-provider/src/providers/solana.ts
+++ b/providers/universal-provider/src/providers/solana.ts
@@ -11,7 +11,7 @@ import {
   SessionNamespace,
   SubProviderOpts,
 } from "../types";
-import { getGlobal, getRpcUrl } from "../utils";
+import { getChainId, getGlobal, getRpcUrl } from "../utils";
 
 class SolanaProvider implements IProvider {
   public name = "solana";
@@ -85,7 +85,8 @@ class SolanaProvider implements IProvider {
   private createHttpProviders(): RpcProvidersMap {
     const http = {};
     this.namespace.chains.forEach((chain) => {
-      http[chain] = this.createHttpProvider(chain, this.namespace.rpcMap?.[chain]);
+      const parsedChainId = getChainId(chain);
+      http[parsedChainId] = this.createHttpProvider(parsedChainId, this.namespace.rpcMap?.[chain]);
     });
     return http;
   }
@@ -110,6 +111,8 @@ class SolanaProvider implements IProvider {
     chainId: string,
     rpcUrl?: string | undefined,
   ): JsonRpcProvider | undefined {
+    console.log("createHttpProvider", chainId, rpcUrl);
+
     const rpc = rpcUrl || getRpcUrl(chainId, this.namespace, this.client.core.projectId);
     if (!rpc) {
       throw new Error(`No RPC url provided for chainId: ${chainId}`);

--- a/providers/universal-provider/src/providers/solana.ts
+++ b/providers/universal-provider/src/providers/solana.ts
@@ -47,15 +47,10 @@ class SolanaProvider implements IProvider {
   public setDefaultChain(chainId: string, rpcUrl?: string | undefined) {
     // http provider exists so just set the chainId
     if (!this.httpProviders[chainId]) {
-      const rpc =
-        rpcUrl || getRpcUrl(`${this.name}:${chainId}`, this.namespace, this.client.core.projectId);
-      if (!rpc) {
-        throw new Error(`No RPC url provided for chainId: ${chainId}`);
-      }
-      this.setHttpProvider(chainId, rpc);
+      this.setHttpProvider(chainId, rpcUrl);
     }
     this.chainId = chainId;
-    this.events.emit(PROVIDER_EVENTS.DEFAULT_CHAIN_CHANGED, `${this.name}:${this.chainId}`);
+    this.events.emit(PROVIDER_EVENTS.DEFAULT_CHAIN_CHANGED, `${this.name}:${chainId}`);
   }
 
   public getDefaultChain(): string {
@@ -116,7 +111,9 @@ class SolanaProvider implements IProvider {
     rpcUrl?: string | undefined,
   ): JsonRpcProvider | undefined {
     const rpc = rpcUrl || getRpcUrl(chainId, this.namespace, this.client.core.projectId);
-    if (typeof rpc === "undefined") return undefined;
+    if (!rpc) {
+      throw new Error(`No RPC url provided for chainId: ${chainId}`);
+    }
     const http = new JsonRpcProvider(new HttpConnection(rpc, getGlobal("disableProviderPing")));
     return http;
   }

--- a/providers/universal-provider/src/utils/misc.ts
+++ b/providers/universal-provider/src/utils/misc.ts
@@ -3,6 +3,7 @@ import {
   isCaipNamespace,
   isValidObject,
   mergeArrays,
+  parseChainId,
   parseNamespaceKey,
 } from "@walletconnect/utils";
 import { RPC_URL } from "../constants";
@@ -10,16 +11,11 @@ import { Namespace, NamespaceConfig } from "../types";
 import { merge } from "lodash";
 
 export function getRpcUrl(chainId: string, rpc: Namespace, projectId?: string): string | undefined {
-  let rpcUrl: string | undefined;
-  const parsedChainId = getChainId(chainId);
-  if (rpc.rpcMap) {
-    rpcUrl = rpc.rpcMap[parsedChainId];
-  }
-
-  if (!rpcUrl) {
-    rpcUrl = `${RPC_URL}?chainId=eip155:${parsedChainId}&projectId=${projectId}`;
-  }
-  return rpcUrl;
+  const chain = parseChainId(chainId);
+  return (
+    rpc.rpcMap?.[chain.reference] ||
+    `${RPC_URL}?chainId=${chain.namespace}:${chain.reference}&projectId=${projectId}`
+  );
 }
 
 export function getChainId(chain: string): number {

--- a/providers/universal-provider/src/utils/misc.ts
+++ b/providers/universal-provider/src/utils/misc.ts
@@ -18,8 +18,8 @@ export function getRpcUrl(chainId: string, rpc: Namespace, projectId?: string): 
   );
 }
 
-export function getChainId(chain: string): number {
-  return chain.includes("eip155") ? Number(chain.split(":")[1]) : Number(chain);
+export function getChainId(chain: string): string {
+  return chain.includes(":") ? chain.split(":")[1] : chain;
 }
 
 export function validateChainApproval(chain: string, chains: string[]): void {


### PR DESCRIPTION
## Description
- resolved an issue where the default rpc url was failing on non-eip155 namespaces
- standardized creation of HTTP providers across sub-providers to remove redundant checks & out of place code snipets

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding
tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
