### PR TITLE
chore: prep for `2.10.6` release

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/*",
     "providers/*"
   ],
-  "version": "2.10.5"
+  "version": "2.10.6"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27475,7 +27475,7 @@
     },
     "packages/core": {
       "name": "@walletconnect/core",
-      "version": "2.10.5",
+      "version": "2.10.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
@@ -27489,8 +27489,8 @@
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.5",
-        "@walletconnect/utils": "2.10.5",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/utils": "2.10.6",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "^3.1.0"
@@ -27519,7 +27519,7 @@
     },
     "packages/react-native-compat": {
       "name": "@walletconnect/react-native-compat",
-      "version": "2.10.5",
+      "version": "2.10.6",
       "license": "Apache-2.0",
       "dependencies": {
         "events": "3.3.0",
@@ -27540,17 +27540,17 @@
     },
     "packages/sign-client": {
       "name": "@walletconnect/sign-client",
-      "version": "2.10.5",
+      "version": "2.10.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@walletconnect/core": "2.10.5",
+        "@walletconnect/core": "2.10.6",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.5",
-        "@walletconnect/utils": "2.10.5",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/utils": "2.10.6",
         "events": "^3.3.0"
       },
       "devDependencies": {
@@ -27563,7 +27563,7 @@
     },
     "packages/types": {
       "name": "@walletconnect/types",
-      "version": "2.10.5",
+      "version": "2.10.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
@@ -27576,7 +27576,7 @@
     },
     "packages/utils": {
       "name": "@walletconnect/utils",
-      "version": "2.10.5",
+      "version": "2.10.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
@@ -27587,7 +27587,7 @@
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.5",
+        "@walletconnect/types": "2.10.6",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -27600,17 +27600,17 @@
     },
     "packages/web3wallet": {
       "name": "@walletconnect/web3wallet",
-      "version": "1.9.4",
+      "version": "1.9.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/auth-client": "2.1.2",
-        "@walletconnect/core": "2.10.5",
+        "@walletconnect/core": "2.10.6",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.0.1",
-        "@walletconnect/sign-client": "2.10.5",
-        "@walletconnect/types": "2.10.5",
-        "@walletconnect/utils": "2.10.5"
+        "@walletconnect/sign-client": "2.10.6",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/utils": "2.10.6"
       },
       "devDependencies": {
         "@ethersproject/wallet": "^5.7.0",
@@ -27619,7 +27619,7 @@
     },
     "providers/ethereum-provider": {
       "name": "@walletconnect/ethereum-provider",
-      "version": "2.10.5",
+      "version": "2.10.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
@@ -27627,10 +27627,10 @@
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/modal": "^2.4.3",
-        "@walletconnect/sign-client": "2.10.5",
-        "@walletconnect/types": "2.10.5",
-        "@walletconnect/universal-provider": "2.10.5",
-        "@walletconnect/utils": "2.10.5",
+        "@walletconnect/sign-client": "2.10.6",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/universal-provider": "2.10.6",
+        "@walletconnect/utils": "2.10.6",
         "events": "^3.3.0"
       },
       "devDependencies": {
@@ -27642,21 +27642,21 @@
     },
     "providers/signer-connection": {
       "name": "@walletconnect/signer-connection",
-      "version": "2.10.5",
+      "version": "2.10.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
-        "@walletconnect/sign-client": "2.10.5",
-        "@walletconnect/types": "2.10.5",
-        "@walletconnect/utils": "2.10.5",
+        "@walletconnect/sign-client": "2.10.6",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/utils": "2.10.6",
         "events": "^3.3.0",
         "uint8arrays": "^3.1.0"
       }
     },
     "providers/universal-provider": {
       "name": "@walletconnect/universal-provider",
-      "version": "2.10.5",
+      "version": "2.10.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
@@ -27664,9 +27664,9 @@
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sign-client": "2.10.5",
-        "@walletconnect/types": "2.10.5",
-        "@walletconnect/utils": "2.10.5",
+        "@walletconnect/sign-client": "2.10.6",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/utils": "2.10.6",
         "events": "^3.3.0"
       },
       "devDependencies": {
@@ -33588,8 +33588,8 @@
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.5",
-        "@walletconnect/utils": "2.10.5",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/utils": "2.10.6",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "node-fetch": "^3.3.0",
@@ -33626,10 +33626,10 @@
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/modal": "^2.4.3",
-        "@walletconnect/sign-client": "2.10.5",
-        "@walletconnect/types": "2.10.5",
-        "@walletconnect/universal-provider": "2.10.5",
-        "@walletconnect/utils": "2.10.5",
+        "@walletconnect/sign-client": "2.10.6",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/universal-provider": "2.10.6",
+        "@walletconnect/utils": "2.10.6",
         "ethereum-test-network": "0.1.6",
         "ethers": "5.6.9",
         "events": "^3.3.0",
@@ -33861,7 +33861,7 @@
       "version": "file:packages/sign-client",
       "requires": {
         "@aws-sdk/client-cloudwatch": "3.450.0",
-        "@walletconnect/core": "2.10.5",
+        "@walletconnect/core": "2.10.6",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "^1.0.13",
@@ -33870,8 +33870,8 @@
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.5",
-        "@walletconnect/utils": "2.10.5",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/utils": "2.10.6",
         "events": "^3.3.0",
         "lokijs": "^1.5.12"
       }
@@ -33881,9 +33881,9 @@
       "requires": {
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
-        "@walletconnect/sign-client": "2.10.5",
-        "@walletconnect/types": "2.10.5",
-        "@walletconnect/utils": "2.10.5",
+        "@walletconnect/sign-client": "2.10.6",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/utils": "2.10.6",
         "events": "^3.3.0",
         "uint8arrays": "^3.1.0"
       }
@@ -33918,9 +33918,9 @@
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sign-client": "2.10.5",
-        "@walletconnect/types": "2.10.5",
-        "@walletconnect/utils": "2.10.5",
+        "@walletconnect/sign-client": "2.10.6",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/utils": "2.10.6",
         "cosmos-wallet": "^1.2.0",
         "ethereum-test-network": "0.1.6",
         "ethers": "5.7.0",
@@ -34100,7 +34100,7 @@
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.5",
+        "@walletconnect/types": "2.10.6",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -34113,13 +34113,13 @@
       "requires": {
         "@ethersproject/wallet": "^5.7.0",
         "@walletconnect/auth-client": "2.1.2",
-        "@walletconnect/core": "2.10.5",
+        "@walletconnect/core": "2.10.6",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.0.1",
-        "@walletconnect/sign-client": "2.10.5",
-        "@walletconnect/types": "2.10.5",
-        "@walletconnect/utils": "2.10.5",
+        "@walletconnect/sign-client": "2.10.6",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/utils": "2.10.6",
         "lokijs": "^1.5.12"
       }
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/core",
   "description": "Core for WalletConnect Protocol",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -42,8 +42,8 @@
     "@walletconnect/relay-auth": "^1.0.4",
     "@walletconnect/safe-json": "^1.0.2",
     "@walletconnect/time": "^1.0.2",
-    "@walletconnect/types": "2.10.5",
-    "@walletconnect/utils": "2.10.5",
+    "@walletconnect/types": "2.10.6",
+    "@walletconnect/utils": "2.10.6",
     "events": "^3.3.0",
     "lodash.isequal": "4.5.0",
     "uint8arrays": "^3.1.0"

--- a/packages/core/src/constants/relayer.ts
+++ b/packages/core/src/constants/relayer.ts
@@ -37,7 +37,7 @@ export const RELAYER_STORAGE_OPTIONS = {
 
 // Updated automatically via `new-version` npm script.
 
-export const RELAYER_SDK_VERSION = "2.10.5";
+export const RELAYER_SDK_VERSION = "2.10.6";
 
 // delay to wait before closing the transport connection after init if not active
 export const RELAYER_TRANSPORT_CUTOFF = 10_000;

--- a/packages/react-native-compat/package.json
+++ b/packages/react-native-compat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/react-native-compat",
   "description": "Shims for WalletConnect Protocol in React Native Projects",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/sign-client",
   "description": "Sign Client for WalletConnect Protocol",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -38,14 +38,14 @@
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },
   "dependencies": {
-    "@walletconnect/core": "2.10.5",
+    "@walletconnect/core": "2.10.6",
     "@walletconnect/events": "^1.0.1",
     "@walletconnect/heartbeat": "1.2.1",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/logger": "^2.0.1",
     "@walletconnect/time": "^1.0.2",
-    "@walletconnect/types": "2.10.5",
-    "@walletconnect/utils": "2.10.5",
+    "@walletconnect/types": "2.10.6",
+    "@walletconnect/utils": "2.10.6",
     "events": "^3.3.0"
   },
   "devDependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/types",
   "description": "Typings for WalletConnect Protocol",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/utils",
   "description": "Utilities for WalletConnect Protocol",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -39,7 +39,7 @@
     "@walletconnect/relay-api": "^1.0.9",
     "@walletconnect/safe-json": "^1.0.2",
     "@walletconnect/time": "^1.0.2",
-    "@walletconnect/types": "2.10.5",
+    "@walletconnect/types": "2.10.6",
     "@walletconnect/window-getters": "^1.0.1",
     "@walletconnect/window-metadata": "^1.0.1",
     "detect-browser": "5.3.0",

--- a/packages/web3wallet/package.json
+++ b/packages/web3wallet/package.json
@@ -2,7 +2,7 @@
   "name": "@walletconnect/web3wallet",
   "description": "Web3Wallet for WalletConnect Protocol",
   "private": true,
-  "version": "1.9.4",
+  "version": "1.9.5",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -30,12 +30,12 @@
   },
   "dependencies": {
     "@walletconnect/auth-client": "2.1.2",
-    "@walletconnect/core": "2.10.5",
+    "@walletconnect/core": "2.10.6",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/logger": "2.0.1",
-    "@walletconnect/sign-client": "2.10.5",
-    "@walletconnect/types": "2.10.5",
-    "@walletconnect/utils": "2.10.5",
+    "@walletconnect/sign-client": "2.10.6",
+    "@walletconnect/types": "2.10.6",
+    "@walletconnect/utils": "2.10.6",
     "@walletconnect/jsonrpc-provider": "1.0.13"
   },
   "devDependencies": {

--- a/providers/ethereum-provider/package.json
+++ b/providers/ethereum-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/ethereum-provider",
   "description": "Ethereum Provider for WalletConnect Protocol",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {
@@ -48,10 +48,10 @@
     "@walletconnect/jsonrpc-types": "^1.0.3",
     "@walletconnect/jsonrpc-utils": "^1.0.8",
     "@walletconnect/modal": "^2.4.3",
-    "@walletconnect/sign-client": "2.10.5",
-    "@walletconnect/types": "2.10.5",
-    "@walletconnect/universal-provider": "2.10.5",
-    "@walletconnect/utils": "2.10.5",
+    "@walletconnect/sign-client": "2.10.6",
+    "@walletconnect/types": "2.10.6",
+    "@walletconnect/universal-provider": "2.10.6",
+    "@walletconnect/utils": "2.10.6",
     "events": "^3.3.0"
   },
   "devDependencies": {

--- a/providers/signer-connection/package.json
+++ b/providers/signer-connection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/signer-connection",
   "description": "Signer Connection for WalletConnect Protocol",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -39,9 +39,9 @@
   "dependencies": {
     "@walletconnect/jsonrpc-types": "^1.0.3",
     "@walletconnect/jsonrpc-utils": "^1.0.8",
-    "@walletconnect/sign-client": "2.10.5",
-    "@walletconnect/types": "2.10.5",
-    "@walletconnect/utils": "2.10.5",
+    "@walletconnect/sign-client": "2.10.6",
+    "@walletconnect/types": "2.10.6",
+    "@walletconnect/utils": "2.10.6",
     "events": "^3.3.0",
     "uint8arrays": "^3.1.0"
   }

--- a/providers/universal-provider/package.json
+++ b/providers/universal-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/universal-provider",
   "description": "Universal Provider for WalletConnect Protocol",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {
@@ -45,9 +45,9 @@
     "@walletconnect/jsonrpc-types": "^1.0.2",
     "@walletconnect/jsonrpc-utils": "^1.0.7",
     "@walletconnect/logger": "^2.0.1",
-    "@walletconnect/sign-client": "2.10.5",
-    "@walletconnect/types": "2.10.5",
-    "@walletconnect/utils": "2.10.5",
+    "@walletconnect/sign-client": "2.10.6",
+    "@walletconnect/types": "2.10.6",
+    "@walletconnect/utils": "2.10.6",
     "events": "^3.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Release Checklist

- [x] **Canary Version QA**

  - [x] I have thoroughly tested the release using a canary version: `2.10.6-rc-0.1`
  - [x] The canary version has been verified to work as expected.
  - [x] All major features and changes have been tested and validated.

- [ ] **Web3Modal Team QA**

  - [ ] The Web3Modal team has tested the release for compatibility and functionality.
  - [ ] The release is backwards compatible with Web3Modal.
  - [ ] Any reported issues or bugs have been addressed or documented.

- [ ] **React Native Team QA**

  - [ ] The React Native team has tested the release for compatibility and functionality (if relevant).
  - [ ] The release works correctly in React Native environments and is backwards compatible with Web3Modal React Native.
  - [ ] Any reported issues or bugs have been addressed or documented.

## Related Issues and Pull Requests
* chore: prep for `2.10.5` release by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/3904
* chore(deps): bump @babel/traverse from 7.22.4 to 7.23.2 by @dependabot in https://github.com/WalletConnect/walletconnect-monorepo/pull/3788
* chore(deps-dev): bump axios from 1.4.0 to 1.6.2 by @dependabot in https://github.com/WalletConnect/walletconnect-monorepo/pull/3935
* chore(deps-dev): bump postcss from 8.4.21 to 8.4.31 by @dependabot in https://github.com/WalletConnect/walletconnect-monorepo/pull/3747
* chore(deps-dev): bump browserify-sign from 4.2.1 to 4.2.2 by @dependabot in https://github.com/WalletConnect/walletconnect-monorepo/pull/3839
* feat: deeplink fallback by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/3939
* fix: `pair` flow by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/3944
* fix: URI validation by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/3960
* chore(deps): bump react-devtools-core from 4.27.8 to 4.28.5 by @dependabot in https://github.com/WalletConnect/walletconnect-monorepo/pull/3901
* feat: expose error types by @Tuditi in https://github.com/WalletConnect/walletconnect-monorepo/pull/3992


## Definition of Done

- [x] The release has been tested using a canary version.
- [ ] The release has been reviewed and approved by the Web3Modal team (if relevant).
- [ ] The release has been reviewed and approved by the React Native team (if relevant).
- [ ] All necessary documentation, including API changes or new features, has been updated.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] All tests (unit, integration, etc.) pass successfully.
- [ ] The release has been properly versioned and tagged.
- [ ] The release notes and changelog have been updated to reflect the changes made.

Please ensure that all the items on the checklist have been completed before merging the release.