### PR TITLE
fix/strip native schemas from uri

### DIFF
--- a/packages/core/test/pairing.spec.ts
+++ b/packages/core/test/pairing.spec.ts
@@ -54,6 +54,28 @@ describe("Pairing", () => {
       expect(coreB.pairing.getPairings()[0].active).toBe(false);
     });
 
+    it("can pair via provided android deeplink URI", async () => {
+      const { uri } = await coreA.pairing.create();
+      await coreB.pairing.pair({ uri: `wc://${uri}` });
+
+      expect(coreA.pairing.pairings.keys.length).toBe(1);
+      expect(coreB.pairing.pairings.keys.length).toBe(1);
+      expect(coreA.pairing.pairings.keys).to.deep.equal(coreB.pairing.pairings.keys);
+      expect(coreA.pairing.getPairings()[0].active).toBe(false);
+      expect(coreB.pairing.getPairings()[0].active).toBe(false);
+    });
+
+    it("can pair via provided iOS deeplink URI", async () => {
+      const { uri } = await coreA.pairing.create();
+      await coreB.pairing.pair({ uri: `wc:${uri}` });
+
+      expect(coreA.pairing.pairings.keys.length).toBe(1);
+      expect(coreB.pairing.pairings.keys.length).toBe(1);
+      expect(coreA.pairing.pairings.keys).to.deep.equal(coreB.pairing.pairings.keys);
+      expect(coreA.pairing.getPairings()[0].active).toBe(false);
+      expect(coreB.pairing.getPairings()[0].active).toBe(false);
+    });
+
     it("can auto-activate the pairing on pair step", async () => {
       const { uri } = await coreA.pairing.create();
       await coreB.pairing.pair({ uri, activatePairing: true });

--- a/packages/utils/src/uri.ts
+++ b/packages/utils/src/uri.ts
@@ -17,6 +17,10 @@ export function parseRelayParams(params: any, delimiter = "-"): RelayerTypes.Pro
 }
 
 export function parseUri(str: string): EngineTypes.UriParameters {
+  // remove android schema prefix
+  str = str.includes("wc://") ? str.replace("wc://", "") : str;
+  // remove ios schema prefix
+  str = str.includes("wc:") ? str.replace("wc:", "") : str;
   const pathStart: number = str.indexOf(":");
   const pathEnd: number | undefined = str.indexOf("?") !== -1 ? str.indexOf("?") : undefined;
   const protocol: string = str.substring(0, pathStart);


### PR DESCRIPTION
## Description
QoL update to improve devex by handling URIs with native schemas (`wc://` & `wc:`) instead of relying on devs to handle them before pairing.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests


## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules