### PR TITLE
fix: `rejectZero` flag on key derivation

### DIFF
--- a/packages/utils/src/crypto.ts
+++ b/packages/utils/src/crypto.ts
@@ -36,6 +36,7 @@ export function deriveSymKey(privateKeyA: string, publicKeyB: string): string {
   const sharedKey = x25519.sharedKey(
     fromString(privateKeyA, BASE16),
     fromString(publicKeyB, BASE16),
+    true,
   );
   const hkdf = new HKDF(SHA256, sharedKey);
   const symKey = hkdf.expand(KEY_LENGTH);


### PR DESCRIPTION
## Description
Set `rejectZero` flag to `true` to avoid cases where keys could result in all zero derived key

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
