### PR TITLE
fix: undefined namespaces

### DIFF
--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -186,10 +186,9 @@ export class UniversalProvider implements IUniversalProvider {
         .then((session) => {
           this.session = session;
           // assign namespaces from session if not already defined
-          if (!this.namespaces) {
-            this.namespaces = populateNamespacesChains(session.namespaces) as NamespaceConfig;
-            this.persist("namespaces", this.namespaces);
-          }
+          const approved = populateNamespacesChains(session.namespaces) as NamespaceConfig;
+          this.namespaces = mergeRequiredOptionalNamespaces(this.namespaces, approved);
+          this.persist("namespaces", this.namespaces);
         })
         .catch((error) => {
           if (error.message !== PROPOSAL_EXPIRY_MESSAGE) {
@@ -373,6 +372,7 @@ export class UniversalProvider implements IUniversalProvider {
           convertChainIdToNumber(requestChainId) !== convertChainIdToNumber(payloadChainId)
             ? `${namespace}:${convertChainIdToNumber(payloadChainId)}`
             : requestChainId;
+
         this.onChainChanged(chainIdToProcess);
       } else {
         this.events.emit(event.name, event.data);
@@ -467,12 +467,21 @@ export class UniversalProvider implements IUniversalProvider {
 
     const [namespace, chainId] = this.validateChain(caip2Chain);
 
+    if (!chainId) return;
+
     if (!internal) {
       this.getProvider(namespace).setDefaultChain(chainId);
     }
 
-    (this.namespaces[namespace] ?? this.namespaces[`${namespace}:${chainId}`]).defaultChain =
-      chainId;
+    if (this.namespaces[namespace]) {
+      this.namespaces[namespace].defaultChain = chainId;
+    } else if (this.namespaces[`${namespace}:${chainId}`]) {
+      this.namespaces[`${namespace}:${chainId}`].defaultChain = chainId;
+    } else {
+      // @ts-ignore
+      this.namespaces[`${namespace}:${chainId}`] = { defaultChain: chainId };
+    }
+
     this.persist("namespaces", this.namespaces);
     this.events.emit("chainChanged", chainId);
   }

--- a/providers/universal-provider/src/utils/misc.ts
+++ b/providers/universal-provider/src/utils/misc.ts
@@ -125,10 +125,12 @@ export function populateNamespacesChains(
   return parsedNamespaces;
 }
 
-export function convertChainIdToNumber(chainId: string | number): number {
+export function convertChainIdToNumber(chainId: string | number): number | string {
   if (typeof chainId === "number") return chainId;
   if (chainId.includes("0x")) {
     return parseInt(chainId, 16);
   }
-  return chainId.includes(":") ? Number(chainId.split(":")[1]) : Number(chainId);
+
+  chainId = chainId.includes(":") ? chainId.split(":")[1] : chainId;
+  return isNaN(Number(chainId)) ? chainId : Number(chainId);
 }

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -848,6 +848,159 @@ describe("UniversalProvider", function () {
           expectedChainId: chains[1],
         });
       });
+      it("should handle switch chain event on non required namespaces", async () => {
+        const dapp = await UniversalProvider.init({
+          ...TEST_PROVIDER_OPTS,
+          name: "dapp",
+        });
+        const wallet = await UniversalProvider.init({
+          ...TEST_PROVIDER_OPTS,
+          name: "wallet",
+        });
+        const chains = ["eip155:1", "eip155:2"];
+        const solanaChains = [
+          "solana:91b171bb158e2d3848fa23a9f1c25182",
+          "solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ",
+        ];
+        await testConnectMethod(
+          {
+            dapp,
+            wallet,
+          },
+          {
+            requiredNamespaces: {
+              "eip155:1": {
+                methods,
+                events,
+              },
+            },
+            optionalNamespaces: {},
+            namespaces: {
+              eip155: {
+                accounts: chains.map((chain) => `${chain}:${walletAddress}`),
+                methods,
+                events,
+              },
+              solana: {
+                accounts: solanaChains.map((chain) => `${chain}:${walletAddress}`),
+                methods,
+                events,
+              },
+            },
+          },
+        );
+        const expectedChainId = solanaChains[1];
+        await Promise.all([
+          new Promise<void>((resolve) => {
+            dapp.on("chainChanged", (chainId: any) => {
+              expect(chainId).to.eql(expectedChainId.split(":")[1]);
+              resolve();
+            });
+          }),
+          wallet.client.emit({
+            topic: dapp.session?.topic || "",
+            event: {
+              name: "chainChanged",
+              data: expectedChainId,
+            },
+            chainId: expectedChainId,
+          }),
+        ]);
+
+        await validateProvider({
+          provider: dapp,
+          chains: solanaChains,
+          addresses: [walletAddress],
+          defaultNamespace: "solana",
+          expectedChainId,
+        });
+      });
+      it("should handle requesting x & y as required & optional chains while wallet approves x + y + z", async () => {
+        const dapp = await UniversalProvider.init({
+          ...TEST_PROVIDER_OPTS,
+          name: "dapp",
+        });
+        const wallet = await UniversalProvider.init({
+          ...TEST_PROVIDER_OPTS,
+          name: "wallet",
+        });
+        const chains = {
+          eip155: ["eip155:1", "eip155:2"],
+          solana: [
+            "solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ",
+            "solana:91b171bb158e2d3848fa23a9f1c25182",
+          ],
+          cosmos: ["cosmos:hub1", "cosmos:hub2"],
+        };
+
+        await testConnectMethod(
+          {
+            dapp,
+            wallet,
+          },
+          {
+            requiredNamespaces: {
+              eip155: {
+                chains: chains.eip155,
+                methods,
+                events,
+              },
+            },
+            optionalNamespaces: {
+              solana: {
+                chains: chains.solana,
+                methods,
+                events,
+              },
+            },
+            namespaces: {
+              eip155: {
+                accounts: chains.eip155.map((chain) => `${chain}:${walletAddress}`),
+                methods,
+                events,
+              },
+              solana: {
+                accounts: chains.solana.map((chain) => `${chain}:${walletAddress}`),
+                methods,
+                events,
+              },
+              cosmos: {
+                accounts: chains.cosmos.map((chain) => `${chain}:${walletAddress}`),
+                methods,
+                events,
+              },
+            },
+          },
+        );
+        const expectedChainId = chains.solana[1];
+        await Promise.all([
+          new Promise<void>((resolve) => {
+            dapp.on("chainChanged", (chainId: any) => {
+              expect(chainId).to.eql(expectedChainId.split(":")[1]);
+              resolve();
+            });
+          }),
+          wallet.client.emit({
+            topic: dapp.session?.topic || "",
+            event: {
+              name: "chainChanged",
+              data: expectedChainId,
+            },
+            chainId: expectedChainId,
+          }),
+        ]);
+
+        // validate that provider is created for each approed namespace
+        expect(Object.keys(dapp.rpcProviders).length).to.eql(Object.keys(chains).length);
+
+        await validateProvider({
+          provider: dapp,
+          chains: chains.solana,
+          addresses: [walletAddress],
+          defaultNamespace: "solana",
+          expectedChainId,
+        });
+      });
     });
   });
 
@@ -948,15 +1101,18 @@ const validateProvider = async (params: ValidateProviderParams) => {
   if (addresses) {
     expect(accounts).to.toMatchObject(addresses);
   }
-  const chain = await provider.request({ method: "eth_chainId" });
-  expect(chain).to.not.be.null;
+
   if (chains) {
-    expect(chains).toContain(`${defaultNamespace}:${chain}`);
     expect(Object.keys(provider.rpcProviders[defaultNamespace].httpProviders)).to.toMatchObject(
       chains.map((c) => c.split(":")[1]),
     );
   }
   if (expectedChainId) {
-    expect(expectedChainId).to.equal(`${defaultNamespace}:${chain}`);
+    const chainId = provider.rpcProviders[defaultNamespace].getDefaultChain();
+    expect(chainId).to.not.be.null;
+    expect(expectedChainId).to.equal(`${defaultNamespace}:${chainId}`);
+    if (chains) {
+      expect(chains).to.include(`${defaultNamespace}:${chainId}`);
+    }
   }
 };


### PR DESCRIPTION
## Description
Fixed a bug where `universal-provider` didn't handle additional approved namespaces. i.e. anything extra than the required & optional was ignored 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests 
`2.11.0-canary-fce34df1`

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
