### PR TITLE
fix: adds `http://` support for deeplinks

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -379,7 +379,7 @@ export async function handleDeeplinkRedirect({
     const env = getEnvironment();
 
     if (env === ENV_MAP.browser) {
-      if (link.startsWith("https://")) {
+      if (link.startsWith("https://") || link.startsWith("http://")) {
         window.open(link, "_blank", "noreferrer noopener");
       } else {
         window.open(link, "_self", "noreferrer noopener");


### PR DESCRIPTION
## Description
Added additional check for `http://` on deeplinks so they are opened in new tab, instead of current, the same behaviour as with `https://`.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding 

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
