### PR TITLE
feat: added atob and btoa polyfills

### DIFF
--- a/packages/react-native-compat/index.js
+++ b/packages/react-native-compat/index.js
@@ -14,6 +14,20 @@ if (typeof Buffer === "undefined") {
   global.Buffer = require("buffer").Buffer;
 }
 
+// Polyfill btoa
+if (typeof btoa === 'undefined') {
+  global.btoa = function (str) {
+    return new Buffer(str, 'binary').toString('base64');
+  };
+}
+
+// Polyfill atob
+if (typeof atob === 'undefined') {
+  global.atob = function (b64Encoded) {
+    return new Buffer(b64Encoded, 'base64').toString('binary');
+  };
+}
+
 if (typeof global?.Linking === "undefined") {
   try {
     global.Linking = require("react-native").Linking;

--- a/packages/react-native-compat/index.js
+++ b/packages/react-native-compat/index.js
@@ -15,16 +15,20 @@ if (typeof Buffer === "undefined") {
 }
 
 // Polyfill btoa
-if (typeof btoa === 'undefined') {
+if (typeof btoa === "undefined") {
   global.btoa = function (str) {
-    return new Buffer(str, 'binary').toString('base64');
+    return Buffer.alloc(str.length, str, "binary").toString("base64");
   };
 }
 
 // Polyfill atob
-if (typeof atob === 'undefined') {
+if (typeof atob === "undefined") {
   global.atob = function (b64Encoded) {
-    return new Buffer(b64Encoded, 'base64').toString('binary');
+    return Buffer.alloc(
+      Buffer.from(b64Encoded, "base64").length,
+      Buffer.from(b64Encoded, "base64"),
+      "binary",
+    ).toString("binary");
   };
 }
 


### PR DESCRIPTION
## Description

Added `atob` and `btoa` polyfills. They are needed for ethers5 and wagmi v2 to work

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
* Tested it in react native sample dapps

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules