### PR TITLE
chore: prep for `2.10.5` release

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/*",
     "providers/*"
   ],
-  "version": "2.10.4"
+  "version": "2.10.5"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27526,23 +27526,6 @@
         "lokijs": "^1.5.12"
       }
     },
-    "packages/web3wallet/node_modules/@walletconnect/jsonrpc-ws-connection": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.13.tgz",
-      "integrity": "sha512-mfOM7uFH4lGtQxG+XklYuFBj6dwVvseTt5/ahOkkmpcAEgz2umuzu7fTR+h5EmjQBdrmYyEBOWADbeaFNxdySg==",
-      "dependencies": {
-        "@walletconnect/jsonrpc-utils": "^1.0.6",
-        "@walletconnect/safe-json": "^1.0.2",
-        "events": "^3.3.0",
-        "tslib": "1.14.1",
-        "ws": "^7.5.1"
-      }
-    },
-    "packages/web3wallet/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "providers/ethereum-provider": {
       "name": "@walletconnect/ethereum-provider",
       "version": "2.10.5",
@@ -33977,24 +33960,6 @@
         "@walletconnect/types": "2.10.5",
         "@walletconnect/utils": "2.10.5",
         "lokijs": "^1.5.12"
-      },
-      "dependencies": {
-        "@walletconnect/jsonrpc-ws-connection": {
-          "version": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.13.tgz",
-          "integrity": "sha512-mfOM7uFH4lGtQxG+XklYuFBj6dwVvseTt5/ahOkkmpcAEgz2umuzu7fTR+h5EmjQBdrmYyEBOWADbeaFNxdySg==",
-          "requires": {
-            "@walletconnect/jsonrpc-utils": "^1.0.6",
-            "@walletconnect/safe-json": "^1.0.2",
-            "events": "^3.3.0",
-            "tslib": "1.14.1",
-            "ws": "^7.5.1"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
       }
     },
     "@walletconnect/window-getters": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27384,7 +27384,7 @@
     },
     "packages/core": {
       "name": "@walletconnect/core",
-      "version": "2.10.4",
+      "version": "2.10.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
@@ -27398,8 +27398,8 @@
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/types": "2.10.5",
+        "@walletconnect/utils": "2.10.5",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "^3.1.0"
@@ -27428,7 +27428,7 @@
     },
     "packages/react-native-compat": {
       "name": "@walletconnect/react-native-compat",
-      "version": "2.10.4",
+      "version": "2.10.5",
       "license": "Apache-2.0",
       "dependencies": {
         "events": "3.3.0",
@@ -27449,17 +27449,17 @@
     },
     "packages/sign-client": {
       "name": "@walletconnect/sign-client",
-      "version": "2.10.4",
+      "version": "2.10.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@walletconnect/core": "2.10.4",
+        "@walletconnect/core": "2.10.5",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/types": "2.10.5",
+        "@walletconnect/utils": "2.10.5",
         "events": "^3.3.0"
       },
       "devDependencies": {
@@ -27472,7 +27472,7 @@
     },
     "packages/types": {
       "name": "@walletconnect/types",
-      "version": "2.10.4",
+      "version": "2.10.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
@@ -27485,7 +27485,7 @@
     },
     "packages/utils": {
       "name": "@walletconnect/utils",
-      "version": "2.10.4",
+      "version": "2.10.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
@@ -27496,7 +27496,7 @@
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.4",
+        "@walletconnect/types": "2.10.5",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -27509,26 +27509,43 @@
     },
     "packages/web3wallet": {
       "name": "@walletconnect/web3wallet",
-      "version": "1.9.3",
+      "version": "1.9.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/auth-client": "2.1.2",
-        "@walletconnect/core": "2.10.4",
+        "@walletconnect/core": "2.10.5",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.0.1",
-        "@walletconnect/sign-client": "2.10.4",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4"
+        "@walletconnect/sign-client": "2.10.5",
+        "@walletconnect/types": "2.10.5",
+        "@walletconnect/utils": "2.10.5"
       },
       "devDependencies": {
         "@ethersproject/wallet": "^5.7.0",
         "lokijs": "^1.5.12"
       }
     },
+    "packages/web3wallet/node_modules/@walletconnect/jsonrpc-ws-connection": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.13.tgz",
+      "integrity": "sha512-mfOM7uFH4lGtQxG+XklYuFBj6dwVvseTt5/ahOkkmpcAEgz2umuzu7fTR+h5EmjQBdrmYyEBOWADbeaFNxdySg==",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0",
+        "tslib": "1.14.1",
+        "ws": "^7.5.1"
+      }
+    },
+    "packages/web3wallet/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "providers/ethereum-provider": {
       "name": "@walletconnect/ethereum-provider",
-      "version": "2.10.4",
+      "version": "2.10.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
@@ -27536,10 +27553,10 @@
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/modal": "^2.4.3",
-        "@walletconnect/sign-client": "2.10.4",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/universal-provider": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/sign-client": "2.10.5",
+        "@walletconnect/types": "2.10.5",
+        "@walletconnect/universal-provider": "2.10.5",
+        "@walletconnect/utils": "2.10.5",
         "events": "^3.3.0"
       },
       "devDependencies": {
@@ -27551,21 +27568,21 @@
     },
     "providers/signer-connection": {
       "name": "@walletconnect/signer-connection",
-      "version": "2.10.4",
+      "version": "2.10.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
-        "@walletconnect/sign-client": "2.10.4",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/sign-client": "2.10.5",
+        "@walletconnect/types": "2.10.5",
+        "@walletconnect/utils": "2.10.5",
         "events": "^3.3.0",
         "uint8arrays": "^3.1.0"
       }
     },
     "providers/universal-provider": {
       "name": "@walletconnect/universal-provider",
-      "version": "2.10.4",
+      "version": "2.10.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
@@ -27573,9 +27590,9 @@
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sign-client": "2.10.4",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/sign-client": "2.10.5",
+        "@walletconnect/types": "2.10.5",
+        "@walletconnect/utils": "2.10.5",
         "events": "^3.3.0"
       },
       "devDependencies": {
@@ -33427,8 +33444,8 @@
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/types": "2.10.5",
+        "@walletconnect/utils": "2.10.5",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "node-fetch": "^3.3.0",
@@ -33465,10 +33482,10 @@
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/modal": "^2.4.3",
-        "@walletconnect/sign-client": "2.10.4",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/universal-provider": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/sign-client": "2.10.5",
+        "@walletconnect/types": "2.10.5",
+        "@walletconnect/universal-provider": "2.10.5",
+        "@walletconnect/utils": "2.10.5",
         "ethereum-test-network": "0.1.6",
         "ethers": "5.6.9",
         "events": "^3.3.0",
@@ -33700,7 +33717,7 @@
       "version": "file:packages/sign-client",
       "requires": {
         "@aws-sdk/client-cloudwatch": "3.450.0",
-        "@walletconnect/core": "2.10.4",
+        "@walletconnect/core": "2.10.5",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "^1.0.13",
@@ -33709,8 +33726,8 @@
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/types": "2.10.5",
+        "@walletconnect/utils": "2.10.5",
         "events": "^3.3.0",
         "lokijs": "^1.5.12"
       }
@@ -33720,9 +33737,9 @@
       "requires": {
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
-        "@walletconnect/sign-client": "2.10.4",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/sign-client": "2.10.5",
+        "@walletconnect/types": "2.10.5",
+        "@walletconnect/utils": "2.10.5",
         "events": "^3.3.0",
         "uint8arrays": "^3.1.0"
       }
@@ -33757,9 +33774,9 @@
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sign-client": "2.10.4",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/sign-client": "2.10.5",
+        "@walletconnect/types": "2.10.5",
+        "@walletconnect/utils": "2.10.5",
         "cosmos-wallet": "^1.2.0",
         "ethereum-test-network": "0.1.6",
         "ethers": "5.7.0",
@@ -33939,7 +33956,7 @@
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.4",
+        "@walletconnect/types": "2.10.5",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -33952,14 +33969,32 @@
       "requires": {
         "@ethersproject/wallet": "^5.7.0",
         "@walletconnect/auth-client": "2.1.2",
-        "@walletconnect/core": "2.10.4",
+        "@walletconnect/core": "2.10.5",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.0.1",
-        "@walletconnect/sign-client": "2.10.4",
-        "@walletconnect/types": "2.10.4",
-        "@walletconnect/utils": "2.10.4",
+        "@walletconnect/sign-client": "2.10.5",
+        "@walletconnect/types": "2.10.5",
+        "@walletconnect/utils": "2.10.5",
         "lokijs": "^1.5.12"
+      },
+      "dependencies": {
+        "@walletconnect/jsonrpc-ws-connection": {
+          "version": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.13.tgz",
+          "integrity": "sha512-mfOM7uFH4lGtQxG+XklYuFBj6dwVvseTt5/ahOkkmpcAEgz2umuzu7fTR+h5EmjQBdrmYyEBOWADbeaFNxdySg==",
+          "requires": {
+            "@walletconnect/jsonrpc-utils": "^1.0.6",
+            "@walletconnect/safe-json": "^1.0.2",
+            "events": "^3.3.0",
+            "tslib": "1.14.1",
+            "ws": "^7.5.1"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@walletconnect/window-getters": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/core",
   "description": "Core for WalletConnect Protocol",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -42,8 +42,8 @@
     "@walletconnect/relay-auth": "^1.0.4",
     "@walletconnect/safe-json": "^1.0.2",
     "@walletconnect/time": "^1.0.2",
-    "@walletconnect/types": "2.10.4",
-    "@walletconnect/utils": "2.10.4",
+    "@walletconnect/types": "2.10.5",
+    "@walletconnect/utils": "2.10.5",
     "events": "^3.3.0",
     "lodash.isequal": "4.5.0",
     "uint8arrays": "^3.1.0"

--- a/packages/core/src/constants/relayer.ts
+++ b/packages/core/src/constants/relayer.ts
@@ -37,7 +37,7 @@ export const RELAYER_STORAGE_OPTIONS = {
 
 // Updated automatically via `new-version` npm script.
 
-export const RELAYER_SDK_VERSION = "2.10.4";
+export const RELAYER_SDK_VERSION = "2.10.5";
 
 // delay to wait before closing the transport connection after init if not active
 export const RELAYER_TRANSPORT_CUTOFF = 10_000;

--- a/packages/react-native-compat/package.json
+++ b/packages/react-native-compat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/react-native-compat",
   "description": "Shims for WalletConnect Protocol in React Native Projects",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -43,8 +43,8 @@
   "peerDependencies": {
     "@react-native-async-storage/async-storage": "*",
     "@react-native-community/netinfo": "*",
-    "react-native-get-random-values": "*",
-    "expo-application": "*"
+    "expo-application": "*",
+    "react-native-get-random-values": "*"
   },
   "peerDependenciesMeta": {
     "expo-application": {

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/sign-client",
   "description": "Sign Client for WalletConnect Protocol",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -38,14 +38,14 @@
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },
   "dependencies": {
-    "@walletconnect/core": "2.10.4",
+    "@walletconnect/core": "2.10.5",
     "@walletconnect/events": "^1.0.1",
     "@walletconnect/heartbeat": "1.2.1",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/logger": "^2.0.1",
     "@walletconnect/time": "^1.0.2",
-    "@walletconnect/types": "2.10.4",
-    "@walletconnect/utils": "2.10.4",
+    "@walletconnect/types": "2.10.5",
+    "@walletconnect/utils": "2.10.5",
     "events": "^3.3.0"
   },
   "devDependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/types",
   "description": "Typings for WalletConnect Protocol",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/utils",
   "description": "Utilities for WalletConnect Protocol",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -39,7 +39,7 @@
     "@walletconnect/relay-api": "^1.0.9",
     "@walletconnect/safe-json": "^1.0.2",
     "@walletconnect/time": "^1.0.2",
-    "@walletconnect/types": "2.10.4",
+    "@walletconnect/types": "2.10.5",
     "@walletconnect/window-getters": "^1.0.1",
     "@walletconnect/window-metadata": "^1.0.1",
     "detect-browser": "5.3.0",

--- a/packages/web3wallet/package.json
+++ b/packages/web3wallet/package.json
@@ -2,7 +2,7 @@
   "name": "@walletconnect/web3wallet",
   "description": "Web3Wallet for WalletConnect Protocol",
   "private": true,
-  "version": "1.9.3",
+  "version": "1.9.4",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -30,12 +30,12 @@
   },
   "dependencies": {
     "@walletconnect/auth-client": "2.1.2",
-    "@walletconnect/core": "2.10.4",
+    "@walletconnect/core": "2.10.5",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/logger": "2.0.1",
-    "@walletconnect/sign-client": "2.10.4",
-    "@walletconnect/types": "2.10.4",
-    "@walletconnect/utils": "2.10.4",
+    "@walletconnect/sign-client": "2.10.5",
+    "@walletconnect/types": "2.10.5",
+    "@walletconnect/utils": "2.10.5",
     "@walletconnect/jsonrpc-provider": "1.0.13"
   },
   "devDependencies": {

--- a/providers/ethereum-provider/package.json
+++ b/providers/ethereum-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/ethereum-provider",
   "description": "Ethereum Provider for WalletConnect Protocol",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {
@@ -47,11 +47,11 @@
     "@walletconnect/jsonrpc-provider": "^1.0.13",
     "@walletconnect/jsonrpc-types": "^1.0.3",
     "@walletconnect/jsonrpc-utils": "^1.0.8",
-    "@walletconnect/sign-client": "2.10.4",
-    "@walletconnect/types": "2.10.4",
-    "@walletconnect/universal-provider": "2.10.4",
     "@walletconnect/modal": "^2.4.3",
-    "@walletconnect/utils": "2.10.4",
+    "@walletconnect/sign-client": "2.10.5",
+    "@walletconnect/types": "2.10.5",
+    "@walletconnect/universal-provider": "2.10.5",
+    "@walletconnect/utils": "2.10.5",
     "events": "^3.3.0"
   },
   "devDependencies": {

--- a/providers/signer-connection/package.json
+++ b/providers/signer-connection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/signer-connection",
   "description": "Signer Connection for WalletConnect Protocol",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -39,9 +39,9 @@
   "dependencies": {
     "@walletconnect/jsonrpc-types": "^1.0.3",
     "@walletconnect/jsonrpc-utils": "^1.0.8",
-    "@walletconnect/sign-client": "2.10.4",
-    "@walletconnect/types": "2.10.4",
-    "@walletconnect/utils": "2.10.4",
+    "@walletconnect/sign-client": "2.10.5",
+    "@walletconnect/types": "2.10.5",
+    "@walletconnect/utils": "2.10.5",
     "events": "^3.3.0",
     "uint8arrays": "^3.1.0"
   }

--- a/providers/universal-provider/package.json
+++ b/providers/universal-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/universal-provider",
   "description": "Universal Provider for WalletConnect Protocol",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {
@@ -45,9 +45,9 @@
     "@walletconnect/jsonrpc-types": "^1.0.2",
     "@walletconnect/jsonrpc-utils": "^1.0.7",
     "@walletconnect/logger": "^2.0.1",
-    "@walletconnect/sign-client": "2.10.4",
-    "@walletconnect/types": "2.10.4",
-    "@walletconnect/utils": "2.10.4",
+    "@walletconnect/sign-client": "2.10.5",
+    "@walletconnect/types": "2.10.5",
+    "@walletconnect/utils": "2.10.5",
     "events": "^3.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Release Checklist

- [x] **Canary Version QA**

  - [x] I have thoroughly tested the release using a canary version: `2.10.5-rc-c91a538`
  - [x] The canary version has been verified to work as expected.
  - [x] All major features and changes have been tested and validated.

- [ ] **Web3Modal Team QA**

  - [ ] The Web3Modal team has tested the release for compatibility and functionality.
  - [ ] The release is backwards compatible with Web3Modal.
  - [ ] Any reported issues or bugs have been addressed or documented.

- [x] **React Native Team QA**

  - [x] The React Native team has tested the release for compatibility and functionality (if relevant).
  - [x] The release works correctly in React Native environments and is backwards compatible with Web3Modal React Native.
  - [ ] Any reported issues or bugs have been addressed or documented.

## Web-examples
https://github.com/WalletConnect/web-examples/pull/318

## Related Issues and Pull Requests
* chore: prep for `2.10.4` by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/3821
* fix(canary): Canary shouldn't fail if Statuspage is down by @arein in https://github.com/WalletConnect/walletconnect-monorepo/pull/3841
* fix(deps): update dependency @walletconnect/keyvaluestorage to v1.1.0 by @renovate in https://github.com/WalletConnect/walletconnect-monorepo/pull/3900
* Fix: modal dependency by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/3891
* fix(deps): update dependency @walletconnect/jsonrpc-ws-connection to v1.0.14 by @renovate in https://github.com/WalletConnect/walletconnect-monorepo/pull/3899
* Feat/send bundleid by @ignaciosantise in https://github.com/WalletConnect/walletconnect-monorepo/pull/3847
* fix: export module folder by @ignaciosantise in https://github.com/WalletConnect/walletconnect-monorepo/pull/3907
* chore: added ios/android folders as ignored paths in renovate config by @ignaciosantise in https://github.com/WalletConnect/walletconnect-monorepo/pull/3915
* chore(deps): update node.js to v21 by @renovate in https://github.com/WalletConnect/walletconnect-monorepo/pull/3810
* chore: migrate AWS SDK for JavaScript v2 APIs to v3 by @trivikr in https://github.com/WalletConnect/walletconnect-monorepo/pull/3918
* chore(deps): update actions/setup-node action to v4 by @renovate in https://github.com/WalletConnect/walletconnect-monorepo/pull/3840
* chore: updates keyvaluestorage to latest by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/3934


## Definition of Done

- [x] The release has been tested using a canary version.
- [ ] The release has been reviewed and approved by the Web3Modal team (if relevant).
- [x] The release has been reviewed and approved by the React Native team (if relevant).
- [x] All necessary documentation, including API changes or new features, has been updated.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] All tests (unit, integration, etc.) pass successfully.
- [x] The release has been properly versioned and tagged.
- [x] The release notes and changelog have been updated to reflect the changes made.

Please ensure that all the items on the checklist have been completed before merging the release.