### PR TITLE
fix: handling invalid session state

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -439,7 +439,7 @@ export class Engine extends IEngine {
     } else {
       const { message } = getInternalError(
         "MISMATCHED_TOPIC",
-        `No Session or Pairing topic found: ${topic}`,
+        `Session or pairing topic not found: ${topic}`,
       );
       throw new Error(message);
     }
@@ -1179,7 +1179,7 @@ export class Engine extends IEngine {
     if (!this.client.core.crypto.keychain.has(topic)) {
       const { message } = getInternalError(
         "MISSING_OR_INVALID",
-        `session keychain doesn't exist: ${topic}`,
+        `session topic does not exist in keychain: ${topic}`,
       );
       await this.deleteSession({ topic });
       throw new Error(message);

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -451,7 +451,7 @@ describe("Sign Client Integration", () => {
                 await dapp.ping({ topic });
               } catch (err) {
                 expect(err.message).to.eq(
-                  `Missing or invalid. session keychain doesn't exist: ${topic}`,
+                  `Missing or invalid. session topic does not exist in keychain: ${topic}`,
                 );
               }
               resolve();

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -180,10 +180,10 @@ export interface EnginePrivate {
   onRelayEventUnknownPayload(event: EngineTypes.EventCallback<any>): Promise<void>;
 
   deleteSession(params: {
-    topic: string,
-    expirerHasDeleted?: boolean,
-    id?: number
-    emitEvent?: boolean
+    topic: string;
+    expirerHasDeleted?: boolean;
+    id?: number;
+    emitEvent?: boolean;
   }): Promise<void>;
 
   deleteProposal(id: number, expirerHasDeleted?: boolean): Promise<void>;

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -179,7 +179,12 @@ export interface EnginePrivate {
 
   onRelayEventUnknownPayload(event: EngineTypes.EventCallback<any>): Promise<void>;
 
-  deleteSession(topic: string, expirerHasDeleted?: boolean): Promise<void>;
+  deleteSession(params: {
+    topic: string,
+    expirerHasDeleted?: boolean,
+    id?: number
+    emitEvent?: boolean
+  }): Promise<void>;
 
   deleteProposal(id: number, expirerHasDeleted?: boolean): Promise<void>;
 


### PR DESCRIPTION
## Description
Implemented several improvements in regards to handling invalid state such as having sessions without their corresponding keychain.
- new cleanup step on load to confirm all sessions have their keychains
- additional checks during requests that the session has all required data
- additional emits of `session_delete` to notify dapp that session got deleted

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests
dogfooding

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
