### PR TITLE
chore: pairing topic setter on session settle

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -271,7 +271,6 @@ export class Engine extends IEngine {
     }
 
     const { pairingTopic, proposer, requiredNamespaces, optionalNamespaces } = proposal;
-    // pairingTopic = pairingTopic || "";
 
     const selfPublicKey = await this.client.core.crypto.generateKeyPair();
     const peerPublicKey = proposer.publicKey;
@@ -1512,7 +1511,7 @@ export class Engine extends IEngine {
         expiry,
         namespaces,
         acknowledged: true,
-        pairingTopic: "", // pairingTopic will be set in the `session_connect` listener
+        pairingTopic: "", // pairingTopic will be set in the `session_connect` handler
         requiredNamespaces: {},
         optionalNamespaces: {},
         controller: controller.publicKey,

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -200,6 +200,7 @@ export class Engine extends IEngine {
         metadata: this.client.metadata,
       },
       expiryTimestamp,
+      pairingTopic: topic,
       ...(sessionProperties && { sessionProperties }),
     };
     const {
@@ -215,6 +216,7 @@ export class Engine extends IEngine {
           session.self.publicKey = publicKey;
           const completeSession = {
             ...session,
+            pairingTopic: proposal.pairingTopic,
             requiredNamespaces: proposal.requiredNamespaces,
             optionalNamespaces: proposal.optionalNamespaces,
           };
@@ -226,6 +228,7 @@ export class Engine extends IEngine {
               metadata: session.peer.metadata,
             });
           }
+          this.cleanupDuplicatePairings(completeSession);
           resolve(completeSession);
         }
       },
@@ -267,8 +270,8 @@ export class Engine extends IEngine {
       throw error;
     }
 
-    let { pairingTopic, proposer, requiredNamespaces, optionalNamespaces } = proposal;
-    pairingTopic = pairingTopic || "";
+    const { pairingTopic, proposer, requiredNamespaces, optionalNamespaces } = proposal;
+    // pairingTopic = pairingTopic || "";
 
     const selfPublicKey = await this.client.core.crypto.generateKeyPair();
     const peerPublicKey = proposer.publicKey;
@@ -279,7 +282,6 @@ export class Engine extends IEngine {
     const sessionSettle = {
       relay: { protocol: relayProtocol ?? "irn" },
       namespaces,
-      pairingTopic,
       controller: { publicKey: selfPublicKey, metadata: this.client.metadata },
       expiry: calcExpiry(SESSION_EXPIRY),
       ...(sessionProperties && { sessionProperties }),
@@ -692,6 +694,7 @@ export class Engine extends IEngine {
       requiredNamespaces: {},
       optionalNamespaces: namespaces,
       relays: [{ protocol: "irn" }],
+      pairingTopic,
       proposer: {
         publicKey,
         metadata: this.client.metadata,
@@ -1501,22 +1504,15 @@ export class Engine extends IEngine {
     const { id, params } = payload;
     try {
       this.isValidSessionSettleRequest(params);
-      const {
-        relay,
-        controller,
-        expiry,
-        namespaces,
-        sessionProperties,
-        pairingTopic,
-        sessionConfig,
-      } = payload.params;
+      const { relay, controller, expiry, namespaces, sessionProperties, sessionConfig } =
+        payload.params;
       const session = {
         topic,
         relay,
         expiry,
         namespaces,
         acknowledged: true,
-        pairingTopic,
+        pairingTopic: "", // pairingTopic will be set in the `session_connect` listener
         requiredNamespaces: {},
         optionalNamespaces: {},
         controller: controller.publicKey,
@@ -1543,7 +1539,6 @@ export class Engine extends IEngine {
         throw new Error(`emitting ${target} without any listeners 997`);
       }
       this.events.emit(engineEvent("session_connect"), { session });
-      this.cleanupDuplicatePairings(session);
     } catch (err: any) {
       await this.sendError({
         id,

--- a/packages/types/src/sign-client/jsonrpc.ts
+++ b/packages/types/src/sign-client/jsonrpc.ts
@@ -44,7 +44,6 @@ export declare namespace JsonRpcTypes {
       namespaces: SessionTypes.Namespaces;
       sessionProperties?: ProposalTypes.SessionProperties;
       sessionConfig?: SessionTypes.SessionConfig;
-      pairingTopic: string;
       expiry: number;
       controller: {
         publicKey: string;

--- a/packages/types/src/sign-client/proposal.ts
+++ b/packages/types/src/sign-client/proposal.ts
@@ -30,7 +30,7 @@ export declare namespace ProposalTypes {
     requiredNamespaces: RequiredNamespaces;
     optionalNamespaces: OptionalNamespaces;
     sessionProperties?: SessionProperties;
-    pairingTopic?: string;
+    pairingTopic: string;
   }
 }
 


### PR DESCRIPTION
## Description
Reworked dapp side to set `pairingTopic` on its own instead of relying on being provided by session settle request

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
existing tests 

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
