### PR TITLE
chore: use new logger canary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7914,17 +7914,13 @@
       }
     },
     "node_modules/@walletconnect/logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.0.1.tgz",
-      "integrity": "sha512-SsTKdsgWm+oDTBeNE/zHxxr5eJfZmE9/5yp/Ku+zJtcTAjELb3DXueWkDXmE9h8uHIbJzIb5wj5lPdzyrjT6hQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.2.tgz",
+      "integrity": "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==",
       "dependencies": {
-        "pino": "7.11.0",
-        "tslib": "1.14.1"
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "7.11.0"
       }
-    },
-    "node_modules/@walletconnect/logger/node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
     },
     "node_modules/@walletconnect/modal": {
       "version": "2.6.2",
@@ -27504,15 +27500,6 @@
         "node-fetch": "^3.3.0"
       }
     },
-    "packages/core/node_modules/@walletconnect/logger": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.2.tgz",
-      "integrity": "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==",
-      "dependencies": {
-        "@walletconnect/safe-json": "^1.0.2",
-        "pino": "7.11.0"
-      }
-    },
     "packages/core/node_modules/node-fetch": {
       "version": "3.3.1",
       "dev": true,
@@ -27571,15 +27558,6 @@
         "@walletconnect/jsonrpc-provider": "^1.0.13",
         "@walletconnect/jsonrpc-ws-connection": "1.0.14",
         "@walletconnect/relay-api": "^1.0.9"
-      }
-    },
-    "packages/sign-client/node_modules/@walletconnect/logger": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.2.tgz",
-      "integrity": "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==",
-      "dependencies": {
-        "@walletconnect/safe-json": "^1.0.2",
-        "pino": "7.11.0"
       }
     },
     "packages/types": {
@@ -27683,7 +27661,7 @@
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
-        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/logger": "^2.1.2",
         "@walletconnect/sign-client": "2.12.1",
         "@walletconnect/types": "2.12.1",
         "@walletconnect/utils": "2.12.1",
@@ -33633,15 +33611,6 @@
         "uint8arrays": "^3.1.0"
       },
       "dependencies": {
-        "@walletconnect/logger": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.2.tgz",
-          "integrity": "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==",
-          "requires": {
-            "@walletconnect/safe-json": "^1.0.2",
-            "pino": "7.11.0"
-          }
-        },
         "node-fetch": {
           "version": "3.3.1",
           "dev": true,
@@ -33782,17 +33751,12 @@
       }
     },
     "@walletconnect/logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.0.1.tgz",
-      "integrity": "sha512-SsTKdsgWm+oDTBeNE/zHxxr5eJfZmE9/5yp/Ku+zJtcTAjELb3DXueWkDXmE9h8uHIbJzIb5wj5lPdzyrjT6hQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.2.tgz",
+      "integrity": "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==",
       "requires": {
-        "pino": "7.11.0",
-        "tslib": "1.14.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1"
-        }
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "7.11.0"
       }
     },
     "@walletconnect/modal": {
@@ -33886,17 +33850,6 @@
         "@walletconnect/types": "2.12.1",
         "@walletconnect/utils": "2.12.1",
         "events": "^3.3.0"
-      },
-      "dependencies": {
-        "@walletconnect/logger": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.2.tgz",
-          "integrity": "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==",
-          "requires": {
-            "@walletconnect/safe-json": "^1.0.2",
-            "pino": "7.11.0"
-          }
-        }
       }
     },
     "@walletconnect/signer-connection": {
@@ -33940,7 +33893,7 @@
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
-        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/logger": "2.1.2",
         "@walletconnect/sign-client": "2.12.1",
         "@walletconnect/types": "2.12.1",
         "@walletconnect/utils": "2.12.1",
@@ -34139,7 +34092,7 @@
         "@walletconnect/core": "2.12.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/logger": "2.0.1",
+        "@walletconnect/logger": "^2.0.1",
         "@walletconnect/sign-client": "2.12.1",
         "@walletconnect/types": "2.12.1",
         "@walletconnect/utils": "2.12.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7915,7 +7915,8 @@
     },
     "node_modules/@walletconnect/logger": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.0.1.tgz",
+      "integrity": "sha512-SsTKdsgWm+oDTBeNE/zHxxr5eJfZmE9/5yp/Ku+zJtcTAjELb3DXueWkDXmE9h8uHIbJzIb5wj5lPdzyrjT6hQ==",
       "dependencies": {
         "pino": "7.11.0",
         "tslib": "1.14.1"
@@ -27559,7 +27560,7 @@
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/logger": "^2.1.2",
         "@walletconnect/time": "^1.0.2",
         "@walletconnect/types": "2.12.1",
         "@walletconnect/utils": "2.12.1",
@@ -27570,6 +27571,15 @@
         "@walletconnect/jsonrpc-provider": "^1.0.13",
         "@walletconnect/jsonrpc-ws-connection": "1.0.14",
         "@walletconnect/relay-api": "^1.0.9"
+      }
+    },
+    "packages/sign-client/node_modules/@walletconnect/logger": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.2.tgz",
+      "integrity": "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "7.11.0"
       }
     },
     "packages/types": {
@@ -27618,7 +27628,7 @@
         "@walletconnect/core": "2.12.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/logger": "2.0.1",
+        "@walletconnect/logger": "^2.0.1",
         "@walletconnect/sign-client": "2.12.1",
         "@walletconnect/types": "2.12.1",
         "@walletconnect/utils": "2.12.1"
@@ -33609,7 +33619,7 @@
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/jsonrpc-ws-connection": "1.0.14",
         "@walletconnect/keyvaluestorage": "^1.1.1",
-        "@walletconnect/logger": "2.1.2",
+        "@walletconnect/logger": "^2.1.2",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
@@ -33773,6 +33783,8 @@
     },
     "@walletconnect/logger": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.0.1.tgz",
+      "integrity": "sha512-SsTKdsgWm+oDTBeNE/zHxxr5eJfZmE9/5yp/Ku+zJtcTAjELb3DXueWkDXmE9h8uHIbJzIb5wj5lPdzyrjT6hQ==",
       "requires": {
         "pino": "7.11.0",
         "tslib": "1.14.1"
@@ -33868,12 +33880,23 @@
         "@walletconnect/jsonrpc-provider": "^1.0.13",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/jsonrpc-ws-connection": "1.0.14",
-        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/logger": "^2.1.2",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/time": "^1.0.2",
         "@walletconnect/types": "2.12.1",
         "@walletconnect/utils": "2.12.1",
         "events": "^3.3.0"
+      },
+      "dependencies": {
+        "@walletconnect/logger": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.2.tgz",
+          "integrity": "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==",
+          "requires": {
+            "@walletconnect/safe-json": "^1.0.2",
+            "pino": "7.11.0"
+          }
+        }
       }
     },
     "@walletconnect/signer-connection": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27486,7 +27486,7 @@
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/jsonrpc-ws-connection": "1.0.14",
         "@walletconnect/keyvaluestorage": "^1.1.1",
-        "@walletconnect/logger": "^2.1.1",
+        "@walletconnect/logger": "^2.1.2",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
@@ -27504,9 +27504,9 @@
       }
     },
     "packages/core/node_modules/@walletconnect/logger": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.1.tgz",
-      "integrity": "sha512-xXM+D6I9Abva2g5x/qcCmZmAVUP0YgUhNquUH0XNhp1kK/Jzp26tJrAHUEHJr1ROjrmbsrdJ2cLEJTVACK6Uvg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.2.tgz",
+      "integrity": "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==",
       "dependencies": {
         "@walletconnect/safe-json": "^1.0.2",
         "pino": "7.11.0"
@@ -33609,7 +33609,7 @@
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/jsonrpc-ws-connection": "1.0.14",
         "@walletconnect/keyvaluestorage": "^1.1.1",
-        "@walletconnect/logger": "^2.1.0",
+        "@walletconnect/logger": "2.1.2",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
@@ -33624,9 +33624,9 @@
       },
       "dependencies": {
         "@walletconnect/logger": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.1.tgz",
-          "integrity": "sha512-xXM+D6I9Abva2g5x/qcCmZmAVUP0YgUhNquUH0XNhp1kK/Jzp26tJrAHUEHJr1ROjrmbsrdJ2cLEJTVACK6Uvg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.2.tgz",
+          "integrity": "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==",
           "requires": {
             "@walletconnect/safe-json": "^1.0.2",
             "pino": "7.11.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27606,7 +27606,7 @@
         "@walletconnect/core": "2.12.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/logger": "^2.1.2",
+        "@walletconnect/logger": "2.1.2",
         "@walletconnect/sign-client": "2.12.1",
         "@walletconnect/types": "2.12.1",
         "@walletconnect/utils": "2.12.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27606,7 +27606,7 @@
         "@walletconnect/core": "2.12.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/logger": "^2.1.2",
         "@walletconnect/sign-client": "2.12.1",
         "@walletconnect/types": "2.12.1",
         "@walletconnect/utils": "2.12.1"
@@ -33893,7 +33893,7 @@
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
-        "@walletconnect/logger": "2.1.2",
+        "@walletconnect/logger": "^2.1.2",
         "@walletconnect/sign-client": "2.12.1",
         "@walletconnect/types": "2.12.1",
         "@walletconnect/utils": "2.12.1",
@@ -34092,7 +34092,7 @@
         "@walletconnect/core": "2.12.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/logger": "2.1.2",
         "@walletconnect/sign-client": "2.12.1",
         "@walletconnect/types": "2.12.1",
         "@walletconnect/utils": "2.12.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/jsonrpc-ws-connection": "1.0.14",
     "@walletconnect/keyvaluestorage": "^1.1.1",
-    "@walletconnect/logger": "^2.1.1",
+    "@walletconnect/logger": "^2.1.2",
     "@walletconnect/relay-api": "^1.0.9",
     "@walletconnect/relay-auth": "^1.0.4",
     "@walletconnect/safe-json": "^1.0.2",

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -42,7 +42,7 @@
     "@walletconnect/events": "^1.0.1",
     "@walletconnect/heartbeat": "1.2.1",
     "@walletconnect/jsonrpc-utils": "1.0.8",
-    "@walletconnect/logger": "^2.0.1",
+    "@walletconnect/logger": "^2.1.2",
     "@walletconnect/time": "^1.0.2",
     "@walletconnect/types": "2.12.1",
     "@walletconnect/utils": "2.12.1",

--- a/packages/web3wallet/package.json
+++ b/packages/web3wallet/package.json
@@ -33,7 +33,7 @@
     "@walletconnect/core": "2.12.1",
     "@walletconnect/jsonrpc-provider": "1.0.13",
     "@walletconnect/jsonrpc-utils": "1.0.8",
-    "@walletconnect/logger": "^2.0.1",
+    "@walletconnect/logger": "^2.1.2",
     "@walletconnect/sign-client": "2.12.1",
     "@walletconnect/types": "2.12.1",
     "@walletconnect/utils": "2.12.1"

--- a/packages/web3wallet/package.json
+++ b/packages/web3wallet/package.json
@@ -33,7 +33,7 @@
     "@walletconnect/core": "2.12.1",
     "@walletconnect/jsonrpc-provider": "1.0.13",
     "@walletconnect/jsonrpc-utils": "1.0.8",
-    "@walletconnect/logger": "^2.1.2",
+    "@walletconnect/logger": "2.1.2",
     "@walletconnect/sign-client": "2.12.1",
     "@walletconnect/types": "2.12.1",
     "@walletconnect/utils": "2.12.1"

--- a/packages/web3wallet/package.json
+++ b/packages/web3wallet/package.json
@@ -33,7 +33,7 @@
     "@walletconnect/core": "2.12.1",
     "@walletconnect/jsonrpc-provider": "1.0.13",
     "@walletconnect/jsonrpc-utils": "1.0.8",
-    "@walletconnect/logger": "2.0.1",
+    "@walletconnect/logger": "^2.0.1",
     "@walletconnect/sign-client": "2.12.1",
     "@walletconnect/types": "2.12.1",
     "@walletconnect/utils": "2.12.1"

--- a/providers/universal-provider/package.json
+++ b/providers/universal-provider/package.json
@@ -44,7 +44,7 @@
     "@walletconnect/jsonrpc-provider": "1.0.13",
     "@walletconnect/jsonrpc-types": "^1.0.2",
     "@walletconnect/jsonrpc-utils": "^1.0.7",
-    "@walletconnect/logger": "^2.0.1",
+    "@walletconnect/logger": "^2.1.2",
     "@walletconnect/sign-client": "2.12.1",
     "@walletconnect/types": "2.12.1",
     "@walletconnect/utils": "2.12.1",


### PR DESCRIPTION
## Description
- Resolves #4414 
- Upgrade to latest `@walletconnect/logger` which contains fix

> [!Note]
> Uses Changes from: https://github.com/WalletConnect/walletconnect-utils/pull/167 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Tested via the repro case mentioned in issue #4414 

## Fixes/Resolves (Optional)

- Resolves #4414 
## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

