### PR TITLE
chore: add section for reference material in "new chain" template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_chain_to_explorer.md
+++ b/.github/ISSUE_TEMPLATE/new_chain_to_explorer.md
@@ -23,6 +23,12 @@ To get a new chain added to the Explorer, you will need to submit the following:
 6. **[SLIP-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md) coin type**:
    _\* slip44 coin type used in the namespace_
 
+**References**
+To ensure timely processing of your request, please provide the following references:
+
+- [ ] Source of RPC endpoints (e.g. RPC docs): [link]
+- [ ] Source of namespace (if non-EIP155) chain information (particularly chainIds): [link]
+
 **Additional context**
 Add any other context here.
 


### PR DESCRIPTION
## Description

### Context
- For "new chain" requests we often have to go and manually x-reference the indicated chainId and RPC endpoints
- This is unnecessary busy work that the submitter will already know where to look for

### Change
- Adds section for the submitter to provide reference links to source material

