### PR TITLE
refactor: removed required & optional namespaces from `sessionSettle`

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -38,7 +38,6 @@ import {
   createDelayedPromise,
   engineEvent,
   getInternalError,
-  getRequiredNamespacesFromNamespaces,
   getSdkError,
   isConformingNamespaces,
   isExpired,
@@ -181,8 +180,8 @@ export class Engine extends IEngine {
           session.self.publicKey = publicKey;
           const completeSession = {
             ...session,
-            requiredNamespaces: session.requiredNamespaces,
-            optionalNamespaces: session.optionalNamespaces,
+            requiredNamespaces: proposal.requiredNamespaces,
+            optionalNamespaces: proposal.optionalNamespaces,
           };
           await this.client.session.set(session.topic, completeSession);
           await this.setExpiry(session.topic, session.expiry);
@@ -226,9 +225,6 @@ export class Engine extends IEngine {
     const proposal = this.client.proposal.get(id);
     let { pairingTopic, proposer, requiredNamespaces, optionalNamespaces } = proposal;
     pairingTopic = pairingTopic || "";
-    if (!isValidObject(requiredNamespaces)) {
-      requiredNamespaces = getRequiredNamespacesFromNamespaces(namespaces, "approve()");
-    }
 
     const selfPublicKey = await this.client.core.crypto.generateKeyPair();
     const peerPublicKey = proposer.publicKey;
@@ -259,8 +255,6 @@ export class Engine extends IEngine {
     const sessionSettle = {
       relay: { protocol: relayProtocol ?? "irn" },
       namespaces,
-      requiredNamespaces,
-      optionalNamespaces,
       pairingTopic,
       controller: { publicKey: selfPublicKey, metadata: this.client.metadata },
       expiry: calcExpiry(SESSION_EXPIRY),
@@ -276,6 +270,8 @@ export class Engine extends IEngine {
     const session = {
       ...sessionSettle,
       topic: sessionTopic,
+      requiredNamespaces,
+      optionalNamespaces,
       pairingTopic,
       acknowledged: false,
       self: sessionSettle.controller,
@@ -816,16 +812,8 @@ export class Engine extends IEngine {
     const { id, params } = payload;
     try {
       this.isValidSessionSettleRequest(params);
-      const {
-        relay,
-        controller,
-        expiry,
-        namespaces,
-        requiredNamespaces,
-        optionalNamespaces,
-        sessionProperties,
-        pairingTopic,
-      } = payload.params;
+      const { relay, controller, expiry, namespaces, sessionProperties, pairingTopic } =
+        payload.params;
       const session = {
         topic,
         relay,
@@ -833,8 +821,8 @@ export class Engine extends IEngine {
         namespaces,
         acknowledged: true,
         pairingTopic,
-        requiredNamespaces,
-        optionalNamespaces,
+        requiredNamespaces: {},
+        optionalNamespaces: {},
         controller: controller.publicKey,
         self: {
           publicKey: "",

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -504,8 +504,6 @@ describe("Sign Client Integration", () => {
         namespaces: TEST_NAMESPACES,
       });
       expect(requiredNamespaces).toMatchObject({});
-      // requiredNamespaces are built internally from the namespaces during approve()
-      expect(sessionA.requiredNamespaces).toMatchObject(TEST_REQUIRED_NAMESPACES);
       expect(sessionA.requiredNamespaces).toMatchObject(
         clients.B.session.get(sessionA.topic).requiredNamespaces,
       );

--- a/packages/types/src/sign-client/jsonrpc.ts
+++ b/packages/types/src/sign-client/jsonrpc.ts
@@ -39,8 +39,6 @@ export declare namespace JsonRpcTypes {
     wc_sessionSettle: {
       relay: RelayerTypes.ProtocolOptions;
       namespaces: SessionTypes.Namespaces;
-      requiredNamespaces: ProposalTypes.RequiredNamespaces;
-      optionalNamespaces: ProposalTypes.OptionalNamespaces;
       sessionProperties?: ProposalTypes.SessionProperties;
       pairingTopic: string;
       expiry: number;


### PR DESCRIPTION
## Description

...request to match the spec https://specs.walletconnect.com/2.0/specs/clients/sign/rpc-methods#wc_sessionsettle as its redundant to transmit these given they're readily available from the `session proposal` on the dapp side

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
