### PR TITLE
fix: handle multiple event handlers for the same event

### DIFF
--- a/packages/web3wallet/src/controllers/engine.ts
+++ b/packages/web3wallet/src/controllers/engine.ts
@@ -124,11 +124,13 @@ export class Engine extends IWeb3WalletEngine {
 
   // ---------- public events ----------------------------------------------- //
   public on: IWeb3WalletEngine["on"] = (name, listener) => {
+    this.setEvent(name, "off");
     this.setEvent(name, "on");
     return this.client.events.on(name, listener);
   };
 
   public once: IWeb3WalletEngine["once"] = (name, listener) => {
+    this.setEvent(name, "off");
     this.setEvent(name, "once");
     return this.client.events.once(name, listener);
   };

--- a/packages/web3wallet/test/sign.spec.ts
+++ b/packages/web3wallet/test/sign.spec.ts
@@ -10,7 +10,7 @@ import { buildApprovedNamespaces, buildAuthObject, getSdkError } from "@walletco
 import { toMiliseconds } from "@walletconnect/time";
 import { Wallet as CryptoWallet } from "@ethersproject/wallet";
 
-import { expect, describe, it, beforeEach, vi, beforeAll, afterAll, afterEach } from "vitest";
+import { expect, describe, it, beforeEach, vi, beforeAll, afterEach, fn } from "vitest";
 import { Web3Wallet, IWeb3Wallet } from "../src";
 import {
   disconnect,
@@ -462,6 +462,25 @@ describe("Sign Integration", () => {
     expect(sessions).to.be.exist;
     expect(Object.values(sessions).length).to.be.eq(1);
     expect(Object.keys(sessions)[0]).to.be.eq(session.topic);
+  });
+
+  it("should handle multiple session proposal listeners correctly", async () => {
+    const firstHandler = vi.fn();
+    const secondHandler = vi.fn();
+
+    await Promise.all([
+      new Promise<void>((resolve) => {
+        wallet.on("session_proposal", firstHandler);
+        wallet.on("session_proposal", secondHandler);
+        wallet.on("session_proposal", () => {
+          resolve();
+        });
+      }),
+      wallet.pair({ uri: uriString }),
+    ]);
+
+    expect(firstHandler.mock.calls).toHaveLength(1);
+    expect(secondHandler.mock.calls).toHaveLength(1);
   });
 
   it("should get pending session proposals", async () => {


### PR DESCRIPTION

## Description
Currently when calling the Wallet Connect wallet's `on` function it registers the `onSessionProposal` handler multiple times in the `signClient`. 
This causes each event to be called as many times as there are event handlers registered for the event.

This fix always calls `off` before calling `on` when setting the `onSessionProposal` handler.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

I added a unit test which caught the issue.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

The bug came up while working on https://github.com/safe-global/safe-wallet-web/pull/3656 and the fix is required to unblock it.