### PR TITLE
fix: reset iframe reference even if it already exist, and restart queue

### DIFF
--- a/packages/core/src/controllers/verify.ts
+++ b/packages/core/src/controllers/verify.ts
@@ -129,16 +129,19 @@ export class Verify extends IVerify {
     let iframeOnLoadResolve: () => void;
     const onMessage = (event: MessageEvent) => {
       if (event.data === "verify_ready") {
-        this.initialized = true;
-        this.processQueue();
+        this.onInit();
         window.removeEventListener("message", onMessage);
         iframeOnLoadResolve();
       }
     };
     await Promise.race([
       new Promise<void>((resolve) => {
-        const exists = document.getElementById(VERIFY_CONTEXT);
-        if (exists) return resolve();
+        const existingIframe = document.getElementById(VERIFY_CONTEXT);
+        if (existingIframe) {
+          this.iframe = existingIframe as HTMLIFrameElement;
+          this.onInit();
+          return resolve();
+        }
 
         window.addEventListener("message", onMessage);
         const iframe = document.createElement("iframe");
@@ -156,6 +159,11 @@ export class Verify extends IVerify {
         }, toMiliseconds(FIVE_SECONDS)),
       ),
     ]);
+  };
+
+  private onInit = () => {
+    this.initialized = true;
+    this.processQueue();
   };
 
   private startAbortTimer(timer: number) {


### PR DESCRIPTION
## Description
Fixed a bug where if the client was initialized and verify iframe was already present, `this.iframe` variable was not set correctly to the existing iframe thus preventing attestation POST

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
Dogfooding 

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
