### PR TITLE
feat:add eip5792 methods as optional methods

### DIFF
--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -39,7 +39,11 @@ export type RpcMethod =
   | "wallet_requestPermissions"
   | "wallet_registerOnboarding"
   | "wallet_watchAsset"
-  | "wallet_scanQRCode";
+  | "wallet_scanQRCode"
+  | "wallet_sendCalls"
+  | "wallet_getCapabilities"
+  | "wallet_getCallsStatus"
+  | "wallet_showCallsStatus";
 
 export type RpcEvent = "accountsChanged" | "chainChanged" | "message" | "disconnect" | "connect";
 

--- a/providers/ethereum-provider/src/constants/rpc.ts
+++ b/providers/ethereum-provider/src/constants/rpc.ts
@@ -17,6 +17,10 @@ export const OPTIONAL_METHODS = [
   "wallet_registerOnboarding",
   "wallet_watchAsset",
   "wallet_scanQRCode",
+  "wallet_sendCalls",
+  "wallet_getCapabilities",
+  "wallet_getCallsStatus",
+  "wallet_showCallsStatus",
 ];
 export const REQUIRED_EVENTS = ["chainChanged", "accountsChanged"];
 export const OPTIONAL_EVENTS = [


### PR DESCRIPTION
Adding EIP-5792 methods on the list of optional RPC methods. These method will become part of session proposal request to wallet.
This will enable wallet supporting EIP-5792 allowing dapps to use it after session is successfully approved by the user.