### PR TITLE
fix: added extra condition in isBrowser function

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -49,7 +49,7 @@ export function isReactNative(): boolean {
 }
 
 export function isBrowser(): boolean {
-  return !isNode() && !!getNavigator();
+  return !isNode() && !!getNavigator() && !!getDocument();
 }
 
 export function getEnvironment(): string {


### PR DESCRIPTION
## Description
* Added an extra condition to isBrowser function as the current one is not enough for react native.
  * `getNavigator` returns `{"product": "ReactNative"}`, and `getDocument` returns `undefined`

The origin of the issue is here: https://github.com/WalletConnect/walletconnect-monorepo/blob/91af38edc2d2a99bae0b5b32f92607d221b74364/packages/utils/src/misc.ts#L406-L407

because `localStorage.getItem` is executed in a RN environment


Another option is to change the `isBrowser` condition to something that also covers react native, such as 

```js
if (!isBrowser() || isReactNative()) return;
```


## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Tested locally in react native

## Fixes/Resolves (Optional)
https://github.com/WalletConnect/web3modal-react-native/issues/116

## Checklist

- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
