### PR TITLE
fix: `relayer.subscribe` concurrency

### DIFF
--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -14,7 +14,7 @@ import {
   SUBSCRIBER_EVENTS,
 } from "../src";
 import { disconnectSocket, TEST_CORE_OPTIONS, throttle } from "./shared";
-import { ICore, IRelayer } from "@walletconnect/types";
+import { ICore, IRelayer, ISubscriber } from "@walletconnect/types";
 import Sinon from "sinon";
 import { JsonRpcRequest } from "@walletconnect/jsonrpc-utils";
 import { generateRandomBytes32, hashMessage } from "@walletconnect/utils";
@@ -145,6 +145,22 @@ describe("Relayer", () => {
       // @ts-expect-error
       expect(spy.calledOnceWith("abc123")).to.be.true;
       expect(id).to.eq("mock-id");
+    });
+
+    it("should subscribe multiple topics", async () => {
+      const spy = Sinon.spy(() => "mock-id");
+      relayer.subscriber.subscribe = spy;
+      const subscriber = relayer.subscriber as ISubscriber;
+      // record the number of listeners before subscribing
+      const startNumListeners = subscriber.events.listenerCount(SUBSCRIBER_EVENTS.created);
+      const topicsToSubscribe = Array.from(Array(5).keys()).map(() => generateRandomBytes32());
+      const subscribePromises = topicsToSubscribe.map((topic) => relayer.subscribe(topic));
+      const onSubscriptionCreatedPromises = topicsToSubscribe.map((topic) =>
+        relayer.subscriber.events.emit(SUBSCRIBER_EVENTS.created, { topic }),
+      );
+      await Promise.all([...subscribePromises, ...onSubscriptionCreatedPromises]);
+      // expect the number of listeners to be the same as before subscribing to confirm proper cleanup
+      expect(subscriber.events.listenerCount(SUBSCRIBER_EVENTS.created)).to.eq(startNumListeners);
     });
 
     it("should be able to resubscribe on topic that already exists", async () => {


### PR DESCRIPTION
## Description
Fixed a bug where `relayer.subscribe` would hang when concurrently called

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
unit tests 

## Fixes/Resolves (Optional)
https://github.com/WalletConnect/walletconnect-monorepo/issues/3693

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
