### PR TITLE
fix: always use fallback verify server

### DIFF
--- a/packages/core/src/constants/verify.ts
+++ b/packages/core/src/constants/verify.ts
@@ -1,7 +1,7 @@
 export const VERIFY_CONTEXT = "verify-api";
 
-export const VERIFY_SERVER = "https://verify.walletconnect.com";
+const VERIFY_SERVER_COM = "https://verify.walletconnect.com";
+const VERIFY_SERVER_ORG = "https://verify.walletconnect.org";
+export const VERIFY_SERVER = VERIFY_SERVER_ORG;
 
-export const VERIFY_FALLBACK_SERVER = "https://verify.walletconnect.org";
-
-export const TRUSTED_VERIFY_URLS = [VERIFY_SERVER, VERIFY_FALLBACK_SERVER];
+export const TRUSTED_VERIFY_URLS = [VERIFY_SERVER_COM, VERIFY_SERVER_ORG];

--- a/packages/core/src/controllers/verify.ts
+++ b/packages/core/src/controllers/verify.ts
@@ -3,12 +3,7 @@ import { IVerify } from "@walletconnect/types";
 import { isBrowser, isNode, isReactNative } from "@walletconnect/utils";
 import { FIVE_SECONDS, ONE_SECOND, toMiliseconds } from "@walletconnect/time";
 
-import {
-  TRUSTED_VERIFY_URLS,
-  VERIFY_CONTEXT,
-  VERIFY_FALLBACK_SERVER,
-  VERIFY_SERVER,
-} from "../constants";
+import { TRUSTED_VERIFY_URLS, VERIFY_CONTEXT, VERIFY_SERVER } from "../constants";
 
 export class Verify extends IVerify {
   public name = VERIFY_CONTEXT;
@@ -49,19 +44,7 @@ export class Verify extends IVerify {
     } catch (error) {
       this.logger.info(`Verify iframe failed to load: ${this.verifyUrl}`);
       this.logger.info(error);
-    }
-
-    if (this.initialized) return;
-
-    this.removeIframe();
-    this.verifyUrl = VERIFY_FALLBACK_SERVER;
-
-    try {
-      await this.createIframe();
-    } catch (error) {
-      this.logger.info(`Verify iframe failed to load: ${this.verifyUrl}`);
-      this.logger.info(error);
-      // if the fallback url fails to load as well, disable verify
+      // if the iframe fails to load, disable verify
       this.verifyDisabled = true;
     }
   };
@@ -79,17 +62,7 @@ export class Verify extends IVerify {
     if (this.isDevEnv) return "";
 
     const verifyUrl = this.getVerifyUrl(params?.verifyUrl);
-    let result;
-    try {
-      result = await this.fetchAttestation(params.attestationId, verifyUrl);
-    } catch (error) {
-      this.logger.info(
-        `failed to resolve attestation: ${params.attestationId} from url: ${verifyUrl}`,
-      );
-      this.logger.info(error);
-      result = await this.fetchAttestation(params.attestationId, VERIFY_FALLBACK_SERVER);
-    }
-    return result;
+    return this.fetchAttestation(params.attestationId, verifyUrl);
   };
 
   get context(): string {

--- a/packages/core/src/controllers/verify.ts
+++ b/packages/core/src/controllers/verify.ts
@@ -72,7 +72,7 @@ export class Verify extends IVerify {
   private fetchAttestation = async (attestationId: string, url: string) => {
     this.logger.info(`resolving attestation: ${attestationId} from url: ${url}`);
     // set artificial timeout to prevent hanging
-    const timeout = this.startAbortTimer(ONE_SECOND * 2);
+    const timeout = this.startAbortTimer(ONE_SECOND * 5);
     const result = await fetch(`${url}/attestation/${attestationId}`, {
       signal: this.abortController.signal,
     });


### PR DESCRIPTION
## Description

`verify.walletconnect.org` is routable in all regions, so just use it directly instead of having fallback logic which increases latency.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Not tested

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules