### PR TITLE
fix: URI validation

### DIFF
--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -387,6 +387,10 @@ export class Pairing implements IPairing {
       const { message } = getInternalError("MISSING_OR_INVALID", `pair() uri: ${params.uri}`);
       throw new Error(message);
     }
+    if (!parseUri(params.uri)?.relay?.protocol) {
+      const { message } = getInternalError("MISSING_OR_INVALID", `pair() uri#relay-protocol`);
+      throw new Error(message);
+    }
   };
 
   private isValidPing = async (params: { topic: string }) => {

--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -387,8 +387,13 @@ export class Pairing implements IPairing {
       const { message } = getInternalError("MISSING_OR_INVALID", `pair() uri: ${params.uri}`);
       throw new Error(message);
     }
-    if (!parseUri(params.uri)?.relay?.protocol) {
+    const uri = parseUri(params.uri);
+    if (!uri?.relay?.protocol) {
       const { message } = getInternalError("MISSING_OR_INVALID", `pair() uri#relay-protocol`);
+      throw new Error(message);
+    }
+    if (!uri?.symKey) {
+      const { message } = getInternalError("MISSING_OR_INVALID", `pair() uri#symKey`);
       throw new Error(message);
     }
   };

--- a/packages/core/test/pairing.spec.ts
+++ b/packages/core/test/pairing.spec.ts
@@ -206,11 +206,21 @@ describe("Pairing", () => {
         );
       });
       it("throws when uri missing relay protocol is provided", async () => {
+        // Using v1 pairing URI as it is unsupported
+        const v1PairingUri =
+          "wc:e9d6ef98-6b65-490b-8726-a21e1afb181d@1?bridge=https%3A%2F%2Fwalletconnect.com&key=73f096cb97aaee97b3d9871ced35fdce1668e652db3d39423ea6cd22e14528bf";
         await expect(
           coreA.pairing.pair({
-            uri: "wc:e9d6ef98-6b65-490b-8726-a21e1afb181d@1?bridge=https%3A%2F%2Fwalletconnect.com&key=73f096cb97aaee97b3d9871ced35fdce1668e652db3d39423ea6cd22e14528bf",
+            uri: v1PairingUri,
           }),
         ).rejects.toThrowError("Missing or invalid. pair() uri#relay-protocol");
+      });
+      it("throws when uri missing relay protocol is provided", async () => {
+        await expect(
+          coreA.pairing.pair({
+            uri: "wc:e9d6ef98-6b65-490b-8726-a21e1afb181d@1?bridge=https%3A%2F%2Fwalletconnect.com&relay-protocol=irn",
+          }),
+        ).rejects.toThrowError("Missing or invalid. pair() uri#symKey");
       });
     });
 

--- a/packages/core/test/pairing.spec.ts
+++ b/packages/core/test/pairing.spec.ts
@@ -205,6 +205,13 @@ describe("Pairing", () => {
           "Missing or invalid. pair() uri: undefined",
         );
       });
+      it("throws when uri missing relay protocol is provided", async () => {
+        await expect(
+          coreA.pairing.pair({
+            uri: "wc:e9d6ef98-6b65-490b-8726-a21e1afb181d@1?bridge=https%3A%2F%2Fwalletconnect.com&key=73f096cb97aaee97b3d9871ced35fdce1668e652db3d39423ea6cd22e14528bf",
+          }),
+        ).rejects.toThrowError("Missing or invalid. pair() uri#relay-protocol");
+      });
     });
 
     describe("ping", () => {


### PR DESCRIPTION
## Description
Fixed a bug where when invalid URI is provided such as `v1` uri, or any other that is missing `relay-protocol` was resulting in unhandled exception instead of returning the rejection 
## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests 

## Fixes/Resolves (Optional)
https://github.com/WalletConnect/walletconnect-monorepo/issues/3813

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
