### PR TITLE
fix: synced expiries

### DIFF
--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -34,7 +34,7 @@ import {
   isJsonRpcResult,
   isJsonRpcError,
 } from "@walletconnect/jsonrpc-utils";
-import { FIVE_MINUTES, THIRTY_DAYS } from "@walletconnect/time";
+import { FIVE_MINUTES, THIRTY_DAYS, toMiliseconds } from "@walletconnect/time";
 import EventEmitter from "events";
 import {
   PAIRING_CONTEXT,
@@ -99,6 +99,7 @@ export class Pairing implements IPairing {
       topic,
       symKey,
       relay,
+      expiryTimestamp: expiry,
     });
     await this.pairings.set(topic, pairing);
     await this.core.relayer.subscribe(topic);
@@ -110,7 +111,7 @@ export class Pairing implements IPairing {
   public pair: IPairing["pair"] = async (params) => {
     this.isInitialized();
     this.isValidPair(params);
-    const { topic, symKey, relay } = parseUri(params.uri);
+    const { topic, symKey, relay, expiryTimestamp } = parseUri(params.uri);
     let existingPairing;
     if (this.pairings.keys.includes(topic)) {
       existingPairing = this.pairings.get(topic);
@@ -121,7 +122,7 @@ export class Pairing implements IPairing {
       }
     }
 
-    const expiry = calcExpiry(FIVE_MINUTES);
+    const expiry = expiryTimestamp || calcExpiry(FIVE_MINUTES);
     const pairing = { topic, relay, expiry, active: false };
     await this.pairings.set(topic, pairing);
     this.core.expirer.set(topic, expiry);
@@ -396,6 +397,16 @@ export class Pairing implements IPairing {
     if (!uri?.symKey) {
       const { message } = getInternalError("MISSING_OR_INVALID", `pair() uri#symKey`);
       throw new Error(message);
+    }
+    if (uri?.expiryTimestamp) {
+      const expiration = toMiliseconds(uri?.expiryTimestamp);
+      if (expiration < Date.now()) {
+        const { message } = getInternalError(
+          "EXPIRED",
+          `pair() URI has expired. Please try again with a new connection URI.`,
+        );
+        throw new Error(message);
+      }
     }
   };
 

--- a/packages/core/src/controllers/publisher.ts
+++ b/packages/core/src/controllers/publisher.ts
@@ -50,7 +50,7 @@ export class Publisher extends IPublisher {
         const publish = await createExpiringPromise(
           this.rpcPublish(topic, message, ttl, relay, prompt, tag, id),
           this.publishTimeout,
-          "Failed to publish payload, please try again.",
+          `Failed to publish payload, please try again. id:${id} tag:${tag}`,
         );
         await publish;
         this.removeRequestFromQueue(id);

--- a/packages/core/src/controllers/publisher.ts
+++ b/packages/core/src/controllers/publisher.ts
@@ -20,7 +20,7 @@ export class Publisher extends IPublisher {
   public name = PUBLISHER_CONTEXT;
   public queue = new Map<string, PublisherTypes.Params>();
 
-  private publishTimeout = toMiliseconds(TEN_SECONDS + 5);
+  private publishTimeout = toMiliseconds(TEN_SECONDS + TEN_SECONDS);
   private needsTransportRestart = false;
 
   constructor(public relayer: IRelayer, public logger: Logger) {

--- a/packages/core/src/controllers/publisher.ts
+++ b/packages/core/src/controllers/publisher.ts
@@ -20,7 +20,7 @@ export class Publisher extends IPublisher {
   public name = PUBLISHER_CONTEXT;
   public queue = new Map<string, PublisherTypes.Params>();
 
-  private publishTimeout = toMiliseconds(TEN_SECONDS + TEN_SECONDS);
+  private publishTimeout = toMiliseconds(TEN_SECONDS * 2);
   private needsTransportRestart = false;
 
   constructor(public relayer: IRelayer, public logger: Logger) {

--- a/packages/core/src/controllers/publisher.ts
+++ b/packages/core/src/controllers/publisher.ts
@@ -20,7 +20,7 @@ export class Publisher extends IPublisher {
   public name = PUBLISHER_CONTEXT;
   public queue = new Map<string, PublisherTypes.Params>();
 
-  private publishTimeout = toMiliseconds(TEN_SECONDS);
+  private publishTimeout = toMiliseconds(TEN_SECONDS + 5);
   private needsTransportRestart = false;
 
   constructor(public relayer: IRelayer, public logger: Logger) {

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { EventEmitter } from "events";
 import { JsonRpcProvider } from "@walletconnect/jsonrpc-provider";
 import {

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -77,13 +77,7 @@ export class Relayer extends IRelayer {
   private connectionStatusPollingInterval = 20;
   private staleConnectionErrors = ["socket hang up", "socket stalled"];
   private hasExperiencedNetworkDisruption = false;
-  private requestsInFlight = new Map<
-    number,
-    {
-      promise: Promise<any>;
-      request: RequestArguments<RelayJsonRpc.SubscribeParams>;
-    }
-  >();
+  private requestsInFlight = new Map<number, Promise<unknown>>();
 
   constructor(opts: RelayerOptions) {
     super(opts);
@@ -182,10 +176,7 @@ export class Relayer extends IRelayer {
     this.logger.debug(`Publishing Request Payload`);
     const id = request.id as number;
     const requestPromise = this.provider.request(request);
-    this.requestsInFlight.set(id, {
-      promise: requestPromise,
-      request,
-    });
+    this.requestsInFlight.set(id, requestPromise);
     try {
       await this.toEstablishConnection();
       const result = await requestPromise;
@@ -223,15 +214,7 @@ export class Relayer extends IRelayer {
   public async transportClose() {
     // wait for all requests to finish before closing the transport
     if (this.requestsInFlight.size > 0) {
-      const identifier = Math.random().toString(36).substring(7);
-      console.log(
-        `${identifier} | ${this.core.name} - waiting for requests to finish: ${this.requestsInFlight.size}`,
-      );
-      this.requestsInFlight.forEach(async (value) => {
-        console.log(`${identifier} | ${this.core.name} - waiting for request`, value.request);
-        await value.promise;
-      });
-      console.log(`${identifier} | ${this.core.name} - requests finished`);
+      await Promise.all(this.requestsInFlight.values());
     }
 
     this.transportExplicitlyClosed = true;

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -222,6 +222,7 @@ export class Relayer extends IRelayer {
   public async transportClose() {
     // wait for all requests to finish before closing the transport
     if (this.requestsInFlight.size > 0) {
+      this.logger.debug("Waiting for all in-flight requests to finish before closing transport...");
       this.requestsInFlight.forEach(async (value) => {
         await value.promise;
       });

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -213,8 +213,8 @@ export class Relayer extends IRelayer {
   public async transportClose() {
     // wait for all requests to finish before closing the transport
     if (this.requestsInFlight.size > 0) {
-      this.logger.warn(`waiting for requests to finish: ${this.requestsInFlight.size}`);
-      await Promise.all(this.requestsInFlight.values());
+      console.log(`waiting for requests to finish: ${this.requestsInFlight.size}`);
+      await Promise.all(this.requestsInFlight.values()).catch((error) => this.logger.error(error));
     }
 
     this.transportExplicitlyClosed = true;

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -213,6 +213,7 @@ export class Relayer extends IRelayer {
   public async transportClose() {
     // wait for all requests to finish before closing the transport
     if (this.requestsInFlight.size > 0) {
+      // eslint-disable-next-line no-console
       console.log(`waiting for requests to finish: ${this.requestsInFlight.size}`);
       await Promise.all(this.requestsInFlight.values()).catch((error) => this.logger.error(error));
     }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -87,6 +87,7 @@ export class Core extends ICore {
     this.pairing = new Pairing(this, this.logger);
     this.verify = new Verify(this.projectId || "", this.logger);
     this.echoClient = new EchoClient(this.projectId || "", this.logger);
+    this.name = opts?.name || CORE_DEFAULT.name;
   }
 
   get context() {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -87,7 +87,6 @@ export class Core extends ICore {
     this.pairing = new Pairing(this, this.logger);
     this.verify = new Verify(this.projectId || "", this.logger);
     this.echoClient = new EchoClient(this.projectId || "", this.logger);
-    this.name = opts?.name || CORE_DEFAULT.name;
   }
 
   get context() {

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -353,7 +353,7 @@ describe("Sign Client Integration", () => {
          * while session request is being approved
          * the queue should continue operating normally after the `respond` rejection
          */
-        it("continue processing requests queue after respond rejection due to disconnected session", async () => {
+        it.skip("continue processing requests queue after respond rejection due to disconnected session", async () => {
           // create the clients and pair them
           const {
             clients,

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -25,7 +25,6 @@ import {
   initTwoPairedClients,
   TEST_CONNECT_PARAMS,
 } from "../shared";
-import { toMiliseconds } from "@walletconnect/time";
 
 describe("Sign Client Integration", () => {
   it("init", async () => {
@@ -561,8 +560,12 @@ describe("Sign Client Integration", () => {
 
       await Promise.all([
         new Promise<void>((resolve) => {
-          (clients.B as SignClient).once("session_request", (payload) => {
+          (clients.B as SignClient).once("session_request", async (payload) => {
             expect(payload.params.expiry).to.be.approximately(calcExpiry(expiry), 1000);
+            await clients.B.respond({
+              topic,
+              response: formatJsonRpcResult(payload.id, "test response"),
+            });
             resolve();
           });
         }),
@@ -611,7 +614,7 @@ describe("Sign Client Integration", () => {
       };
       await Promise.all([
         new Promise<void>((resolve) => {
-          clients.B.once("session_request", (payload) => {
+          clients.B.once("session_request", async (payload) => {
             const { params } = payload;
             const session = clients.B.session.get(payload.topic);
             expect(params).toMatchObject(testRequestProps);
@@ -621,6 +624,10 @@ describe("Sign Client Integration", () => {
               ),
             ).to.exist;
             expect(session.requiredNamespaces[TEST_AVALANCHE_CHAIN]).to.exist;
+            await clients.B.respond({
+              topic,
+              response: formatJsonRpcResult(payload.id, "test response"),
+            });
             resolve();
           });
         }),

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -435,6 +435,9 @@ describe("Sign Client Integration", () => {
           await deleteClients(clients);
         });
         it("should handle invalid session state with missing keychain", async () => {
+          process.on("unhandledRejection", (err) => {
+            console.error("ping failed", err);
+          });
           const {
             clients,
             sessionA: { topic },

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -419,12 +419,17 @@ describe("Sign Client Integration", () => {
               });
               resolve();
             }),
-            Array.from(Array(expectedRequests).keys()).map(() =>
-              clients.A.request({
-                topic: topicA,
-                ...TEST_REQUEST_PARAMS,
-              }),
-            ),
+            new Promise<void>(async (resolve) => {
+              await Promise.all([
+                ...Array.from(Array(expectedRequests).keys()).map(() =>
+                  clients.A.request({
+                    topic: topicA,
+                    ...TEST_REQUEST_PARAMS,
+                  }),
+                ),
+              ]);
+              resolve();
+            }),
           ]);
           await throttle(1000);
           await deleteClients(clients);

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -560,7 +560,10 @@ describe("Sign Client Integration", () => {
       await Promise.all([
         new Promise<void>((resolve) => {
           (clients.B as SignClient).once("session_request", async (payload) => {
-            expect(payload.params.expiry).to.be.approximately(calcExpiry(expiry), 1000);
+            expect(payload.params.request.expiryTimestamp).to.be.approximately(
+              calcExpiry(expiry),
+              1000,
+            );
             await clients.B.respond({
               topic,
               response: formatJsonRpcResult(payload.id, "test response"),

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -337,11 +337,12 @@ describe("Sign Client Integration", () => {
                 if (receivedRequests >= expectedRequests) resolve();
               });
             }),
-            Array.from(Array(expectedRequests).keys()).map(() =>
-              clients.A.request({
-                topic,
-                ...TEST_REQUEST_PARAMS,
-              }),
+            Array.from(Array(expectedRequests).keys()).map(
+              async () =>
+                await clients.A.request({
+                  topic,
+                  ...TEST_REQUEST_PARAMS,
+                }),
             ),
           ]);
           await throttle(1000);

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -165,7 +165,6 @@ describe("Sign Client Integration", () => {
       // 7. attempt to pair again with the same URI
       // 8. should receive an error the pairing already exists
       await expect(wallet.pair({ uri })).rejects.toThrowError();
-
       await deleteClients({ A: dapp, B: wallet });
     });
   });
@@ -352,7 +351,7 @@ describe("Sign Client Integration", () => {
          * while session request is being approved
          * the queue should continue operating normally after the `respond` rejection
          */
-        it.skip("continue processing requests queue after respond rejection due to disconnected session", async () => {
+        it("continue processing requests queue after respond rejection due to disconnected session", async () => {
           // create the clients and pair them
           const {
             clients,

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -410,24 +410,23 @@ describe("Sign Client Integration", () => {
                   // eslint-disable-next-line no-console
                   console.log("respond error", err);
                 });
-                if (receivedRequests >= expectedRequests) resolve();
+                if (receivedRequests > expectedRequests) resolve();
               });
-            }),
-            new Promise<void>(async (resolve) => {
-              await clients.A.request({
-                topic: topicB,
-                ...TEST_REQUEST_PARAMS,
-              });
-              resolve();
             }),
             new Promise<void>(async (resolve) => {
               await Promise.all([
-                ...Array.from(Array(expectedRequests).keys()).map(() =>
-                  clients.A.request({
-                    topic: topicA,
-                    ...TEST_REQUEST_PARAMS,
-                  }),
+                ...Array.from(Array(expectedRequests).keys()).map(
+                  async () =>
+                    await clients.A.request({
+                      topic: topicA,
+                      ...TEST_REQUEST_PARAMS,
+                    }),
                 ),
+                clients.A.request({
+                  topic: topicB,
+                  ...TEST_REQUEST_PARAMS,
+                  // eslint-disable-next-line no-console
+                }).catch((e) => console.error(e)), // capture the error from the session disconnect
               ]);
               resolve();
             }),
@@ -436,9 +435,6 @@ describe("Sign Client Integration", () => {
           await deleteClients(clients);
         });
         it("should handle invalid session state with missing keychain", async () => {
-          process.on("unhandledRejection", (err) => {
-            console.error("ping failed", err);
-          });
           const {
             clients,
             sessionA: { topic },

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -413,8 +413,8 @@ describe("Sign Client Integration", () => {
                 if (receivedRequests >= expectedRequests) resolve();
               });
             }),
-            new Promise<void>((resolve) => {
-              clients.A.request({
+            new Promise<void>(async (resolve) => {
+              await clients.A.request({
                 topic: topicB,
                 ...TEST_REQUEST_PARAMS,
               });
@@ -447,7 +447,6 @@ describe("Sign Client Integration", () => {
           const sessions = dapp.session.getAll();
           expect(sessions.length).to.eq(1);
           await dapp.core.crypto.keychain.del(topic);
-
           await Promise.all([
             new Promise<void>((resolve) => {
               dapp.on("session_delete", async (args) => {
@@ -571,8 +570,8 @@ describe("Sign Client Integration", () => {
             resolve();
           });
         }),
-        new Promise<void>((resolve) => {
-          clients.A.request({ ...TEST_REQUEST_PARAMS, topic, expiry });
+        new Promise<void>(async (resolve) => {
+          await clients.A.request({ ...TEST_REQUEST_PARAMS, topic, expiry });
           resolve();
         }),
       ]);
@@ -629,8 +628,8 @@ describe("Sign Client Integration", () => {
             resolve();
           });
         }),
-        new Promise<void>((resolve) => {
-          clients.A.request({ ...testRequestProps, topic });
+        new Promise<void>(async (resolve) => {
+          await clients.A.request({ ...testRequestProps, topic });
           resolve();
         }),
       ]);

--- a/packages/sign-client/test/shared/init.ts
+++ b/packages/sign-client/test/shared/init.ts
@@ -22,12 +22,14 @@ export async function initTwoClients(
   sharedClientOpts: SignClientTypes.Options = {},
 ) {
   const A = await SignClient.init({
+    name: "A",
     ...TEST_SIGN_CLIENT_OPTIONS_A,
     ...sharedClientOpts,
     ...clientOptsA,
   });
 
   const B = await SignClient.init({
+    name: "B",
     ...TEST_SIGN_CLIENT_OPTIONS_B,
     ...sharedClientOpts,
     ...clientOptsB,
@@ -41,7 +43,7 @@ export async function initTwoPairedClients(
   clientOptsB: SignClientTypes.Options = {},
   sharedClientOpts: SignClientTypes.Options = {},
 ) {
-  let clients;
+  let clients: Clients;
   let pairingA;
   let sessionA;
   let retries = 0;
@@ -50,10 +52,10 @@ export async function initTwoPairedClients(
       throw new Error("Could not pair clients");
     }
     try {
-      clients = await createExpiringPromise(
+      clients = (await createExpiringPromise(
         initTwoClients(clientOptsA, clientOptsB, sharedClientOpts),
         TESTS_CONNECT_TIMEOUT,
-      );
+      )) as Clients;
 
       const settled: any = await createExpiringPromise(
         testConnectMethod(clients),

--- a/packages/types/src/sign-client/client.ts
+++ b/packages/types/src/sign-client/client.ts
@@ -39,6 +39,7 @@ export declare namespace SignClientTypes {
     } & BaseEventArgs<{
       request: { method: string; params: any };
       chainId: string;
+      expiry?: number;
     }>;
     session_request_sent: {
       request: { method: string; params: any };

--- a/packages/types/src/sign-client/client.ts
+++ b/packages/types/src/sign-client/client.ts
@@ -37,7 +37,7 @@ export declare namespace SignClientTypes {
     session_request: {
       verifyContext: Verify.Context;
     } & BaseEventArgs<{
-      request: { method: string; params: any; expiryTimestamp?: number; };
+      request: { method: string; params: any; expiryTimestamp?: number };
       chainId: string;
     }>;
     session_request_sent: {

--- a/packages/types/src/sign-client/client.ts
+++ b/packages/types/src/sign-client/client.ts
@@ -37,9 +37,8 @@ export declare namespace SignClientTypes {
     session_request: {
       verifyContext: Verify.Context;
     } & BaseEventArgs<{
-      request: { method: string; params: any };
+      request: { method: string; params: any; expiryTimestamp?: number; };
       chainId: string;
-      expiry?: number;
     }>;
     session_request_sent: {
       request: { method: string; params: any };

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -124,8 +124,12 @@ export declare namespace EngineTypes {
   type AcknowledgedPromise = Promise<{ acknowledged: () => Promise<void> }>;
 
   interface RpcOpts {
-    req: RelayerTypes.PublishOptions;
-    res: RelayerTypes.PublishOptions;
+    req: RelayerTypes.PublishOptions & {
+      ttl: number;
+    };
+    res: RelayerTypes.PublishOptions & {
+      ttl: number;
+    };
   }
 
   type RpcOptsMap = Record<JsonRpcTypes.WcMethod, RpcOpts>;

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -43,6 +43,7 @@ export declare namespace EngineTypes {
     topic: string;
     symKey: string;
     relay: RelayerTypes.ProtocolOptions;
+    expiryTimestamp?: number;
   }
 
   interface EventCallback<T extends JsonRpcRequest | JsonRpcResponse> {

--- a/packages/types/src/sign-client/jsonrpc.ts
+++ b/packages/types/src/sign-client/jsonrpc.ts
@@ -35,6 +35,7 @@ export declare namespace JsonRpcTypes {
         publicKey: string;
         metadata: SignClientTypes.Metadata;
       };
+      expiryTimestamp?: number;
     };
     wc_sessionSettle: {
       relay: RelayerTypes.ProtocolOptions;
@@ -61,6 +62,7 @@ export declare namespace JsonRpcTypes {
         method: string;
         params: any;
       };
+      expiryTimestamp?: number;
       chainId: string;
     };
     wc_sessionEvent: {

--- a/packages/types/src/sign-client/jsonrpc.ts
+++ b/packages/types/src/sign-client/jsonrpc.ts
@@ -61,8 +61,8 @@ export declare namespace JsonRpcTypes {
       request: {
         method: string;
         params: any;
+        expiryTimestamp?: number;
       };
-      expiryTimestamp?: number;
       chainId: string;
     };
     wc_sessionEvent: {

--- a/packages/types/src/sign-client/pendingRequest.ts
+++ b/packages/types/src/sign-client/pendingRequest.ts
@@ -1,11 +1,11 @@
 import { IStore, Verify } from "../core";
-import { JsonRpcTypes } from "./jsonrpc";
+import { SignClientTypes } from "./";
 
 export declare namespace PendingRequestTypes {
   export interface Struct {
     topic: string;
     id: number;
-    params: JsonRpcTypes.RequestParams["wc_sessionRequest"];
+    params: SignClientTypes.EventArguments["session_request"]["params"];
     verifyContext: Verify.Context;
   }
 }

--- a/packages/types/src/sign-client/proposal.ts
+++ b/packages/types/src/sign-client/proposal.ts
@@ -17,7 +17,8 @@ export declare namespace ProposalTypes {
 
   export interface Struct {
     id: number;
-    expiry: number;
+    expiry?: number; // deprecated in favour of expiryTimespamp
+    expiryTimestamp: number;
     relays: RelayerTypes.ProtocolOptions[];
     proposer: {
       publicKey: string;

--- a/packages/types/src/sign-client/proposal.ts
+++ b/packages/types/src/sign-client/proposal.ts
@@ -17,7 +17,10 @@ export declare namespace ProposalTypes {
 
   export interface Struct {
     id: number;
-    expiry?: number; // deprecated in favour of expiryTimespamp
+    /**
+     * @deprecated in favor of expiryTimestamp
+     */
+    expiry?: number;
     expiryTimestamp: number;
     relays: RelayerTypes.ProtocolOptions[];
     proposer: {

--- a/packages/utils/src/uri.ts
+++ b/packages/utils/src/uri.ts
@@ -34,6 +34,9 @@ export function parseUri(str: string): EngineTypes.UriParameters {
     version: parseInt(requiredValues[1], 10),
     symKey: queryParams.symKey as string,
     relay: parseRelayParams(queryParams),
+    expiryTimestamp: queryParams.expiryTimestamp
+      ? parseInt(queryParams.expiryTimestamp as string, 10)
+      : undefined,
   };
   return result;
 }
@@ -60,6 +63,7 @@ export function formatUri(params: EngineTypes.UriParameters): string {
     qs.stringify({
       symKey: params.symKey,
       ...formatRelayParams(params.relay),
+      expiryTimestamp: params.expiryTimestamp,
     })
   );
 }

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -66,22 +66,7 @@ describe("UniversalProvider", function () {
   afterAll(async () => {
     // close test network
     await testNetwork.close();
-    // disconnect provider
-    await Promise.all([
-      new Promise<void>((resolve) => {
-        provider.on("session_delete", () => {
-          resolve();
-        });
-      }),
-      new Promise<void>(async (resolve) => {
-        await walletClient.disconnect();
-        resolve();
-      }),
-    ]);
-    expect(walletClient.client?.session.values.length).to.eql(0);
-    await throttle(1_000);
-    await provider.client.core.relayer.transportClose();
-    await walletClient.client?.core.relayer.transportClose();
+    await deleteProviders({ A: provider, B: walletClient.provider });
   });
 
   describe("eip155", () => {


### PR DESCRIPTION
## Description
Implemented synced expiries for session proposals and session requests. Synced expiries are defined by the sending peer and used by both sending & receiving peers. If no `expiryTimestamp` is received, default values are used.

Additionally
- patched a few flaky tests to always await async requests
- increased publish<->ack timeout to 20s
- implemented mechanism to wait for all requests in flight (that wait for a relay ack) to complete before closing transport 
- implemented cleanup on sent pending requests (history store) when the session is disconnected

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests
dogfooding
https://github.com/WalletConnect/web-examples/pull/432

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
