### PR TITLE
fix: process incoming requests in order

### DIFF
--- a/packages/core/src/controllers/subscriber.ts
+++ b/packages/core/src/controllers/subscriber.ts
@@ -457,9 +457,7 @@ export class Subscriber extends ISubscriber {
     await this.batchSubscribe(pendingSubscriptions);
 
     if (this.pendingBatchMessages.length) {
-      console.log("starting delivery batch messages");
       await this.relayer.handleBatchMessageEvents(this.pendingBatchMessages);
-      console.log("batch messages delivered successfully");
       this.pendingBatchMessages = [];
     }
   }

--- a/packages/core/src/controllers/subscriber.ts
+++ b/packages/core/src/controllers/subscriber.ts
@@ -457,7 +457,9 @@ export class Subscriber extends ISubscriber {
     await this.batchSubscribe(pendingSubscriptions);
 
     if (this.pendingBatchMessages.length) {
+      console.log("starting delivery batch messages");
       await this.relayer.handleBatchMessageEvents(this.pendingBatchMessages);
+      console.log("batch messages delivered successfully");
       this.pendingBatchMessages = [];
     }
   }

--- a/packages/sign-client/src/client.ts
+++ b/packages/sign-client/src/client.ts
@@ -253,6 +253,7 @@ export class SignClient extends ISignClient {
       await this.auth.init();
       this.core.verify.init({ verifyUrl: this.metadata.verifyUrl });
       this.logger.info(`SignClient Initialization Success`);
+      this.engine.processRelayMessageCache();
     } catch (error: any) {
       this.logger.info(`SignClient Initialization Failure`);
       this.logger.error(error.message);

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -1336,9 +1336,11 @@ export class Engine extends IEngine {
       if (!request) continue;
 
       try {
-        this.processRequest(request);
+        console.log("Processing request", request.payload.id);
+        await this.processRequest(request);
         // small delay to allow for any async tasks to complete
         await new Promise((resolve) => setTimeout(resolve, 300));
+        console.log("Request processed", request.payload.id, "✅");
       } catch (error) {
         this.client.logger.warn(error);
       }
@@ -1346,7 +1348,7 @@ export class Engine extends IEngine {
     this.requestQueue.state = ENGINE_QUEUE_STATES.idle;
   };
 
-  private processRequest: EnginePrivate["onRelayEventRequest"] = (event) => {
+  private processRequest: EnginePrivate["onRelayEventRequest"] = async (event) => {
     const { topic, payload } = event;
     const reqMethod = payload.method as JsonRpcTypes.WcMethod;
 
@@ -1356,23 +1358,23 @@ export class Engine extends IEngine {
 
     switch (reqMethod) {
       case "wc_sessionPropose":
-        return this.onSessionProposeRequest(topic, payload);
+        return await this.onSessionProposeRequest(topic, payload);
       case "wc_sessionSettle":
-        return this.onSessionSettleRequest(topic, payload);
+        return await this.onSessionSettleRequest(topic, payload);
       case "wc_sessionUpdate":
-        return this.onSessionUpdateRequest(topic, payload);
+        return await this.onSessionUpdateRequest(topic, payload);
       case "wc_sessionExtend":
-        return this.onSessionExtendRequest(topic, payload);
+        return await this.onSessionExtendRequest(topic, payload);
       case "wc_sessionPing":
-        return this.onSessionPingRequest(topic, payload);
+        return await this.onSessionPingRequest(topic, payload);
       case "wc_sessionDelete":
-        return this.onSessionDeleteRequest(topic, payload);
+        return await this.onSessionDeleteRequest(topic, payload);
       case "wc_sessionRequest":
-        return this.onSessionRequest(topic, payload);
+        return await this.onSessionRequest(topic, payload);
       case "wc_sessionEvent":
-        return this.onSessionEventRequest(topic, payload);
+        return await this.onSessionEventRequest(topic, payload);
       case "wc_sessionAuthenticate":
-        return this.onSessionAuthenticateRequest(topic, payload);
+        return await this.onSessionAuthenticateRequest(topic, payload);
       default:
         return this.client.logger.info(`Unsupported request method ${reqMethod}`);
     }

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -1361,8 +1361,6 @@ export class Engine extends IEngine {
 
       try {
         await this.processRequest(request);
-        // small delay to allow for any async tasks to complete
-        await new Promise((resolve) => setTimeout(resolve, 300));
       } catch (error) {
         this.client.logger.warn(error);
       }

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -200,7 +200,7 @@ export interface EnginePrivate {
     rpcOpts?: RelayerTypes.PublishOptions;
   }): Promise<void>;
 
-  onRelayEventRequest(event: EngineTypes.EventCallback<JsonRpcRequest>): void;
+  onRelayEventRequest(event: EngineTypes.EventCallback<JsonRpcRequest>): Promise<void>;
 
   onRelayEventResponse(event: EngineTypes.EventCallback<JsonRpcResponse>): Promise<void>;
 

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -402,4 +402,6 @@ export abstract class IEngine {
   }) => string;
 
   public abstract rejectSessionAuthenticate(params: EngineTypes.RejectParams): Promise<void>;
+
+  public abstract processRelayMessageCache(): void;
 }


### PR DESCRIPTION
## Description
Updated intake logic of incoming relay messages so they are processed by Sign Client one by one instead of all at the same time. The old approach was resulting in conflicts when messages were dependent on each other such as `session_update` adding new chain to the session and `session_event`instructing the client to switch to that new chain. In the above case, the `session_event` must be processed after the `session_update` has finished the update, else the client has no knowledge of that new chain.

Additionally,  implemented `relayMessageCache` that stores any messages received while the client is still initializing and the messages are processed after init has finished. This allows implementing apps to setup all event listeners and not miss  events 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
dogfooding

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
