### PR TITLE
fix: metadata field required

### DIFF
--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -1,8 +1,8 @@
-import { TEST_WALLET_METADATA } from "./../../../../providers/universal-provider/test/shared/constants";
 import {
   TEST_APP_METADATA_A,
   TEST_EMPTY_METADATA,
   TEST_INVALID_METADATA,
+  TEST_WALLET_METADATA,
 } from "./../shared/values";
 import {
   formatJsonRpcError,

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -1,4 +1,9 @@
-import { TEST_EMPTY_METADATA, TEST_INVALID_METADATA } from "./../shared/values";
+import { TEST_WALLET_METADATA } from "./../../../../providers/universal-provider/test/shared/constants";
+import {
+  TEST_APP_METADATA_A,
+  TEST_EMPTY_METADATA,
+  TEST_INVALID_METADATA,
+} from "./../shared/values";
 import {
   formatJsonRpcError,
   formatJsonRpcResult,
@@ -177,8 +182,16 @@ describe("Sign Client Integration", () => {
       await deleteClients(clients);
     });
     it("should emit session_proposal on every pair attempt with same URI as long as the proposal has not yet been approved or rejected", async () => {
-      const dapp = await SignClient.init({ ...TEST_SIGN_CLIENT_OPTIONS, name: "dapp" });
-      const wallet = await SignClient.init({ ...TEST_SIGN_CLIENT_OPTIONS, name: "wallet" });
+      const dapp = await SignClient.init({
+        ...TEST_SIGN_CLIENT_OPTIONS,
+        name: "dapp",
+        metadata: TEST_APP_METADATA_A,
+      });
+      const wallet = await SignClient.init({
+        ...TEST_SIGN_CLIENT_OPTIONS,
+        name: "wallet",
+        metadata: TEST_WALLET_METADATA,
+      });
       const { uri, approval } = await dapp.connect(TEST_CONNECT_PARAMS);
       if (!uri) throw new Error("URI is undefined");
       expect(uri).to.exist;
@@ -224,8 +237,16 @@ describe("Sign Client Integration", () => {
       await deleteClients({ A: dapp, B: wallet });
     });
     it("should set `sessionConfig`", async () => {
-      const dapp = await SignClient.init({ ...TEST_SIGN_CLIENT_OPTIONS, name: "dapp" });
-      const wallet = await SignClient.init({ ...TEST_SIGN_CLIENT_OPTIONS, name: "wallet" });
+      const dapp = await SignClient.init({
+        ...TEST_SIGN_CLIENT_OPTIONS,
+        name: "dapp",
+        metadata: TEST_APP_METADATA_A,
+      });
+      const wallet = await SignClient.init({
+        ...TEST_SIGN_CLIENT_OPTIONS,
+        name: "wallet",
+        metadata: TEST_WALLET_METADATA,
+      });
       const { uri, approval } = await dapp.connect(TEST_CONNECT_PARAMS);
       if (!uri) throw new Error("URI is undefined");
       expect(uri).to.exist;
@@ -267,8 +288,16 @@ describe("Sign Client Integration", () => {
       await deleteClients({ A: dapp, B: wallet });
     });
     it("should use rejected tag for session_propose", async () => {
-      const dapp = await SignClient.init({ ...TEST_SIGN_CLIENT_OPTIONS, name: "dapp" });
-      const wallet = await SignClient.init({ ...TEST_SIGN_CLIENT_OPTIONS, name: "wallet" });
+      const dapp = await SignClient.init({
+        ...TEST_SIGN_CLIENT_OPTIONS,
+        name: "dapp",
+        metadata: TEST_APP_METADATA_A,
+      });
+      const wallet = await SignClient.init({
+        ...TEST_SIGN_CLIENT_OPTIONS,
+        name: "wallet",
+        metadata: TEST_WALLET_METADATA,
+      });
       const { uri } = await dapp.connect(TEST_CONNECT_PARAMS);
       if (!uri) throw new Error("URI is undefined");
       expect(uri).to.exist;

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -45,6 +45,19 @@ describe("Sign Client Integration", () => {
     await deleteClients({ A: client, B: undefined });
   });
 
+  it("should not initialize without metadata object", async () => {
+    const options = TEST_SIGN_CLIENT_OPTIONS;
+    delete options.metadata;
+
+    await expect(
+      SignClient.init({
+        ...options,
+        name: "init",
+        signConfig: { disableRequestQueue: true },
+      }),
+    ).rejects.toThrowError("name is required value in metadata");
+  });
+
   it("should not initialize with empty metadata", async () => {
     await expect(
       SignClient.init({

--- a/packages/sign-client/test/shared/values.ts
+++ b/packages/sign-client/test/shared/values.ts
@@ -285,3 +285,10 @@ export const TEST_INVALID_METADATA: SignClientTypes.Metadata = {
   url: "",
   icons: ["test"],
 };
+
+export const TEST_WALLET_METADATA = {
+  name: "Test Wallet",
+  description: "Test Wallet for WalletConnect",
+  url: "https://walletconnect.com/",
+  icons: ["https://avatars.githubusercontent.com/u/37784886"],
+};

--- a/packages/types/src/sign-client/client.ts
+++ b/packages/types/src/sign-client/client.ts
@@ -66,7 +66,7 @@ export declare namespace SignClientTypes {
 
   interface Options extends CoreTypes.Options {
     core?: ICore;
-    metadata: Metadata;
+    metadata?: Metadata;
     signConfig?: SignConfig;
   }
 }

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -68,7 +68,7 @@ export interface EthereumRpcConfig {
   optionalEvents?: string[];
   rpcMap: EthereumRpcMap;
   projectId: string;
-  metadata: Metadata;
+  metadata?: Metadata;
   showQrModal: boolean;
   qrModalOptions?: QrModalOptions;
 }
@@ -213,7 +213,7 @@ export type EthereumProviderOptions = {
   events?: string[];
   optionalEvents?: string[];
   rpcMap?: EthereumRpcMap;
-  metadata: Metadata;
+  metadata?: Metadata;
   showQrModal: boolean;
   qrModalOptions?: QrModalOptions;
   disableProviderPing?: boolean;
@@ -558,13 +558,18 @@ export class EthereumProvider implements IEthereumProvider {
   }
 
   protected async initialize(opts: EthereumProviderOptions) {
+    const metadata = this.rpc.metadata;
+    if (metadata === undefined) {
+      throw new Error("Metadata field is required");
+    }
+
     this.rpc = this.getRpcConfig(opts);
     this.chainId = this.rpc.chains.length
       ? getEthereumChainId(this.rpc.chains)
       : getEthereumChainId(this.rpc.optionalChains);
     this.signer = await UniversalProvider.init({
       projectId: this.rpc.projectId,
-      metadata: this.rpc.metadata,
+      metadata,
       disableProviderPing: opts.disableProviderPing,
       relayUrl: opts.relayUrl,
       storageOptions: opts.storageOptions,

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -558,12 +558,13 @@ export class EthereumProvider implements IEthereumProvider {
   }
 
   protected async initialize(opts: EthereumProviderOptions) {
+    this.rpc = this.getRpcConfig(opts);
+
     const metadata = this.rpc.metadata;
     if (metadata === undefined) {
       throw new Error("Metadata field is required");
     }
 
-    this.rpc = this.getRpcConfig(opts);
     this.chainId = this.rpc.chains.length
       ? getEthereumChainId(this.rpc.chains)
       : getEthereumChainId(this.rpc.optionalChains);

--- a/providers/ethereum-provider/test/index.spec.ts
+++ b/providers/ethereum-provider/test/index.spec.ts
@@ -1,4 +1,3 @@
-import { TEST_APP_METADATA_A } from "./../../../packages/sign-client/test/shared/values";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import Web3 from "web3";
 import { BigNumber, providers, utils } from "ethers";
@@ -24,6 +23,7 @@ import {
   TEST_ETHEREUM_METHODS_REQUIRED,
   TEST_ETHEREUM_METHODS_OPTIONAL,
   TEST_WALLET_METADATA,
+  TEST_APP_METADATA_A,
 } from "./shared/constants";
 import { EthereumProviderOptions } from "../src/EthereumProvider";
 import { parseChainId } from "@walletconnect/utils";

--- a/providers/ethereum-provider/test/index.spec.ts
+++ b/providers/ethereum-provider/test/index.spec.ts
@@ -564,6 +564,7 @@ describe("EthereumProvider", function () {
           chains: [],
           optionalChains: [],
           showQrModal: false,
+          metadata: TEST_WALLET_METADATA,
         }),
       ).rejects.toThrowError("No chains specified in either `chains` or `optionalChains`");
     });

--- a/providers/ethereum-provider/test/index.spec.ts
+++ b/providers/ethereum-provider/test/index.spec.ts
@@ -1,3 +1,4 @@
+import { TEST_APP_METADATA_A } from "./../../../packages/sign-client/test/shared/values";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import Web3 from "web3";
 import { BigNumber, providers, utils } from "ethers";
@@ -53,7 +54,7 @@ describe("EthereumProvider", function () {
         },
       },
       disableProviderPing: true,
-      metadata: TEST_WALLET_METADATA,
+      metadata: TEST_APP_METADATA_A,
     });
     walletClient = await WalletClient.init(provider, TEST_WALLET_CLIENT_OPTS);
     await provider.connect({

--- a/providers/ethereum-provider/test/shared/constants.ts
+++ b/providers/ethereum-provider/test/shared/constants.ts
@@ -83,3 +83,14 @@ export const TEST_ETHEREUM_METHODS_OPTIONAL = [
   "personal_sign",
   "eth_signTypedData",
 ];
+
+export const TEST_APP_METADATA_A = {
+  name: "App A (Proposer)",
+  description: "Description of Proposer App run by client A",
+  url: "https://app.a.walletconnect.com",
+  icons: ["https://avatars.githubusercontent.com/u/37784886"],
+  redirect: {
+    universal: "App A (Proposer)",
+    native: "App A Native (Proposer)",
+  },
+};


### PR DESCRIPTION
## Description

- Metadata validation was introduced, however in the [same PR](https://github.com/WalletConnect/walletconnect-monorepo/pull/4554) it was made required. Reverting the change and making it optional again.
- Test to cover the state when the object is not provided

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your configuration.

## Fixes/Resolves (Optional)

Please list any issues that are fixed by this PR in the format `#<issue number>`. If it fixes multiple issues, please put each issue in a separate line. If this Pull Request does not fix any issues, please delete this section.

## Examples/Screenshots (Optional)

Please attach a screenshot or screen recording of features/fixes you've implemented to verify your changes. Please also note any relevant details for your configuration. If your changes do not affect the UI, please delete this section.

Use this table template to show examples of your changes:

| Before       | After        |
| ------------ | ------------ |
| Content Cell | Content Cell |
| Content Cell | Content Cell |

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
