### PR TITLE
chore: added ios/android folders as ignored paths in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,5 +19,6 @@
       "matchPackagePatterns": ["@walletconnect/*"],
       "schedule": ["at any time"]
     }
-  ]
+  ],
+  "ignorePaths": ["**/android/**", "**/ios/**"]
 }


### PR DESCRIPTION
## Description
Ignoring android & ios folders in renovate bot config

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
