### PR TITLE
feat: provider request set custom expiry

### DIFF
--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -236,15 +236,16 @@ export class EthereumProvider implements IEthereumProvider {
     return provider;
   }
 
-  public async request<T = unknown>(args: RequestArguments): Promise<T> {
-    return await this.signer.request(args, this.formatChainId(this.chainId));
+  public async request<T = unknown>(args: RequestArguments, expiry?: number): Promise<T> {
+    return await this.signer.request(args, this.formatChainId(this.chainId), expiry);
   }
 
   public sendAsync(
     args: RequestArguments,
     callback: (error: Error | null, response: JsonRpcResult) => void,
+    expiry?: number,
   ): void {
-    this.signer.sendAsync(args, callback, this.formatChainId(this.chainId));
+    this.signer.sendAsync(args, callback, this.formatChainId(this.chainId), expiry);
   }
 
   get connected(): boolean {

--- a/providers/ethereum-provider/test/index.spec.ts
+++ b/providers/ethereum-provider/test/index.spec.ts
@@ -175,7 +175,7 @@ describe("EthereumProvider", function () {
         `Missing or invalid. request() expiry: ${expiryToTest}. Expiry must be a number (in seconds) between ${SESSION_REQUEST_EXPIRY_BOUNDARIES.min} and ${SESSION_REQUEST_EXPIRY_BOUNDARIES.max}`,
       );
     });
-    it("should reject when low expiry is used", async () => {
+    it("should reject when higher than max expiry is used", async () => {
       const expiryToTest = SESSION_REQUEST_EXPIRY_BOUNDARIES.max + 1;
       await expect(
         provider.request({ method: "personal_sign" }, expiryToTest),

--- a/providers/ethereum-provider/test/index.spec.ts
+++ b/providers/ethereum-provider/test/index.spec.ts
@@ -3,7 +3,7 @@ import Web3 from "web3";
 import { BigNumber, providers, utils } from "ethers";
 import { TestNetwork } from "ethereum-test-network";
 
-import { SignClient } from "@walletconnect/sign-client";
+import { SESSION_REQUEST_EXPIRY_BOUNDARIES, SignClient } from "@walletconnect/sign-client";
 
 import {
   ERC20Token__factory,
@@ -48,7 +48,7 @@ describe("EthereumProvider", function () {
       qrModalOptions: {
         themeMode: "dark",
         themeVariables: {
-          "--w3m-z-index": "99",
+          "--wcm-z-index": "99",
         },
       },
       disableProviderPing: true,
@@ -165,6 +165,26 @@ describe("EthereumProvider", function () {
       }),
     ]);
   });
+
+  describe("validation", () => {
+    it("should reject when lower than min expiry is used", async () => {
+      const expiryToTest = SESSION_REQUEST_EXPIRY_BOUNDARIES.min - 1;
+      await expect(
+        provider.request({ method: "personal_sign" }, expiryToTest),
+      ).rejects.toThrowError(
+        `Missing or invalid. request() expiry: ${expiryToTest}. Expiry must be a number (in seconds) between ${SESSION_REQUEST_EXPIRY_BOUNDARIES.min} and ${SESSION_REQUEST_EXPIRY_BOUNDARIES.max}`,
+      );
+    });
+    it("should reject when low expiry is used", async () => {
+      const expiryToTest = SESSION_REQUEST_EXPIRY_BOUNDARIES.max + 1;
+      await expect(
+        provider.request({ method: "personal_sign" }, expiryToTest),
+      ).rejects.toThrowError(
+        `Missing or invalid. request() expiry: ${expiryToTest}. Expiry must be a number (in seconds) between ${SESSION_REQUEST_EXPIRY_BOUNDARIES.min} and ${SESSION_REQUEST_EXPIRY_BOUNDARIES.max}`,
+      );
+    });
+  });
+
   describe("eip155", () => {
     describe("Web3", () => {
       let web3: Web3;

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -71,6 +71,7 @@ export class UniversalProvider implements IUniversalProvider {
   public async request<T = unknown>(
     args: RequestArguments,
     chain?: string | undefined,
+    expiry?: number | undefined,
   ): Promise<T> {
     const [namespace, chainId] = this.validateChain(chain);
 
@@ -84,6 +85,7 @@ export class UniversalProvider implements IUniversalProvider {
       },
       chainId: `${namespace}:${chainId}`,
       topic: this.session.topic,
+      expiry,
     });
   }
 
@@ -91,9 +93,10 @@ export class UniversalProvider implements IUniversalProvider {
     args: RequestArguments,
     callback: (error: Error | null, response: JsonRpcResult) => void,
     chain?: string | undefined,
+    expiry?: number | undefined,
   ): void {
     const id = new Date().getTime();
-    this.request(args, chain)
+    this.request(args, chain, expiry)
       .then((response) => callback(null, formatJsonRpcResult(id, response)))
       .catch((error) => callback(error, undefined as any));
   }

--- a/providers/universal-provider/src/types/misc.ts
+++ b/providers/universal-provider/src/types/misc.ts
@@ -67,6 +67,7 @@ export interface RequestParams {
   request: RequestArguments;
   chainId: string;
   id?: number;
+  expiry?: number;
 }
 
 export interface RequestArguments {


### PR DESCRIPTION
## Description

Added the ability to set custom request expiry when using the providers. The custom expiry was already supported by `sign-client` so only needed to pass down the arguments

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

