### PR TITLE
feat: optionally disable deeplinks

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -268,7 +268,7 @@ export class Engine extends IEngine {
       controller: { publicKey: selfPublicKey, metadata: this.client.metadata },
       expiry: calcExpiry(SESSION_EXPIRY),
       ...(sessionProperties && { sessionProperties }),
-      sessionConfig,
+      ...(sessionConfig && { sessionConfig }),
     };
     await this.client.core.relayer.subscribe(sessionTopic);
     const session = {
@@ -1027,7 +1027,7 @@ export class Engine extends IEngine {
           metadata: controller.metadata,
         },
         ...(sessionProperties && { sessionProperties }),
-        sessionConfig,
+        ...(sessionConfig && { sessionConfig }),
       };
       await this.sendResult<"wc_sessionSettle">({
         id: payload.id,

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -243,7 +243,7 @@ export class Engine extends IEngine {
       this.client.logger.error("approve() -> isValidApprove() failed");
       throw error;
     }
-    const { id, relayProtocol, namespaces, sessionProperties } = params;
+    const { id, relayProtocol, namespaces, sessionProperties, sessionConfig } = params;
     let proposal;
     try {
       proposal = this.client.proposal.get(id);
@@ -268,6 +268,7 @@ export class Engine extends IEngine {
       controller: { publicKey: selfPublicKey, metadata: this.client.metadata },
       expiry: calcExpiry(SESSION_EXPIRY),
       ...(sessionProperties && { sessionProperties }),
+      sessionConfig,
     };
     await this.client.core.relayer.subscribe(sessionTopic);
     const session = {
@@ -429,6 +430,7 @@ export class Engine extends IEngine {
       throw error;
     }
     const { chainId, request, topic, expiry = ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl } = params;
+    const session = this.client.session.get(topic);
     const clientRpcId = payloadId();
     const relayRpcId = getBigIntRpcId().toString() as any;
     const { done, resolve, reject } = createDelayedPromise<T>(
@@ -468,11 +470,14 @@ export class Engine extends IEngine {
         resolve();
       }),
       new Promise<void>(async (resolve) => {
-        const wcDeepLink = await getDeepLink(
-          this.client.core.storage,
-          WALLETCONNECT_DEEPLINK_CHOICE,
-        );
-        handleDeeplinkRedirect({ id: clientRpcId, topic, wcDeepLink });
+        // only attempt to handle deeplinks if they are not explicitly disabled in the session config
+        if (!session.sessionConfig?.disableDeepLink) {
+          const wcDeepLink = await getDeepLink(
+            this.client.core.storage,
+            WALLETCONNECT_DEEPLINK_CHOICE,
+          );
+          handleDeeplinkRedirect({ id: clientRpcId, topic, wcDeepLink });
+        }
         resolve();
       }),
       done(),
@@ -994,9 +999,17 @@ export class Engine extends IEngine {
     const { id, params } = payload;
     try {
       this.isValidSessionSettleRequest(params);
-      const { relay, controller, expiry, namespaces, sessionProperties, pairingTopic } =
-        payload.params;
+      const {
+        relay,
+        controller,
+        expiry,
+        namespaces,
+        sessionProperties,
+        pairingTopic,
+        sessionConfig,
+      } = payload.params;
       const session = {
+        ...payload.params,
         topic,
         relay,
         expiry,
@@ -1015,6 +1028,7 @@ export class Engine extends IEngine {
           metadata: controller.metadata,
         },
         ...(sessionProperties && { sessionProperties }),
+        sessionConfig,
       };
       await this.sendResult<"wc_sessionSettle">({
         id: payload.id,

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -1009,7 +1009,6 @@ export class Engine extends IEngine {
         sessionConfig,
       } = payload.params;
       const session = {
-        ...payload.params,
         topic,
         relay,
         expiry,

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -163,7 +163,7 @@ describe("Sign Client Integration", () => {
       await expect(wallet.pair({ uri })).rejects.toThrowError();
       await deleteClients({ A: dapp, B: wallet });
     });
-    it.only("should set `sessionConfig`", async () => {
+    it("should set `sessionConfig`", async () => {
       const dapp = await SignClient.init({ ...TEST_SIGN_CLIENT_OPTIONS, name: "dapp" });
       const wallet = await SignClient.init({ ...TEST_SIGN_CLIENT_OPTIONS, name: "wallet" });
       const { uri, approval } = await dapp.connect(TEST_CONNECT_PARAMS);

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -163,6 +163,49 @@ describe("Sign Client Integration", () => {
       await expect(wallet.pair({ uri })).rejects.toThrowError();
       await deleteClients({ A: dapp, B: wallet });
     });
+    it.only("should set `sessionConfig`", async () => {
+      const dapp = await SignClient.init({ ...TEST_SIGN_CLIENT_OPTIONS, name: "dapp" });
+      const wallet = await SignClient.init({ ...TEST_SIGN_CLIENT_OPTIONS, name: "wallet" });
+      const { uri, approval } = await dapp.connect(TEST_CONNECT_PARAMS);
+      if (!uri) throw new Error("URI is undefined");
+      expect(uri).to.exist;
+      const parsedUri = parseUri(uri);
+      const sessionConfig = {
+        disableDeepLink: true,
+      };
+      let sessionTopic = "";
+      await Promise.all([
+        new Promise<void>((resolve) => {
+          wallet.once("session_proposal", async (params) => {
+            expect(params).to.exist;
+            expect(params.params.pairingTopic).to.eq(parsedUri.topic);
+            const { acknowledged } = await wallet.approve({
+              id: params.id,
+              namespaces: TEST_NAMESPACES,
+              sessionConfig,
+            });
+            sessionTopic = (await acknowledged()).topic;
+            resolve();
+          });
+        }),
+        new Promise<void>(async (resolve) => {
+          const session = await approval();
+          expect(session).to.exist;
+          expect(session.topic).to.exist;
+          expect(session.pairingTopic).to.eq(parsedUri.topic);
+          resolve();
+        }),
+        wallet.pair({ uri }),
+      ]);
+      const sessionDapp = dapp.session.get(sessionTopic);
+      const sessionWallet = wallet.session.get(sessionTopic);
+      expect(sessionDapp).to.exist;
+      expect(sessionWallet).to.exist;
+      expect(sessionDapp.sessionConfig).to.eql(sessionConfig);
+      expect(sessionWallet.sessionConfig).to.eql(sessionConfig);
+      expect(sessionWallet.sessionConfig).to.eql(sessionDapp.sessionConfig);
+      await deleteClients({ A: dapp, B: wallet });
+    });
   });
 
   describe("disconnect", () => {

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -67,6 +67,7 @@ export declare namespace EngineTypes {
     id: number;
     namespaces: SessionTypes.Namespaces;
     sessionProperties?: ProposalTypes.SessionProperties;
+    sessionConfig?: SessionTypes.SessionConfig;
     relayProtocol?: string;
   }
 

--- a/packages/types/src/sign-client/jsonrpc.ts
+++ b/packages/types/src/sign-client/jsonrpc.ts
@@ -41,6 +41,7 @@ export declare namespace JsonRpcTypes {
       relay: RelayerTypes.ProtocolOptions;
       namespaces: SessionTypes.Namespaces;
       sessionProperties?: ProposalTypes.SessionProperties;
+      sessionConfig?: SessionTypes.SessionConfig;
       pairingTopic: string;
       expiry: number;
       controller: {

--- a/packages/types/src/sign-client/session.ts
+++ b/packages/types/src/sign-client/session.ts
@@ -17,6 +17,10 @@ export declare namespace SessionTypes {
 
   type Namespaces = Record<string, Namespace>;
 
+  interface SessionConfig {
+    disableDeepLink?: boolean;
+  }
+
   interface Struct {
     topic: string;
     pairingTopic: string;
@@ -28,6 +32,7 @@ export declare namespace SessionTypes {
     requiredNamespaces: ProposalTypes.RequiredNamespaces;
     optionalNamespaces: ProposalTypes.OptionalNamespaces;
     sessionProperties?: ProposalTypes.SessionProperties;
+    sessionConfig?: SessionConfig;
     self: {
       publicKey: string;
       metadata: SignClientTypes.Metadata;

--- a/packages/web3wallet/src/controllers/engine.ts
+++ b/packages/web3wallet/src/controllers/engine.ts
@@ -35,8 +35,11 @@ export class Engine extends IWeb3WalletEngine {
   // Sign //
   public approveSession: IWeb3WalletEngine["approveSession"] = async (sessionProposal) => {
     const { topic, acknowledged } = await this.signClient.approve({
+      ...sessionProposal,
       id: sessionProposal.id,
       namespaces: sessionProposal.namespaces,
+      sessionProperties: sessionProposal.sessionProperties,
+      sessionConfig: sessionProposal.sessionConfig,
     });
     await acknowledged();
     return this.signClient.session.get(topic);

--- a/packages/web3wallet/src/types/engine.ts
+++ b/packages/web3wallet/src/types/engine.ts
@@ -24,6 +24,8 @@ export abstract class IWeb3WalletEngine {
   public abstract approveSession(params: {
     id: number;
     namespaces: Record<string, SessionTypes.Namespace>;
+    sessionProperties?: ProposalTypes.SessionProperties;
+    sessionConfig?: SessionTypes.SessionConfig;
     relayProtocol?: string;
   }): Promise<SessionTypes.Struct>;
 

--- a/packages/web3wallet/test/sign.spec.ts
+++ b/packages/web3wallet/test/sign.spec.ts
@@ -55,6 +55,7 @@ describe("Sign Integration", () => {
   });
 
   it("should approve session proposal", async () => {
+    const sessionConfig = { disableDeepLink: false };
     await Promise.all([
       new Promise((resolve) => {
         wallet.on("session_proposal", async (sessionProposal) => {
@@ -64,6 +65,7 @@ describe("Sign Integration", () => {
           session = await wallet.approveSession({
             id,
             namespaces: TEST_NAMESPACES,
+            sessionConfig,
           });
           expect(params.requiredNamespaces).to.toMatchObject(TEST_REQUIRED_NAMESPACES);
           resolve(session);
@@ -74,6 +76,9 @@ describe("Sign Integration", () => {
       }),
       wallet.pair({ uri: uriString }),
     ]);
+    expect(session).to.be.exist;
+    expect(session.topic).to.be.exist;
+    expect(session.sessionConfig).to.eql(sessionConfig);
   });
   it("should reject session proposal", async () => {
     const rejectionError = getSdkError("USER_REJECTED");


### PR DESCRIPTION
## Description
Added `sessionConfig` to sessions with a prop `disableDeepLink` that allows wallets to disable deeplink behaviour on session by session basis. Use case is when a wallet is launched in a browser tab, to avoid opening in new tab on every request
context: https://walletconnect.slack.com/archives/C03RVH94K5K/p1711033401102829
## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding, tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

https://linear.app/walletconnect/issue/W3M-90/fireblocks-issue-with-opening-new-tab
