### PR TITLE
fix: unique watch label for each topic

### DIFF
--- a/packages/core/src/controllers/subscriber.ts
+++ b/packages/core/src/controllers/subscriber.ts
@@ -122,20 +122,20 @@ export class Subscriber extends ISubscriber {
   public isSubscribed: ISubscriber["isSubscribed"] = async (topic: string) => {
     // topic subscription is already resolved
     if (this.topics.includes(topic)) return true;
-
+    const label = `${this.pendingSubscriptionWatchLabel}_${topic}`;
     // wait for the subscription to resolve
     const exists = await new Promise<boolean>((resolve, reject) => {
       const watch = new Watch();
-      watch.start(this.pendingSubscriptionWatchLabel);
+      watch.start(label);
       const interval = setInterval(() => {
         if (!this.pending.has(topic) && this.topics.includes(topic)) {
           clearInterval(interval);
-          watch.stop(this.pendingSubscriptionWatchLabel);
+          watch.stop(label);
           resolve(true);
         }
-        if (watch.elapsed(this.pendingSubscriptionWatchLabel) >= PENDING_SUB_RESOLUTION_TIMEOUT) {
+        if (watch.elapsed(label) >= PENDING_SUB_RESOLUTION_TIMEOUT) {
           clearInterval(interval);
-          watch.stop(this.pendingSubscriptionWatchLabel);
+          watch.stop(label);
           reject(new Error("Subscription resolution timeout"));
         }
       }, this.pollingInterval);


### PR DESCRIPTION
## Description
To avoid unexpected behaviours when `isSubscribed` is called simultaneously multiple times, now unique subscribtion is used per topic 

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
canary - `2.11.0-canary.0`


## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
