### PR TITLE
feat: updates session without waiting for an ack from the peer

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -373,7 +373,7 @@ export class Engine extends IEngine {
         resolve();
       }
     });
-    // update the session with the new namespaces, if the publish fails, revert to the old
+    // Update the session with the new namespaces, if the publish fails, revert to the old.
     // This allows the client to use the updated session like emitting events
     // without waiting for the peer to acknowledge
     await this.client.session.update(topic, { namespaces });

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -366,7 +366,7 @@ export class Engine extends IEngine {
     const relayRpcId = getBigIntRpcId().toString() as any;
 
     const oldNamespaces = this.client.session.get(topic).namespaces;
-    this.events.once(engineEvent("session_update", clientRpcId), async ({ error }: any) => {
+    this.events.once(engineEvent("session_update", clientRpcId), ({ error }: any) => {
       if (error) reject(error);
       else {
         resolve();

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -369,11 +369,13 @@ export class Engine extends IEngine {
     this.events.once(engineEvent("session_update", clientRpcId), async ({ error }: any) => {
       if (error) reject(error);
       else {
-        await this.client.session.update(topic, { namespaces });
         resolve();
       }
     });
-
+    // update the session with the new namespaces, if the publish fails, revert to the old
+    // this allows the client to use the updated session like emitting events
+    // without waiting for the peer to acknowledge
+    await this.client.session.update(topic, { namespaces });
     this.sendRequest({
       topic,
       method: "wc_sessionUpdate",

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -374,7 +374,7 @@ export class Engine extends IEngine {
       }
     });
     // update the session with the new namespaces, if the publish fails, revert to the old
-    // this allows the client to use the updated session like emitting events
+    // This allows the client to use the updated session like emitting events
     // without waiting for the peer to acknowledge
     await this.client.session.update(topic, { namespaces });
     this.sendRequest({

--- a/packages/web3wallet/src/controllers/engine.ts
+++ b/packages/web3wallet/src/controllers/engine.ts
@@ -47,11 +47,11 @@ export class Engine extends IWeb3WalletEngine {
   };
 
   public updateSession: IWeb3WalletEngine["updateSession"] = async (params) => {
-    return await (await this.signClient.update(params)).acknowledged();
+    return await this.signClient.update(params);
   };
 
   public extendSession: IWeb3WalletEngine["extendSession"] = async (params) => {
-    return await (await this.signClient.extend(params)).acknowledged();
+    return await this.signClient.extend(params);
   };
 
   public respondSessionRequest: IWeb3WalletEngine["respondSessionRequest"] = async (params) => {

--- a/packages/web3wallet/src/types/engine.ts
+++ b/packages/web3wallet/src/types/engine.ts
@@ -38,10 +38,12 @@ export abstract class IWeb3WalletEngine {
   public abstract updateSession(params: {
     topic: string;
     namespaces: SessionTypes.Namespaces;
-  }): Promise<void>;
+  }): Promise<{ acknowledged: () => Promise<void> }>;
 
   // update session expiry (SIGN)
-  public abstract extendSession(params: { topic: string }): Promise<void>;
+  public abstract extendSession(params: {
+    topic: string;
+  }): Promise<{ acknowledged: () => Promise<void> }>;
 
   // respond JSON-RPC request (SIGN)
   public abstract respondSessionRequest(params: {


### PR DESCRIPTION
## Description
Added improvement to session update that allows wallets to update session withut waiting for the dapp to acknowledge. There are several benefits to this approach such as
- optimized for mobile where almost always only the foreground app is online thus acknowledgement is impossible from app that is in background
- better handles updates on multiple sessions where all/almost all peers are offline
- allows client to immediately utilize the updated session such as emit events with the updated valus

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding, tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
