### PR TITLE
fix: awaits sending session proposal before returning connection URI

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -206,6 +206,7 @@ export class Engine extends IEngine {
       topic,
       method: "wc_sessionPropose",
       params: proposal,
+      throwOnFailedPublish: true,
     });
 
     const expiry = calcExpiry(FIVE_MINUTES);


### PR DESCRIPTION
## Description
Added an await when sending session proposal so we can avoid cases where publishing is delayed or fails thus rendeing the connection URI unusable 
canary release - `2.11.0-canary-f92166d`

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
