### PR TITLE
fix: optimize cleanup

### DIFF
--- a/packages/core/src/controllers/history.ts
+++ b/packages/core/src/controllers/history.ts
@@ -85,6 +85,7 @@ export class JsonRpcHistory extends IJsonRpcHistory {
       expiry: calcExpiry(THIRTY_DAYS),
     };
     this.records.set(record.id, record);
+    this.persist();
     this.events.emit(HISTORY_EVENTS.created, record);
   };
 
@@ -99,6 +100,7 @@ export class JsonRpcHistory extends IJsonRpcHistory {
       ? { error: response.error }
       : { result: response.result };
     this.records.set(record.id, record);
+    this.persist();
     this.events.emit(HISTORY_EVENTS.updated, record);
   };
 
@@ -121,6 +123,7 @@ export class JsonRpcHistory extends IJsonRpcHistory {
         this.events.emit(HISTORY_EVENTS.deleted, record);
       }
     });
+    this.persist();
   };
 
   public exists: IJsonRpcHistory["exists"] = async (topic, id) => {
@@ -196,22 +199,17 @@ export class JsonRpcHistory extends IJsonRpcHistory {
       const eventName = HISTORY_EVENTS.created;
       this.logger.info(`Emitting ${eventName}`);
       this.logger.debug({ type: "event", event: eventName, record });
-      this.persist();
     });
     this.events.on(HISTORY_EVENTS.updated, (record: JsonRpcRecord) => {
       const eventName = HISTORY_EVENTS.updated;
       this.logger.info(`Emitting ${eventName}`);
       this.logger.debug({ type: "event", event: eventName, record });
-      this.persist();
     });
 
-    this.events.on(HISTORY_EVENTS.deleted, (record: JsonRpcRecord, persist = true) => {
+    this.events.on(HISTORY_EVENTS.deleted, (record: JsonRpcRecord) => {
       const eventName = HISTORY_EVENTS.deleted;
       this.logger.info(`Emitting ${eventName}`);
       this.logger.debug({ type: "event", event: eventName, record });
-      if (persist) {
-        this.persist();
-      }
     });
 
     this.core.heartbeat.on(HEARTBEAT_EVENTS.pulse, () => {

--- a/packages/core/src/controllers/history.ts
+++ b/packages/core/src/controllers/history.ts
@@ -220,16 +220,17 @@ export class JsonRpcHistory extends IJsonRpcHistory {
   private cleanup() {
     try {
       this.isInitialized();
-      let cleaned = false;
+      let deleted = false;
       this.records.forEach((record: JsonRpcRecord) => {
         const msToExpiry = toMiliseconds(record.expiry || 0) - Date.now();
         if (msToExpiry <= 0) {
           this.logger.info(`Deleting expired history log: ${record.id}`);
           this.records.delete(record.id);
           this.events.emit(HISTORY_EVENTS.deleted, record, false);
+          deleted = true;
         }
       });
-      if (cleaned) {
+      if (deleted) {
         this.persist();
       }
     } catch (e) {

--- a/packages/core/src/controllers/history.ts
+++ b/packages/core/src/controllers/history.ts
@@ -219,6 +219,7 @@ export class JsonRpcHistory extends IJsonRpcHistory {
 
   private cleanup() {
     try {
+      this.isInitialized();
       let cleaned = false;
       this.records.forEach((record: JsonRpcRecord) => {
         const msToExpiry = toMiliseconds(record.expiry || 0) - Date.now();


### PR DESCRIPTION
## Description

Fixes that cleanup was `O(n^2)` because it was persisting and serializing all of the `records` as JSON after deleting each one, rather than when it was done. [Slack conversation](https://walletconnect.slack.com/archives/C03RVH94K5K/p1711057253775659?thread_ts=1706293777.018499&cid=C03RVH94K5K)

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Not tested, can someone test this?

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules