### PR TITLE
fix: responding to request on disconnected session

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -381,6 +381,13 @@ export class Engine extends IEngine {
 
   public respond: IEngine["respond"] = async (params) => {
     await this.isInitialized();
+
+    // if the session is already disconnected, we can't respond to the request so we need to delete it
+    await this.isValidSessionTopic(params.topic).catch((error) => {
+      this.cleanupAfterResponse(params);
+      throw error;
+    });
+
     await this.isValidRespond(params);
     const { topic, response } = params;
     const { id } = response;

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -381,13 +381,6 @@ export class Engine extends IEngine {
 
   public respond: IEngine["respond"] = async (params) => {
     await this.isInitialized();
-
-    // if the session is already disconnected, we can't respond to the request so we need to delete it
-    await this.isValidSessionTopic(params.topic).catch((error) => {
-      this.cleanupAfterResponse(params);
-      throw error;
-    });
-
     await this.isValidRespond(params);
     const { topic, response } = params;
     const { id } = response;
@@ -1051,7 +1044,7 @@ export class Engine extends IEngine {
   };
 
   private cleanupAfterResponse = (params: EngineTypes.RespondParams) => {
-    this.deletePendingSessionRequest(params.response.id, { message: "fulfilled", code: 0 });
+    this.deletePendingSessionRequest(params.response?.id, { message: "fulfilled", code: 0 });
     // intentionally delay the emitting of the next pending request a bit
     setTimeout(() => {
       this.sessionRequestQueue.state = ENGINE_QUEUE_STATES.idle;
@@ -1400,7 +1393,11 @@ export class Engine extends IEngine {
       throw new Error(message);
     }
     const { topic, response } = params;
-    await this.isValidSessionTopic(topic);
+    // if the session is already disconnected, we can't respond to the request so we need to delete it
+    await this.isValidSessionTopic(topic).catch((error) => {
+      this.cleanupAfterResponse(params);
+      throw error;
+    });
     if (!isValidResponse(response)) {
       const { message } = getInternalError(
         "MISSING_OR_INVALID",

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -497,6 +497,11 @@ export class Engine extends IEngine {
     this.client.core.storage
       .removeItem(WALLETCONNECT_DEEPLINK_CHOICE)
       .catch((e) => this.client.logger.warn(e));
+    this.getPendingSessionRequests().forEach((r) => {
+      if (r.topic === topic) {
+        this.deletePendingSessionRequest(r.id, getSdkError("USER_DISCONNECTED"));
+      }
+    });
   };
 
   private deleteProposal: EnginePrivate["deleteProposal"] = async (id, expirerHasDeleted) => {

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -6,7 +6,7 @@ import {
 } from "@walletconnect/jsonrpc-utils";
 import { RelayerTypes } from "@walletconnect/types";
 import { getSdkError, parseUri } from "@walletconnect/utils";
-import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
+import { expect, describe, it, vi } from "vitest";
 import SignClient, { WALLETCONNECT_DEEPLINK_CHOICE } from "../../src";
 
 import {
@@ -339,6 +339,88 @@ describe("Sign Client Integration", () => {
             Array.from(Array(expectedRequests).keys()).map(() =>
               clients.A.request({
                 topic,
+                ...TEST_REQUEST_PARAMS,
+              }),
+            ),
+          ]);
+          await throttle(1000);
+          await deleteClients(clients);
+        });
+        /**
+         * this test simulates the case where a session is disconnected
+         * while session request is being approved
+         * the queue should continue operating normally after the `respond` rejection
+         */
+        it("should handle session disconnect durign request approval", async () => {
+          // create the clients and pair them
+          const {
+            clients,
+            sessionA: { topic: topicA },
+          } = await initTwoPairedClients({}, {}, { logger: "error" });
+          const dapp = clients.A as SignClient;
+          const wallet = clients.B as SignClient;
+          const { uri, approval } = await dapp.connect({
+            requiredNamespaces: {},
+          });
+
+          let topicB = "";
+          await Promise.all([
+            new Promise<void>((resolve) => {
+              wallet.once("session_proposal", async (args) => {
+                const { id } = args.params;
+                await wallet.approve({
+                  id,
+                  namespaces: TEST_NAMESPACES,
+                });
+                resolve();
+              });
+            }),
+            wallet.pair({ uri: uri! }),
+            new Promise<void>(async (resolve) => {
+              const session = await approval();
+              topicB = session.topic;
+              resolve();
+            }),
+          ]);
+
+          const expectedRequests = 5;
+          let receivedRequests = 0;
+          await Promise.all([
+            new Promise<void>((resolve) => {
+              clients.B.on("session_request", async (args) => {
+                receivedRequests++;
+                const { id, topic } = args;
+
+                // capture the request on topicB, disconnect and try to approve the request
+                if (topic === topicB) {
+                  await new Promise<void>(async (_resolve) => {
+                    await wallet.disconnect({
+                      topic,
+                      reason: getSdkError("USER_DISCONNECTED"),
+                    });
+                    _resolve();
+                  });
+                }
+                await clients.B.respond({
+                  topic,
+                  response: formatJsonRpcResult(id, "ok"),
+                }).catch((err) => {
+                  // eslint-disable-next-line no-console
+                  console.log("respond error", err);
+                });
+                if (receivedRequests >= expectedRequests) resolve();
+              });
+            }),
+            new Promise<void>((resolve) => {
+              clients.A.request({
+                topic: topicB,
+                ...TEST_REQUEST_PARAMS,
+              });
+              resolve();
+            }),
+            Array.from(Array(expectedRequests).keys()).map(() =>
+              clients.A.request({
+                topic: topicA,
                 ...TEST_REQUEST_PARAMS,
               }),
             ),

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -351,7 +351,7 @@ describe("Sign Client Integration", () => {
          * while session request is being approved
          * the queue should continue operating normally after the `respond` rejection
          */
-        it("should handle session disconnect durign request approval", async () => {
+        it("continue processing requests queue after respond rejection due to disconnected session", async () => {
           // create the clients and pair them
           const {
             clients,


### PR DESCRIPTION
## Description
Fixed a bug where trying to respond  to a session request on already disconnected session was causing the request queue to hang for the remaining expiry of that request

resolves https://github.com/WalletConnect/walletconnect-monorepo/issues/4063

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests
dogfooding in example apps

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
