### PR TITLE
feat: add visionOS support

### DIFF
--- a/packages/react-native-compat/react-native-compat.podspec
+++ b/packages/react-native-compat/react-native-compat.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "11.0" }
+  s.platforms    = { :ios => "11.0", :visionos => "1.0" }
   s.source       = { :git => "https://github.com/walletconnect/walletconnect-monorepo.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm}"
@@ -37,5 +37,5 @@ Pod::Spec.new do |s|
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"
    end
-  end    
+  end
 end


### PR DESCRIPTION
## Description

Add support for [React Native visionOS](https://github.com/callstack/react-native-visionos), the new out-of-tree platform.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

This only adds a new platform to the podspec, so the module can be detected and installed by the visionOS platform. No changes to any existing functionality.

## Checklist

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

I'm building a wallet in visionOS using `@walletconnect/web3wallet` and this is needed because `@walletconnect/react-native-compat` is a dependency. With this change, I'm able to install the module in visionOS and connect the wallet as usual, as in any other platform.
