### PR TITLE
fix: saves `session` object before sending `sessionSettle` request

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -291,6 +291,7 @@ export class Engine extends IEngine {
       this.client.logger.error(error);
       // if the publish fails, delete the session and throw an error
       this.client.session.delete(sessionTopic, getSdkError("USER_DISCONNECTED"));
+      await this.client.core.relayer.unsubscribe(sessionTopic);
       throw error;
     }
 

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -267,12 +267,6 @@ export class Engine extends IEngine {
       ...(sessionProperties && { sessionProperties }),
     };
     await this.client.core.relayer.subscribe(sessionTopic);
-    await this.sendRequest({
-      topic: sessionTopic,
-      method: "wc_sessionSettle",
-      params: sessionSettle,
-      throwOnFailedPublish: true,
-    });
     const session = {
       ...sessionSettle,
       topic: sessionTopic,
@@ -286,6 +280,20 @@ export class Engine extends IEngine {
       controller: selfPublicKey,
     };
     await this.client.session.set(sessionTopic, session);
+    try {
+      await this.sendRequest({
+        topic: sessionTopic,
+        method: "wc_sessionSettle",
+        params: sessionSettle,
+        throwOnFailedPublish: true,
+      });
+    } catch (error) {
+      this.client.logger.error(error);
+      // if the publish fails, delete the session and throw an error
+      this.client.session.delete(sessionTopic, getSdkError("USER_DISCONNECTED"));
+      throw error;
+    }
+
     await this.setExpiry(sessionTopic, calcExpiry(SESSION_EXPIRY));
     return {
       topic: sessionTopic,


### PR DESCRIPTION
## Description
Flipped the execution order of `sessionSettle` & saving the `session` object to avoid potential race condition where `sessionSettle response` was received before the session object was saved resulting in an exception that the session is missing.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding 

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
