### PR TITLE
fix: fallback event listener cleanup

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -710,8 +710,6 @@ export class Engine extends IEngine {
     };
     // handle session authenticate response
     const onAuthenticate = async (payload: any) => {
-      // remove cleanup for fallback response
-      this.events.off(engineEvent("session_connect"), onSessionConnect);
       if (payload.error) {
         // wallets that do not support wc_sessionAuthenticate will return an error
         // we should not reject the promise in this case as the fallback session proposal will be used
@@ -719,6 +717,10 @@ export class Engine extends IEngine {
         if (payload.error.code === error.code) return;
         return reject(payload.error.message);
       }
+
+      // cleanup listener for fallback response
+      this.events.off(engineEvent("session_connect"), onSessionConnect);
+
       const {
         cacaos,
         responder,

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -715,6 +715,9 @@ export class Engine extends IEngine {
         // we should not reject the promise in this case as the fallback session proposal will be used
         const error = getSdkError("WC_METHOD_UNSUPPORTED", "wc_sessionAuthenticate");
         if (payload.error.code === error.code) return;
+
+        // cleanup listener for fallback response
+        this.events.off(engineEvent("session_connect"), onSessionConnect);
         return reject(payload.error.message);
       }
 

--- a/packages/sign-client/test/sdk/auth.spec.ts
+++ b/packages/sign-client/test/sdk/auth.spec.ts
@@ -1124,6 +1124,15 @@ describe("Authenticated Sessions", () => {
       metadata: TEST_APP_METADATA_B,
     });
 
+    // force wallet to not support `wc_sessionAuthenticate` by removing it from registered methods
+    const supportedMethods = ENGINE_RPC_OPTS;
+    const toRegisterMethods = Object.keys(supportedMethods).filter(
+      (method) => method !== "wc_sessionAuthenticate",
+    );
+    //@ts-expect-error
+    wallet.core.pairing.registeredMethods = [];
+    wallet.core.pairing.register({ methods: toRegisterMethods });
+
     await Promise.all([
       new Promise<void>((resolve) => {
         wallet.on("session_proposal", async (payload) => {
@@ -1151,7 +1160,7 @@ describe("Authenticated Sessions", () => {
         });
       }),
       new Promise<void>((resolve) => {
-        wallet.pair({ uri: uri.replace("methods", "") });
+        wallet.pair({ uri });
         resolve();
       }),
     ]);


### PR DESCRIPTION
## Description
Fixed bug where fallback listener (`session_connect`) should not be removed on error response `WC_METHOD_UNSUPPORTED`

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding 
tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
