### PR TITLE
fix: request queue state on pending request delete

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -1090,10 +1090,14 @@ export class Engine extends IEngine {
       expirerHasDeleted ? Promise.resolve() : this.client.core.expirer.del(id),
     ]);
     this.addToRecentlyDeleted(id, "request");
-    this.sessionRequestQueue.queue = this.sessionRequestQueue.queue.filter((r) => r.id !== id);
-    // set the requestQueue state to idle if expirer has deleted a request as trying to respond to it would result in an exception
-    if (expirerHasDeleted) {
+
+    // this request being the first means it was already emitted to the wallet but hasn't been responded to
+    // so we need to reset the queue state back to idle
+    if (id === this.sessionRequestQueue.queue[0]?.id) {
       this.sessionRequestQueue.state = ENGINE_QUEUE_STATES.idle;
+    }
+    this.sessionRequestQueue.queue = this.sessionRequestQueue.queue.filter((r) => r.id !== id);
+    if (expirerHasDeleted) {
       this.client.events.emit("session_request_expire", { id });
     }
   };

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -1069,7 +1069,7 @@ export class Engine extends IEngine {
         this.deletePendingSessionRequest(r.id, getSdkError("USER_DISCONNECTED"));
       }
     });
-    // reset the queue state back to idle if the deleted session is still in the queue
+    // reset the queue state back to idle if a request for the deleted session is still in the queue
     if (topic === this.sessionRequestQueue.queue[0]?.topic) {
       this.sessionRequestQueue.state = ENGINE_QUEUE_STATES.idle;
     }

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -343,6 +343,8 @@ describe("Sign Client Integration", () => {
         expect(clients.B.pendingRequest.getAll().length).to.eq(0);
         // @ts-expect-error - sessionRequestQueue is private property
         expect(clients.B.engine.sessionRequestQueue.state).to.eq(ENGINE_QUEUE_STATES.idle);
+        // @ts-expect-error - force close the transport due to pending session request
+        clients.A.core.relayer.hasExperiencedNetworkDisruption = true;
         await deleteClients(clients);
       });
     });


### PR DESCRIPTION
## Description
Fixed a bug where session request queue state was not updated when a pending request was deleted due to session disconnect 
## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests, dogfooding

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
