### PR TITLE
fix: duplicate connection

### DIFF
--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -180,13 +180,14 @@ export class Relayer extends IRelayer {
   public request = async (request: RequestArguments<RelayJsonRpc.SubscribeParams>) => {
     this.logger.debug(`Publishing Request Payload`);
     const id = request.id as number;
-    const requestPromise = this.provider.request(request);
-    this.requestsInFlight.set(id, {
-      promise: requestPromise,
-      request,
-    });
+
     try {
       await this.toEstablishConnection();
+      const requestPromise = this.provider.request(request);
+      this.requestsInFlight.set(id, {
+        promise: requestPromise,
+        request,
+      });
       const result = await requestPromise;
       return result;
     } catch (e) {

--- a/packages/sign-client/test/sdk/transport.spec.ts
+++ b/packages/sign-client/test/sdk/transport.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { initTwoClients, testConnectMethod, deleteClients, throttle } from "../shared";
 
 describe("Sign Client Transport Tests", () => {
@@ -57,13 +57,44 @@ describe("Sign Client Transport Tests", () => {
       ]);
       await deleteClients(clients);
     });
-    it("should automatically start transport on request after being closed", async () => {
+    it("should automatically start transport on request after being closed. Case 1", async () => {
       const clients = await initTwoClients();
       const {
         sessionA: { topic },
       } = await testConnectMethod(clients);
       await clients.A.core.relayer.transportClose();
       await throttle(2000);
+      await Promise.all([
+        new Promise((resolve) => {
+          clients.B.on("session_ping", (event: any) => {
+            resolve(event);
+          });
+        }),
+        new Promise((resolve) => {
+          clients.A.on("session_ping", (event: any) => {
+            resolve(event);
+          });
+        }),
+        new Promise(async (resolve) => {
+          await clients.A.ping({ topic });
+          await clients.B.ping({ topic });
+          resolve(true);
+        }),
+      ]);
+      await deleteClients(clients);
+    });
+    it("should automatically start transport on request after being closed. Case 2", async () => {
+      const clients = await initTwoClients();
+
+      await throttle(12000);
+
+      // both clients should be auto disconnected
+      expect(clients.A.core.relayer.connected).toBe(false);
+      expect(clients.B.core.relayer.connected).toBe(false);
+
+      const {
+        sessionA: { topic },
+      } = await testConnectMethod(clients);
       await Promise.all([
         new Promise((resolve) => {
           clients.B.on("session_ping", (event: any) => {

--- a/packages/sign-client/test/sdk/transport.spec.ts
+++ b/packages/sign-client/test/sdk/transport.spec.ts
@@ -57,5 +57,31 @@ describe("Sign Client Transport Tests", () => {
       ]);
       await deleteClients(clients);
     });
+    it("should automatically start transport on request after being closed", async () => {
+      const clients = await initTwoClients();
+      const {
+        sessionA: { topic },
+      } = await testConnectMethod(clients);
+      await clients.A.core.relayer.transportClose();
+      await throttle(2000);
+      await Promise.all([
+        new Promise((resolve) => {
+          clients.B.on("session_ping", (event: any) => {
+            resolve(event);
+          });
+        }),
+        new Promise((resolve) => {
+          clients.A.on("session_ping", (event: any) => {
+            resolve(event);
+          });
+        }),
+        new Promise(async (resolve) => {
+          await clients.A.ping({ topic });
+          await clients.B.ping({ topic });
+          resolve(true);
+        }),
+      ]);
+      await deleteClients(clients);
+    });
   });
 });


### PR DESCRIPTION
## Description
Resolved a bug where where `provider.request` can open a connection a long with `this.toEstablishConnection` as from it's POV, socket is invactive. In this scenario only 1 socket must be created

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
