### PR TITLE
feat(experimental): use shared core reference via globals

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/*",
     "providers/*"
   ],
-  "version": "2.10.4"
+  "version": "2.10.4-184f2234"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6283,6 +6283,40 @@
         "node": ">=16"
       }
     },
+    "node_modules/@walletconnect/auth-client/node_modules/@walletconnect/types": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.10.4.tgz",
+      "integrity": "sha512-eQpOElyiwJp3tepuOS3TS9dXTl9jVVlrC3iVA8bytnbLagkAUxmiv/s7PyDFx+ndXwQVh8PFBkWg1oxGwgCSBA==",
+      "dependencies": {
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/heartbeat": "1.2.1",
+        "@walletconnect/jsonrpc-types": "1.0.3",
+        "@walletconnect/keyvaluestorage": "^1.0.2",
+        "@walletconnect/logger": "^2.0.1",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/auth-client/node_modules/@walletconnect/utils": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.10.4.tgz",
+      "integrity": "sha512-XbrKgnQ0hC9DC9wjFb468MEYMoJxnCVmOj2gi01DA4FSr8fJi7wwNRUnlnZzLWrUWrHuaPReYe4PgBAgIv363g==",
+      "dependencies": {
+        "@stablelib/chacha20poly1305": "1.0.1",
+        "@stablelib/hkdf": "1.0.1",
+        "@stablelib/random": "^1.0.2",
+        "@stablelib/sha256": "1.0.1",
+        "@stablelib/x25519": "^1.0.3",
+        "@walletconnect/relay-api": "^1.0.9",
+        "@walletconnect/safe-json": "^1.0.2",
+        "@walletconnect/time": "^1.0.2",
+        "@walletconnect/types": "2.10.4",
+        "@walletconnect/window-getters": "^1.0.1",
+        "@walletconnect/window-metadata": "^1.0.1",
+        "detect-browser": "5.3.0",
+        "query-string": "7.1.3",
+        "uint8arrays": "^3.1.0"
+      }
+    },
     "node_modules/@walletconnect/core": {
       "resolved": "packages/core",
       "link": true
@@ -25643,7 +25677,7 @@
     },
     "packages/core": {
       "name": "@walletconnect/core",
-      "version": "2.10.4",
+      "version": "2.10.4-184f2234",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
@@ -25657,8 +25691,8 @@
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/types": "2.10.4-184f2234",
+        "@walletconnect/utils": "2.10.4-184f2234",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "^3.1.0"
@@ -25687,7 +25721,7 @@
     },
     "packages/react-native-compat": {
       "name": "@walletconnect/react-native-compat",
-      "version": "2.10.4",
+      "version": "2.10.4-184f2234",
       "license": "Apache-2.0",
       "dependencies": {
         "events": "3.3.0",
@@ -25702,17 +25736,17 @@
     },
     "packages/sign-client": {
       "name": "@walletconnect/sign-client",
-      "version": "2.10.4",
+      "version": "2.10.4-184f2234",
       "license": "Apache-2.0",
       "dependencies": {
-        "@walletconnect/core": "2.10.4",
+        "@walletconnect/core": "2.10.4-184f2234",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/types": "2.10.4-184f2234",
+        "@walletconnect/utils": "2.10.4-184f2234",
         "events": "^3.3.0"
       },
       "devDependencies": {
@@ -25725,7 +25759,7 @@
     },
     "packages/types": {
       "name": "@walletconnect/types",
-      "version": "2.10.4",
+      "version": "2.10.4-184f2234",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
@@ -25738,7 +25772,7 @@
     },
     "packages/utils": {
       "name": "@walletconnect/utils",
-      "version": "2.10.4",
+      "version": "2.10.4-184f2234",
       "license": "Apache-2.0",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
@@ -25749,7 +25783,7 @@
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.4",
+        "@walletconnect/types": "2.10.4-184f2234",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -25779,19 +25813,92 @@
         "lokijs": "^1.5.12"
       }
     },
+    "packages/web3wallet/node_modules/@walletconnect/core": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.10.4.tgz",
+      "integrity": "sha512-MGdw5a4dIlQFPxVHEw2neIpHPAw3gtrsJYyUqm6rI+1c1SfmZyOPCaYTr6zPU2cnoWQUjv2ePMLeO/JKy3Yh5g==",
+      "dependencies": {
+        "@walletconnect/heartbeat": "1.2.1",
+        "@walletconnect/jsonrpc-provider": "1.0.13",
+        "@walletconnect/jsonrpc-types": "1.0.3",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.13",
+        "@walletconnect/keyvaluestorage": "^1.0.2",
+        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/relay-api": "^1.0.9",
+        "@walletconnect/relay-auth": "^1.0.4",
+        "@walletconnect/safe-json": "^1.0.2",
+        "@walletconnect/time": "^1.0.2",
+        "@walletconnect/types": "2.10.4",
+        "@walletconnect/utils": "2.10.4",
+        "events": "^3.3.0",
+        "lodash.isequal": "4.5.0",
+        "uint8arrays": "^3.1.0"
+      }
+    },
+    "packages/web3wallet/node_modules/@walletconnect/sign-client": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.10.4.tgz",
+      "integrity": "sha512-C5VHkK59/DQNrJS91UXLn5OSr0drXHkKjajhl2a9hb3h6kxuSdlWbyC0yRPKT1sD0fQho8+EWZHBiV063yBePw==",
+      "dependencies": {
+        "@walletconnect/core": "2.10.4",
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/heartbeat": "1.2.1",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "@walletconnect/types": "2.10.4",
+        "@walletconnect/utils": "2.10.4",
+        "events": "^3.3.0"
+      }
+    },
+    "packages/web3wallet/node_modules/@walletconnect/types": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.10.4.tgz",
+      "integrity": "sha512-eQpOElyiwJp3tepuOS3TS9dXTl9jVVlrC3iVA8bytnbLagkAUxmiv/s7PyDFx+ndXwQVh8PFBkWg1oxGwgCSBA==",
+      "dependencies": {
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/heartbeat": "1.2.1",
+        "@walletconnect/jsonrpc-types": "1.0.3",
+        "@walletconnect/keyvaluestorage": "^1.0.2",
+        "@walletconnect/logger": "^2.0.1",
+        "events": "^3.3.0"
+      }
+    },
+    "packages/web3wallet/node_modules/@walletconnect/utils": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.10.4.tgz",
+      "integrity": "sha512-XbrKgnQ0hC9DC9wjFb468MEYMoJxnCVmOj2gi01DA4FSr8fJi7wwNRUnlnZzLWrUWrHuaPReYe4PgBAgIv363g==",
+      "dependencies": {
+        "@stablelib/chacha20poly1305": "1.0.1",
+        "@stablelib/hkdf": "1.0.1",
+        "@stablelib/random": "^1.0.2",
+        "@stablelib/sha256": "1.0.1",
+        "@stablelib/x25519": "^1.0.3",
+        "@walletconnect/relay-api": "^1.0.9",
+        "@walletconnect/safe-json": "^1.0.2",
+        "@walletconnect/time": "^1.0.2",
+        "@walletconnect/types": "2.10.4",
+        "@walletconnect/window-getters": "^1.0.1",
+        "@walletconnect/window-metadata": "^1.0.1",
+        "detect-browser": "5.3.0",
+        "query-string": "7.1.3",
+        "uint8arrays": "^3.1.0"
+      }
+    },
     "providers/ethereum-provider": {
       "name": "@walletconnect/ethereum-provider",
-      "version": "2.10.4",
+      "version": "2.10.4-184f2234",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
         "@walletconnect/jsonrpc-provider": "^1.0.13",
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
-        "@walletconnect/sign-client": "2.10.4",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/universal-provider": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/sign-client": "2.10.4-184f2234",
+        "@walletconnect/types": "2.10.4-184f2234",
+        "@walletconnect/universal-provider": "2.10.4-184f2234",
+        "@walletconnect/utils": "2.10.4-184f2234",
         "events": "^3.3.0"
       },
       "devDependencies": {
@@ -25812,21 +25919,21 @@
     },
     "providers/signer-connection": {
       "name": "@walletconnect/signer-connection",
-      "version": "2.10.4",
+      "version": "2.10.4-184f2234",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
-        "@walletconnect/sign-client": "2.10.4",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/sign-client": "2.10.4-184f2234",
+        "@walletconnect/types": "2.10.4-184f2234",
+        "@walletconnect/utils": "2.10.4-184f2234",
         "events": "^3.3.0",
         "uint8arrays": "^3.1.0"
       }
     },
     "providers/universal-provider": {
       "name": "@walletconnect/universal-provider",
-      "version": "2.10.4",
+      "version": "2.10.4-184f2234",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
@@ -25834,9 +25941,9 @@
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sign-client": "2.10.4",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/sign-client": "2.10.4-184f2234",
+        "@walletconnect/types": "2.10.4-184f2234",
+        "@walletconnect/utils": "2.10.4-184f2234",
         "events": "^3.3.0"
       },
       "devDependencies": {
@@ -30581,6 +30688,42 @@
         "@walletconnect/utils": "^2.10.1",
         "events": "^3.3.0",
         "isomorphic-unfetch": "^3.1.0"
+      },
+      "dependencies": {
+        "@walletconnect/types": {
+          "version": "2.10.4",
+          "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.10.4.tgz",
+          "integrity": "sha512-eQpOElyiwJp3tepuOS3TS9dXTl9jVVlrC3iVA8bytnbLagkAUxmiv/s7PyDFx+ndXwQVh8PFBkWg1oxGwgCSBA==",
+          "requires": {
+            "@walletconnect/events": "^1.0.1",
+            "@walletconnect/heartbeat": "1.2.1",
+            "@walletconnect/jsonrpc-types": "1.0.3",
+            "@walletconnect/keyvaluestorage": "^1.0.2",
+            "@walletconnect/logger": "^2.0.1",
+            "events": "^3.3.0"
+          }
+        },
+        "@walletconnect/utils": {
+          "version": "2.10.4",
+          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.10.4.tgz",
+          "integrity": "sha512-XbrKgnQ0hC9DC9wjFb468MEYMoJxnCVmOj2gi01DA4FSr8fJi7wwNRUnlnZzLWrUWrHuaPReYe4PgBAgIv363g==",
+          "requires": {
+            "@stablelib/chacha20poly1305": "1.0.1",
+            "@stablelib/hkdf": "1.0.1",
+            "@stablelib/random": "^1.0.2",
+            "@stablelib/sha256": "1.0.1",
+            "@stablelib/x25519": "^1.0.3",
+            "@walletconnect/relay-api": "^1.0.9",
+            "@walletconnect/safe-json": "^1.0.2",
+            "@walletconnect/time": "^1.0.2",
+            "@walletconnect/types": "2.10.4",
+            "@walletconnect/window-getters": "^1.0.1",
+            "@walletconnect/window-metadata": "^1.0.1",
+            "detect-browser": "5.3.0",
+            "query-string": "7.1.3",
+            "uint8arrays": "^3.1.0"
+          }
+        }
       }
     },
     "@walletconnect/core": {
@@ -30598,8 +30741,8 @@
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/types": "2.10.4-184f2234",
+        "@walletconnect/utils": "2.10.4-184f2234",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "node-fetch": "^3.3.0",
@@ -30636,10 +30779,10 @@
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/modal": "^2.4.3",
-        "@walletconnect/sign-client": "2.10.4",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/universal-provider": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/sign-client": "2.10.4-184f2234",
+        "@walletconnect/types": "2.10.4-184f2234",
+        "@walletconnect/universal-provider": "2.10.4-184f2234",
+        "@walletconnect/utils": "2.10.4-184f2234",
         "ethereum-test-network": "0.1.6",
         "ethers": "5.6.9",
         "events": "^3.3.0",
@@ -30886,7 +31029,7 @@
     "@walletconnect/sign-client": {
       "version": "file:packages/sign-client",
       "requires": {
-        "@walletconnect/core": "2.10.4",
+        "@walletconnect/core": "2.10.4-184f2234",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "^1.0.13",
@@ -30895,8 +31038,8 @@
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/types": "2.10.4-184f2234",
+        "@walletconnect/utils": "2.10.4-184f2234",
         "aws-sdk": "2.1194.0",
         "events": "^3.3.0",
         "lokijs": "^1.5.12"
@@ -30907,9 +31050,9 @@
       "requires": {
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
-        "@walletconnect/sign-client": "2.10.4",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/sign-client": "2.10.4-184f2234",
+        "@walletconnect/types": "2.10.4-184f2234",
+        "@walletconnect/utils": "2.10.4-184f2234",
         "events": "^3.3.0",
         "uint8arrays": "^3.1.0"
       }
@@ -30944,9 +31087,9 @@
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sign-client": "2.10.4",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/sign-client": "2.10.4-184f2234",
+        "@walletconnect/types": "2.10.4-184f2234",
+        "@walletconnect/utils": "2.10.4-184f2234",
         "cosmos-wallet": "^1.2.0",
         "ethereum-test-network": "0.1.6",
         "ethers": "5.7.0",
@@ -31126,7 +31269,7 @@
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.4",
+        "@walletconnect/types": "2.10.4-184f2234",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -31147,6 +31290,81 @@
         "@walletconnect/types": "2.10.4",
         "@walletconnect/utils": "2.10.4",
         "lokijs": "^1.5.12"
+      },
+      "dependencies": {
+        "@walletconnect/core": {
+          "version": "2.10.4",
+          "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.10.4.tgz",
+          "integrity": "sha512-MGdw5a4dIlQFPxVHEw2neIpHPAw3gtrsJYyUqm6rI+1c1SfmZyOPCaYTr6zPU2cnoWQUjv2ePMLeO/JKy3Yh5g==",
+          "requires": {
+            "@walletconnect/heartbeat": "1.2.1",
+            "@walletconnect/jsonrpc-provider": "1.0.13",
+            "@walletconnect/jsonrpc-types": "1.0.3",
+            "@walletconnect/jsonrpc-utils": "1.0.8",
+            "@walletconnect/jsonrpc-ws-connection": "1.0.13",
+            "@walletconnect/keyvaluestorage": "^1.0.2",
+            "@walletconnect/logger": "^2.0.1",
+            "@walletconnect/relay-api": "^1.0.9",
+            "@walletconnect/relay-auth": "^1.0.4",
+            "@walletconnect/safe-json": "^1.0.2",
+            "@walletconnect/time": "^1.0.2",
+            "@walletconnect/types": "2.10.4",
+            "@walletconnect/utils": "2.10.4",
+            "events": "^3.3.0",
+            "lodash.isequal": "4.5.0",
+            "uint8arrays": "^3.1.0"
+          }
+        },
+        "@walletconnect/sign-client": {
+          "version": "2.10.4",
+          "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.10.4.tgz",
+          "integrity": "sha512-C5VHkK59/DQNrJS91UXLn5OSr0drXHkKjajhl2a9hb3h6kxuSdlWbyC0yRPKT1sD0fQho8+EWZHBiV063yBePw==",
+          "requires": {
+            "@walletconnect/core": "2.10.4",
+            "@walletconnect/events": "^1.0.1",
+            "@walletconnect/heartbeat": "1.2.1",
+            "@walletconnect/jsonrpc-utils": "1.0.8",
+            "@walletconnect/logger": "^2.0.1",
+            "@walletconnect/time": "^1.0.2",
+            "@walletconnect/types": "2.10.4",
+            "@walletconnect/utils": "2.10.4",
+            "events": "^3.3.0"
+          }
+        },
+        "@walletconnect/types": {
+          "version": "2.10.4",
+          "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.10.4.tgz",
+          "integrity": "sha512-eQpOElyiwJp3tepuOS3TS9dXTl9jVVlrC3iVA8bytnbLagkAUxmiv/s7PyDFx+ndXwQVh8PFBkWg1oxGwgCSBA==",
+          "requires": {
+            "@walletconnect/events": "^1.0.1",
+            "@walletconnect/heartbeat": "1.2.1",
+            "@walletconnect/jsonrpc-types": "1.0.3",
+            "@walletconnect/keyvaluestorage": "^1.0.2",
+            "@walletconnect/logger": "^2.0.1",
+            "events": "^3.3.0"
+          }
+        },
+        "@walletconnect/utils": {
+          "version": "2.10.4",
+          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.10.4.tgz",
+          "integrity": "sha512-XbrKgnQ0hC9DC9wjFb468MEYMoJxnCVmOj2gi01DA4FSr8fJi7wwNRUnlnZzLWrUWrHuaPReYe4PgBAgIv363g==",
+          "requires": {
+            "@stablelib/chacha20poly1305": "1.0.1",
+            "@stablelib/hkdf": "1.0.1",
+            "@stablelib/random": "^1.0.2",
+            "@stablelib/sha256": "1.0.1",
+            "@stablelib/x25519": "^1.0.3",
+            "@walletconnect/relay-api": "^1.0.9",
+            "@walletconnect/safe-json": "^1.0.2",
+            "@walletconnect/time": "^1.0.2",
+            "@walletconnect/types": "2.10.4",
+            "@walletconnect/window-getters": "^1.0.1",
+            "@walletconnect/window-metadata": "^1.0.1",
+            "detect-browser": "5.3.0",
+            "query-string": "7.1.3",
+            "uint8arrays": "^3.1.0"
+          }
+        }
       }
     },
     "@walletconnect/window-getters": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "npm-publish:rc": "lerna exec --no-private -- npm publish --access public --tag rc",
     "npm-publish:latest": "lerna exec --no-private -- npm publish --access public --tag latest",
     "npm-publish:next": "lerna exec --no-private -- npm publish --access public --tag next",
-    "npm-publish:canary": "lerna exec --no-private -- npm publish --access public --tag canary"
+    "npm-publish:canary": "lerna exec --no-private -- npm publish --access public --tag canary",
+    "npm-publish:experimental": "lerna exec --no-private -- npm publish --access public --tag experimental"
   },
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/core",
   "description": "Core for WalletConnect Protocol",
-  "version": "2.10.4",
+  "version": "2.10.4-184f2234",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -42,8 +42,8 @@
     "@walletconnect/relay-auth": "^1.0.4",
     "@walletconnect/safe-json": "^1.0.2",
     "@walletconnect/time": "^1.0.2",
-    "@walletconnect/types": "2.10.4",
-    "@walletconnect/utils": "2.10.4",
+    "@walletconnect/types": "2.10.4-184f2234",
+    "@walletconnect/utils": "2.10.4-184f2234",
     "events": "^3.3.0",
     "lodash.isequal": "4.5.0",
     "uint8arrays": "^3.1.0"

--- a/packages/core/src/constants/relayer.ts
+++ b/packages/core/src/constants/relayer.ts
@@ -37,7 +37,7 @@ export const RELAYER_STORAGE_OPTIONS = {
 
 // Updated automatically via `new-version` npm script.
 
-export const RELAYER_SDK_VERSION = "2.10.4";
+export const RELAYER_SDK_VERSION = "2.10.4-184f2234";
 
 // delay to wait before closing the transport connection after init if not active
 export const RELAYER_TRANSPORT_CUTOFF = 10_000;

--- a/packages/core/test/expirer.spec.ts
+++ b/packages/core/test/expirer.spec.ts
@@ -19,6 +19,8 @@ describe("Expirer", () => {
 
   describe("storageKey", () => {
     it("provides the expected default `storageKey` format", () => {
+      // @ts-ignore
+      global.__walletconnect_core__ = undefined;
       const core = new Core(TEST_CORE_OPTIONS);
       const expirer = new Expirer(core, logger);
       expect(expirer.storageKey).to.equal(
@@ -26,6 +28,8 @@ describe("Expirer", () => {
       );
     });
     it("provides the expected custom `storageKey` format", () => {
+      // @ts-ignore
+      global.__walletconnect_core__ = undefined;
       const core = new Core({ ...TEST_CORE_OPTIONS, customStoragePrefix: "test" });
       const expirer = new Expirer(core, logger);
       expect(expirer.storageKey).to.equal(
@@ -35,6 +39,8 @@ describe("Expirer", () => {
   });
 
   it("should expire payload", async () => {
+    // @ts-ignore
+    global.__walletconnect_core__ = undefined;
     const core = new Core(TEST_CORE_OPTIONS);
     await core.start();
     // confirm the expirer is empty

--- a/packages/core/test/messages.spec.ts
+++ b/packages/core/test/messages.spec.ts
@@ -19,6 +19,8 @@ describe("Messages", () => {
   let topic: string;
 
   beforeEach(async () => {
+    // @ts-ignore
+    global.__walletconnect_core__ = undefined;
     const core = new Core(TEST_CORE_OPTIONS);
     messageTracker = new MessageTracker(logger, core);
     topic = generateRandomBytes32();

--- a/packages/core/test/pairing.spec.ts
+++ b/packages/core/test/pairing.spec.ts
@@ -5,7 +5,11 @@ import { TEST_CORE_OPTIONS, disconnectSocket, waitForEvent } from "./shared";
 import { generateRandomBytes32 } from "@walletconnect/utils";
 
 const createCoreClients: () => Promise<{ coreA: ICore; coreB: ICore }> = async () => {
+  // @ts-ignore
+  global.__walletconnect_core__ = undefined;
   const coreA = new Core(TEST_CORE_OPTIONS);
+  // @ts-ignore
+  global.__walletconnect_core__ = undefined;
   const coreB = new Core(TEST_CORE_OPTIONS);
   await coreA.start();
   await coreB.start();

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -26,6 +26,8 @@ describe("Relayer", () => {
   let relayer: IRelayer;
 
   beforeEach(async () => {
+    // @ts-ignore
+    global.__walletconnect_core__ = undefined;
     core = new Core(TEST_CORE_OPTIONS);
     await core.start();
     relayer = core.relayer;

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -14,6 +14,8 @@ describe("Store", () => {
   let store: IStore<any, any>;
 
   beforeEach(async () => {
+    // @ts-ignore
+    global.__walletconnect_core__ = undefined;
     core = new Core(TEST_CORE_OPTIONS);
     store = new Store(core, logger, MOCK_STORE_NAME);
     await store.init();

--- a/packages/core/test/subscriber.spec.ts
+++ b/packages/core/test/subscriber.spec.ts
@@ -23,6 +23,8 @@ describe("Subscriber", () => {
   let core: ICore;
 
   beforeEach(async () => {
+    // @ts-ignore
+    global.__walletconnect_core__ = undefined;
     core = new Core(TEST_CORE_OPTIONS);
     await core.start();
 

--- a/packages/react-native-compat/package.json
+++ b/packages/react-native-compat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/react-native-compat",
   "description": "Shims for WalletConnect Protocol in React Native Projects",
-  "version": "2.10.4",
+  "version": "2.10.4-184f2234",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/sign-client",
   "description": "Sign Client for WalletConnect Protocol",
-  "version": "2.10.4",
+  "version": "2.10.4-184f2234",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -38,14 +38,14 @@
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },
   "dependencies": {
-    "@walletconnect/core": "2.10.4",
+    "@walletconnect/core": "2.10.4-184f2234",
     "@walletconnect/events": "^1.0.1",
     "@walletconnect/heartbeat": "1.2.1",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/logger": "^2.0.1",
     "@walletconnect/time": "^1.0.2",
-    "@walletconnect/types": "2.10.4",
-    "@walletconnect/utils": "2.10.4",
+    "@walletconnect/types": "2.10.4-184f2234",
+    "@walletconnect/utils": "2.10.4-184f2234",
     "events": "^3.3.0"
   },
   "devDependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/types",
   "description": "Typings for WalletConnect Protocol",
-  "version": "2.10.4",
+  "version": "2.10.4-184f2234",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/utils",
   "description": "Utilities for WalletConnect Protocol",
-  "version": "2.10.4",
+  "version": "2.10.4-184f2234",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -39,7 +39,7 @@
     "@walletconnect/relay-api": "^1.0.9",
     "@walletconnect/safe-json": "^1.0.2",
     "@walletconnect/time": "^1.0.2",
-    "@walletconnect/types": "2.10.4",
+    "@walletconnect/types": "2.10.4-184f2234",
     "@walletconnect/window-getters": "^1.0.1",
     "@walletconnect/window-metadata": "^1.0.1",
     "detect-browser": "5.3.0",

--- a/providers/ethereum-provider/package.json
+++ b/providers/ethereum-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/ethereum-provider",
   "description": "Ethereum Provider for WalletConnect Protocol",
-  "version": "2.10.4",
+  "version": "2.10.4-184f2234",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {
@@ -47,10 +47,10 @@
     "@walletconnect/jsonrpc-provider": "^1.0.13",
     "@walletconnect/jsonrpc-types": "^1.0.3",
     "@walletconnect/jsonrpc-utils": "^1.0.8",
-    "@walletconnect/sign-client": "2.10.4",
-    "@walletconnect/types": "2.10.4",
-    "@walletconnect/universal-provider": "2.10.4",
-    "@walletconnect/utils": "2.10.4",
+    "@walletconnect/sign-client": "2.10.4-184f2234",
+    "@walletconnect/types": "2.10.4-184f2234",
+    "@walletconnect/universal-provider": "2.10.4-184f2234",
+    "@walletconnect/utils": "2.10.4-184f2234",
     "events": "^3.3.0"
   },
   "devDependencies": {

--- a/providers/signer-connection/package.json
+++ b/providers/signer-connection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/signer-connection",
   "description": "Signer Connection for WalletConnect Protocol",
-  "version": "2.10.4",
+  "version": "2.10.4-184f2234",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -39,9 +39,9 @@
   "dependencies": {
     "@walletconnect/jsonrpc-types": "^1.0.3",
     "@walletconnect/jsonrpc-utils": "^1.0.8",
-    "@walletconnect/sign-client": "2.10.4",
-    "@walletconnect/types": "2.10.4",
-    "@walletconnect/utils": "2.10.4",
+    "@walletconnect/sign-client": "2.10.4-184f2234",
+    "@walletconnect/types": "2.10.4-184f2234",
+    "@walletconnect/utils": "2.10.4-184f2234",
     "events": "^3.3.0",
     "uint8arrays": "^3.1.0"
   }

--- a/providers/universal-provider/package.json
+++ b/providers/universal-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/universal-provider",
   "description": "Universal Provider for WalletConnect Protocol",
-  "version": "2.10.4",
+  "version": "2.10.4-184f2234",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {
@@ -45,9 +45,9 @@
     "@walletconnect/jsonrpc-types": "^1.0.2",
     "@walletconnect/jsonrpc-utils": "^1.0.7",
     "@walletconnect/logger": "^2.0.1",
-    "@walletconnect/sign-client": "2.10.4",
-    "@walletconnect/types": "2.10.4",
-    "@walletconnect/utils": "2.10.4",
+    "@walletconnect/sign-client": "2.10.4-184f2234",
+    "@walletconnect/types": "2.10.4-184f2234",
+    "@walletconnect/utils": "2.10.4-184f2234",
     "events": "^3.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

- This is an experimental PoC of sharing a `Core` instance by:
	- identifying the current global scope (`window`, `global`, `globalThis`)
	- Binding the instantiated `Core` instance to `globalScope.__walletconnect_core__`
	- If the binding already exists, instruct the current core controller to consume this global reference instead and bind its controllers from it, instead of instantiating its own.
	- Will only bind to an existing core reference if the `CoreOpts` match, else instantiate a separate one.

- I've made some accommodations due to technicalities of this current approach:
	- Using `console.log` instead of `this.logger` since it was erroring at runtime regarding `this.logger` not yet being defined at this stage of initialisation
	- Creating a separate `this.self = this` reference: This is primarily to work around Typescript complaining about direct assignments to `this`.


## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

- Release on `experimental` dist for all monorepo pkgs: `2.10.4-184f2234`
- I've done some manual validation that two cores can run in parallel and share a relayer, WS connection etc successfully this way, but it's by no means validated as stable.
- Some tests are currently still failing due to the attempt to share cores, which I've overridden where possible in test setups/teardowns for now.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
