### PR TITLE
feat: rejection tags

### DIFF
--- a/packages/sign-client/src/constants/engine.ts
+++ b/packages/sign-client/src/constants/engine.ts
@@ -15,6 +15,16 @@ export const ENGINE_RPC_OPTS: EngineTypes.RpcOptsMap = {
       prompt: false,
       tag: 1101,
     },
+    reject: {
+      ttl: FIVE_MINUTES,
+      prompt: false,
+      tag: 1120,
+    },
+    autoReject: {
+      ttl: FIVE_MINUTES,
+      prompt: false,
+      tag: 1121,
+    },
   },
   wc_sessionSettle: {
     req: {
@@ -111,6 +121,16 @@ export const ENGINE_RPC_OPTS: EngineTypes.RpcOptsMap = {
       ttl: ONE_HOUR,
       prompt: false,
       tag: 1117,
+    },
+    reject: {
+      ttl: FIVE_MINUTES,
+      prompt: false,
+      tag: 1118,
+    },
+    autoReject: {
+      ttl: FIVE_MINUTES,
+      prompt: false,
+      tag: 1119,
     },
   },
 };

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -1851,6 +1851,8 @@ export class Engine extends IEngine {
         id: payload.id,
       });
     } catch (err: any) {
+      this.client.logger.error(err);
+
       const receiverPublicKey = payload.params.requester.publicKey;
       const senderPublicKey = await this.client.core.crypto.generateKeyPair();
 
@@ -1866,7 +1868,6 @@ export class Engine extends IEngine {
         encodeOpts,
         rpcOpts: ENGINE_RPC_OPTS.wc_sessionAuthenticate.autoReject,
       });
-      this.client.logger.error(err);
     }
   };
 

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -366,6 +366,7 @@ export class Engine extends IEngine {
         id,
         topic: pairingTopic,
         error: reason,
+        rpcOpts: ENGINE_RPC_OPTS.wc_sessionPropose.reject,
       });
       await this.client.proposal.delete(id, getSdkError("USER_DISCONNECTED"));
     }
@@ -1003,6 +1004,7 @@ export class Engine extends IEngine {
       topic: responseTopic,
       error: reason,
       encodeOpts,
+      rpcOpts: ENGINE_RPC_OPTS.wc_sessionAuthenticate.reject,
     });
     await this.client.auth.requests.delete(id, { message: "rejected", code: 0 });
     await this.client.proposal.delete(id, getSdkError("USER_DISCONNECTED"));
@@ -1214,7 +1216,7 @@ export class Engine extends IEngine {
   };
 
   private sendError: EnginePrivate["sendError"] = async (params) => {
-    const { id, topic, error, encodeOpts } = params;
+    const { id, topic, error, encodeOpts, rpcOpts } = params;
     const payload = formatJsonRpcError(id, error);
     let message;
     try {
@@ -1231,7 +1233,7 @@ export class Engine extends IEngine {
       this.client.logger.error(`sendError() -> history.get(${topic}, ${id}) failed`);
       throw error;
     }
-    const opts = ENGINE_RPC_OPTS[record.request.method].res;
+    const opts = rpcOpts || ENGINE_RPC_OPTS[record.request.method].res;
     // await is intentionally omitted to speed up performance
     this.client.core.relayer.publish(topic, message, opts);
     await this.client.core.history.resolve(payload);
@@ -1434,6 +1436,7 @@ export class Engine extends IEngine {
         id,
         topic,
         error: err,
+        rpcOpts: ENGINE_RPC_OPTS.wc_sessionPropose.autoReject,
       });
       this.client.logger.error(err);
     }

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -1851,10 +1851,19 @@ export class Engine extends IEngine {
         id: payload.id,
       });
     } catch (err: any) {
+      const receiverPublicKey = payload.params.requester.publicKey;
+      const senderPublicKey = await this.client.core.crypto.generateKeyPair();
+
+      const encodeOpts = {
+        type: TYPE_1,
+        receiverPublicKey,
+        senderPublicKey,
+      };
       await this.sendError({
         id: payload.id,
         topic,
         error: err,
+        encodeOpts,
         rpcOpts: ENGINE_RPC_OPTS.wc_sessionAuthenticate.autoReject,
       });
       this.client.logger.error(err);

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -5,7 +5,7 @@ import {
 } from "@walletconnect/jsonrpc-utils";
 import { calcExpiry, getSdkError, parseUri } from "@walletconnect/utils";
 import { expect, describe, it, vi } from "vitest";
-import SignClient, { WALLETCONNECT_DEEPLINK_CHOICE } from "../../src";
+import SignClient, { ENGINE_RPC_OPTS, WALLETCONNECT_DEEPLINK_CHOICE } from "../../src";
 
 import {
   initTwoClients,
@@ -22,6 +22,7 @@ import {
   initTwoPairedClients,
   TEST_CONNECT_PARAMS,
 } from "../shared";
+import { RELAYER_EVENTS } from "@walletconnect/core";
 
 describe("Sign Client Integration", () => {
   it("init", async () => {
@@ -210,6 +211,34 @@ describe("Sign Client Integration", () => {
       expect(sessionDapp.sessionConfig).to.eql(sessionConfig);
       expect(sessionWallet.sessionConfig).to.eql(sessionConfig);
       expect(sessionWallet.sessionConfig).to.eql(sessionDapp.sessionConfig);
+      await deleteClients({ A: dapp, B: wallet });
+    });
+    it("should use rejected tag for session_propose", async () => {
+      const dapp = await SignClient.init({ ...TEST_SIGN_CLIENT_OPTIONS, name: "dapp" });
+      const wallet = await SignClient.init({ ...TEST_SIGN_CLIENT_OPTIONS, name: "wallet" });
+      const { uri } = await dapp.connect(TEST_CONNECT_PARAMS);
+      if (!uri) throw new Error("URI is undefined");
+      expect(uri).to.exist;
+      await Promise.all([
+        new Promise<void>((resolve) => {
+          wallet.core.relayer.once(RELAYER_EVENTS.publish, (payload) => {
+            const { opts } = payload;
+            const expectedOpts = ENGINE_RPC_OPTS.wc_sessionPropose.reject;
+            expect(opts).to.exist;
+            expect(opts.tag).to.eq(expectedOpts?.tag);
+            expect(opts.ttl).to.eq(expectedOpts?.ttl);
+            expect(opts.prompt).to.eq(expectedOpts?.prompt);
+            resolve();
+          });
+        }),
+        new Promise<void>((resolve) => {
+          wallet.once("session_proposal", async (params) => {
+            await wallet.reject({ id: params.id, reason: getSdkError("USER_REJECTED") });
+            resolve();
+          });
+        }),
+        wallet.pair({ uri }),
+      ]);
       await deleteClients({ A: dapp, B: wallet });
     });
   });

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -139,6 +139,12 @@ export declare namespace EngineTypes {
     res: RelayerTypes.PublishOptions & {
       ttl: number;
     };
+    reject?: RelayerTypes.PublishOptions & {
+      ttl: number;
+    };
+    autoReject?: RelayerTypes.PublishOptions & {
+      ttl: number;
+    };
   }
 
   type RpcOptsMap = Record<JsonRpcTypes.WcMethod, RpcOpts>;
@@ -191,6 +197,7 @@ export interface EnginePrivate {
     topic: string;
     error: JsonRpcTypes.Error;
     encodeOpts?: CryptoTypes.EncodeOptions;
+    rpcOpts?: RelayerTypes.PublishOptions;
   }): Promise<void>;
 
   onRelayEventRequest(event: EngineTypes.EventCallback<JsonRpcRequest>): void;


### PR DESCRIPTION
## Description

- Added new rejection tags according to spec https://github.com/WalletConnect/walletconnect-specs/pull/230
- Added try/catch around `onSessionAuthenticateRequest` that auto responds with an error if there is an exception

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests 

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
