### PR TITLE
fix: `pair` flow

### DIFF
--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -121,12 +121,6 @@ export class Pairing implements IPairing {
       }
     }
 
-    // avoid overwriting keychain pairing already exists
-    if (!this.core.crypto.keychain.has(topic)) {
-      await this.core.crypto.setSymKey(symKey, topic);
-      await this.core.relayer.subscribe(topic, { relay });
-    }
-
     const expiry = calcExpiry(FIVE_MINUTES);
     const pairing = { topic, relay, expiry, active: false };
     await this.pairings.set(topic, pairing);
@@ -137,6 +131,13 @@ export class Pairing implements IPairing {
     }
 
     this.events.emit(PAIRING_EVENTS.create, pairing);
+
+    // avoid overwriting keychain pairing already exists
+    if (!this.core.crypto.keychain.has(topic)) {
+      await this.core.crypto.setSymKey(symKey, topic);
+      await this.core.relayer.subscribe(topic, { relay });
+    }
+
     return pairing;
   };
 

--- a/packages/core/test/pairing.spec.ts
+++ b/packages/core/test/pairing.spec.ts
@@ -293,21 +293,20 @@ describe("Pairing", () => {
       const { uri } = await coreA.pairing.create();
       const { topic } = parseUri(uri);
       coreB.pairing.events.on(PAIRING_EVENTS.create, () => {
-        expect(coreB.pairing.pairings.keys.length).toBe(1);
-        expect(coreB.pairing.pairings.values[0].topic).toEqual(topic);
         pairingCreatedEventTime = performance.now();
         pairingCreatedEvent = true;
       });
 
-      coreB.relayer.subscriber.events.on(SUBSCRIBER_EVENTS.created, (subscription) => {
+      coreB.relayer.subscriber.events.on(SUBSCRIBER_EVENTS.created, () => {
         subscriptionCreatedEventTime = performance.now();
         subscriptionCreatedEvent = true;
-        expect(subscription.topic).toEqual(topic);
       });
 
       coreB.pairing.pair({ uri });
       await waitForEvent(() => pairingCreatedEvent);
       await waitForEvent(() => subscriptionCreatedEvent);
+      expect(coreB.pairing.pairings.keys.length).toBe(1);
+      expect(coreB.pairing.pairings.values[0].topic).toEqual(topic);
       expect(subscriptionCreatedEventTime).toBeGreaterThan(pairingCreatedEventTime);
     });
   });

--- a/packages/core/test/pairing.spec.ts
+++ b/packages/core/test/pairing.spec.ts
@@ -1,8 +1,8 @@
 import { expect, describe, it, beforeEach, afterEach } from "vitest";
 import { ICore } from "@walletconnect/types";
-import { Core, CORE_PROTOCOL, CORE_VERSION } from "../src";
+import { Core, CORE_PROTOCOL, CORE_VERSION, PAIRING_EVENTS, SUBSCRIBER_EVENTS } from "../src";
 import { TEST_CORE_OPTIONS, disconnectSocket, waitForEvent } from "./shared";
-import { generateRandomBytes32 } from "@walletconnect/utils";
+import { generateRandomBytes32, parseUri } from "@walletconnect/utils";
 
 const createCoreClients: () => Promise<{ coreA: ICore; coreB: ICore }> = async () => {
   const coreA = new Core(TEST_CORE_OPTIONS);
@@ -275,6 +275,40 @@ describe("Pairing", () => {
           "No matching key. pairing topic doesn't exist: none",
         );
       });
+    });
+  });
+  describe("events", () => {
+    it("should emit 'pairing_create' event", async () => {
+      let pairingCreatedEvent = false;
+      coreB.pairing.events.on(PAIRING_EVENTS.create, () => (pairingCreatedEvent = true));
+      const { uri } = await coreA.pairing.create();
+      coreB.pairing.pair({ uri });
+      await waitForEvent(() => pairingCreatedEvent);
+    });
+    it("should store pairing before subscribing to its topic", async () => {
+      let pairingCreatedEvent = false;
+      let pairingCreatedEventTime = 0;
+      let subscriptionCreatedEvent = false;
+      let subscriptionCreatedEventTime = 0;
+      const { uri } = await coreA.pairing.create();
+      const { topic } = parseUri(uri);
+      coreB.pairing.events.on(PAIRING_EVENTS.create, () => {
+        expect(coreB.pairing.pairings.keys.length).toBe(1);
+        expect(coreB.pairing.pairings.values[0].topic).toEqual(topic);
+        pairingCreatedEventTime = performance.now();
+        pairingCreatedEvent = true;
+      });
+
+      coreB.relayer.subscriber.events.on(SUBSCRIBER_EVENTS.created, (subscription) => {
+        subscriptionCreatedEventTime = performance.now();
+        subscriptionCreatedEvent = true;
+        expect(subscription.topic).toEqual(topic);
+      });
+
+      coreB.pairing.pair({ uri });
+      await waitForEvent(() => pairingCreatedEvent);
+      await waitForEvent(() => subscriptionCreatedEvent);
+      expect(subscriptionCreatedEventTime).toBeGreaterThan(pairingCreatedEventTime);
     });
   });
 });

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -1114,6 +1114,7 @@ export class Engine extends IEngine {
           optionalNamespaces: proposal.optionalNamespaces,
           relays: proposal.relays,
           proposer: proposal.proposer,
+          sessionProperties: proposal.sessionProperties,
         },
         proposal.id,
       ),


### PR DESCRIPTION
## Description
Moved storing `symKey` & subscribing to the pairing topic after the pairing itself has been stored to avoid cases where the topic can start to receive payloads before the pairing has been saved & `pair()` method is resolved   

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
