### PR TITLE
feat: cloudwatch metrics tags

### DIFF
--- a/packages/sign-client/test/shared/metrics.ts
+++ b/packages/sign-client/test/shared/metrics.ts
@@ -1,5 +1,7 @@
 import { CloudWatch, PutMetricDataCommandInput } from "@aws-sdk/client-cloudwatch";
 
+const tag = process.env.TAG || "default";
+
 export const uploadCanaryResultsToCloudWatch = async (
   env: string,
   region: string,
@@ -23,6 +25,10 @@ export const uploadCanaryResultsToCloudWatch = async (
           Name: "Region",
           Value: region,
         },
+        {
+          Name: "Tag",
+          Value: tag,
+        },
       ],
       Unit: "Count",
       Value: isTestPassed ? 1 : 0,
@@ -38,6 +44,10 @@ export const uploadCanaryResultsToCloudWatch = async (
         {
           Name: "Region",
           Value: region,
+        },
+        {
+          Name: "Tag",
+          Value: tag,
         },
       ],
       Unit: "Count",
@@ -58,6 +68,10 @@ export const uploadCanaryResultsToCloudWatch = async (
           Name: "Region",
           Value: region,
         },
+        {
+          Name: "Tag",
+          Value: tag,
+        },
       ],
       Unit: "Milliseconds",
       Value: testDurationMs,
@@ -77,6 +91,10 @@ export const uploadCanaryResultsToCloudWatch = async (
         {
           Name: "Region",
           Value: region,
+        },
+        {
+          Name: "Tag",
+          Value: tag,
         },
       ],
       Unit: "Milliseconds",
@@ -124,6 +142,10 @@ export const uploadLoadTestConnectionDataToCloudWatch = async (
             Name: "Target",
             Value: target,
           },
+          {
+            Name: "Tag",
+            Value: tag,
+          },
         ],
         Unit: "Count",
         Value: successfullyConnected,
@@ -135,6 +157,10 @@ export const uploadLoadTestConnectionDataToCloudWatch = async (
           {
             Name: "Target",
             Value: target,
+          },
+          {
+            Name: "Tag",
+            Value: tag,
           },
         ],
         Unit: "Count",
@@ -148,6 +174,10 @@ export const uploadLoadTestConnectionDataToCloudWatch = async (
             Name: "Target",
             Value: target,
           },
+          {
+            Name: "Tag",
+            Value: tag,
+          },
         ],
         Unit: "Milliseconds",
         Value: averagePairingTimeMs,
@@ -159,6 +189,10 @@ export const uploadLoadTestConnectionDataToCloudWatch = async (
           {
             Name: "Target",
             Value: target,
+          },
+          {
+            Name: "Tag",
+            Value: tag,
           },
         ],
         Unit: "Milliseconds",


### PR DESCRIPTION
> Creating a release? Please use the [Release PR Template](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/.github/pr_template_release.md) instead.

## Description

This adds the `Tag` dimension to all metrics exported by the sign client canary. It's a requirement for the relay to be able to run multiple canaries with different configurations and be able to distinguish resulting metrics.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Untested.

## Fixes/Resolves (Optional)

Please list any issues that are fixed by this PR in the format `#<issue number>`. If it fixes multiple issues, please put each issue in a separate line. If this Pull Request does not fix any issues, please delete this section.

## Examples/Screenshots (Optional)

Please attach a screenshot or screen recording of features/fixes you've implemented to verify your changes. Please also note any relevant details for your configuration. If your changes do not affect the UI, please delete this section.

Use this table template to show examples of your changes:

| Before       | After        |
| ------------ | ------------ |
| Content Cell | Content Cell |
| Content Cell | Content Cell |

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
