### PR TITLE
Feat/pairing idempotency

### DIFF
--- a/packages/core/src/constants/pairing.ts
+++ b/packages/core/src/constants/pairing.ts
@@ -51,3 +51,10 @@ export const PAIRING_RPC_OPTS: Record<
     },
   },
 };
+
+export const PAIRING_EVENTS = {
+  create: "pairing_create",
+  expire: "pairing_expire",
+  delete: "pairing_delete",
+  ping: "pairing_ping",
+};

--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -116,7 +116,7 @@ export class Pairing implements IPairing {
       existingPairing = this.pairings.get(topic);
       if (existingPairing.active) {
         throw new Error(
-          `Pairing already exists: ${topic}. Please try again with new connection URI.`,
+          `Pairing already exists: ${topic}. Please try again with a new connection URI.`,
         );
       }
     }

--- a/packages/core/test/pairing.spec.ts
+++ b/packages/core/test/pairing.spec.ts
@@ -64,19 +64,20 @@ describe("Pairing", () => {
 
     it("throws when pairing is attempted on topic that already exists", async () => {
       const { topic, uri } = await coreA.pairing.create();
+      coreA.pairing.pairings.get(topic).active = true;
       await expect(coreA.pairing.pair({ uri })).rejects.toThrowError(
         `Pairing already exists: ${topic}`,
       );
     });
 
-    it("throws when keychain already exists", async () => {
-      const maliciousTopic = generateRandomBytes32();
+    it("should not override existing keychain values", async () => {
+      const keychainTopic = generateRandomBytes32();
+      const keychainValue = generateRandomBytes32();
       let { topic, uri } = await coreA.pairing.create();
-      coreA.crypto.keychain.set(maliciousTopic, maliciousTopic);
-      uri = uri.replace(topic, maliciousTopic);
-      await expect(coreA.pairing.pair({ uri })).rejects.toThrowError(
-        `Keychain already exists: ${maliciousTopic}`,
-      );
+      coreA.crypto.keychain.set(keychainTopic, keychainValue);
+      uri = uri.replace(topic, keychainTopic);
+      await coreA.pairing.pair({ uri });
+      expect(coreA.crypto.keychain.get(keychainTopic)).toBe(keychainValue);
     });
   });
 


### PR DESCRIPTION
## Description
Implemented pairing handling that allows URI/QR to be scanned multiple times as long as the proposal has not been responded to. This allows apps to re-scan & continue with pairing flow even in cases of accidental app/modal closing without the need to create brand new pairing and restart the whole process

- Added new event when pairing is created
- Pairing API throws only when pairing exists & is active
- Sign client subscribes to `PAIRING_EVENTS.create` &  emit pending proposal for that pairing if available


## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding
tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
