### PR TITLE
chore: partially dedupe fetch implementations and use native fetch instead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10462,14 +10462,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -14172,28 +14164,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -14582,17 +14552,6 @@
       "version": "1.7.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -20573,24 +20532,6 @@
       },
       "engines": {
         "node": ">= 0.10.5"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
       }
     },
     "node_modules/node-environment-flags": {
@@ -26599,14 +26540,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/web3": {
       "version": "1.7.5",
       "dev": true,
@@ -27484,31 +27417,11 @@
         "@walletconnect/types": "2.13.3",
         "@walletconnect/utils": "2.13.3",
         "events": "3.3.0",
-        "isomorphic-unfetch": "3.1.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "3.1.0"
       },
       "devDependencies": {
-        "@types/lodash.isequal": "4.5.6",
-        "node-fetch": "3.3.0"
-      }
-    },
-    "packages/core/node_modules/node-fetch": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
-      "dev": true,
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
+        "@types/lodash.isequal": "4.5.6"
       }
     },
     "packages/core/node_modules/uint8arrays": {
@@ -27609,7 +27522,7 @@
     },
     "packages/web3wallet": {
       "name": "@walletconnect/web3wallet",
-      "version": "2.13.3",
+      "version": "1.12.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/auth-client": "2.1.2",
@@ -33641,23 +33554,10 @@
         "@walletconnect/types": "2.13.3",
         "@walletconnect/utils": "2.13.3",
         "events": "3.3.0",
-        "isomorphic-unfetch": "3.1.0",
         "lodash.isequal": "4.5.0",
-        "node-fetch": "3.3.0",
         "uint8arrays": "3.1.0"
       },
       "dependencies": {
-        "node-fetch": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-          "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
-          "dev": true,
-          "requires": {
-            "data-uri-to-buffer": "^4.0.0",
-            "fetch-blob": "^3.1.4",
-            "formdata-polyfill": "^4.0.10"
-          }
-        },
         "uint8arrays": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.0.tgz",
@@ -35960,10 +35860,6 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
-    },
-    "data-uri-to-buffer": {
-      "version": "4.0.1",
-      "dev": true
     },
     "dateformat": {
       "version": "3.0.3",
@@ -38424,14 +38320,6 @@
         "bser": "2.1.1"
       }
     },
-    "fetch-blob": {
-      "version": "3.2.0",
-      "dev": true,
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -38711,13 +38599,6 @@
     "form-data-encoder": {
       "version": "1.7.1",
       "dev": true
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "dev": true,
-      "requires": {
-        "fetch-blob": "^3.1.2"
-      }
     },
     "forwarded": {
       "version": "0.2.0",
@@ -43156,10 +43037,6 @@
         "minimatch": "^3.0.2"
       }
     },
-    "node-domexception": {
-      "version": "1.0.0",
-      "dev": true
-    },
     "node-environment-flags": {
       "version": "1.0.6",
       "dev": true,
@@ -47490,10 +47367,6 @@
       "requires": {
         "defaults": "^1.0.3"
       }
-    },
-    "web-streams-polyfill": {
-      "version": "3.2.1",
-      "dev": true
     },
     "web3": {
       "version": "1.7.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,5 +50,8 @@
   },
   "devDependencies": {
     "@types/lodash.isequal": "4.5.6"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,12 +45,10 @@
     "@walletconnect/types": "2.13.3",
     "@walletconnect/utils": "2.13.3",
     "events": "3.3.0",
-    "isomorphic-unfetch": "3.1.0",
     "lodash.isequal": "4.5.0",
     "uint8arrays": "3.1.0"
   },
   "devDependencies": {
-    "@types/lodash.isequal": "4.5.6",
-    "node-fetch": "3.3.0"
+    "@types/lodash.isequal": "4.5.6"
   }
 }

--- a/packages/core/src/controllers/echo.ts
+++ b/packages/core/src/controllers/echo.ts
@@ -1,7 +1,6 @@
 import { generateChildLogger, Logger } from "@walletconnect/logger";
 import { IEchoClient } from "@walletconnect/types";
 import { ECHO_CONTEXT, ECHO_URL } from "../constants";
-import fetch from "isomorphic-unfetch";
 
 export class EchoClient extends IEchoClient {
   public readonly context = ECHO_CONTEXT;

--- a/packages/core/test/verify.spec.ts
+++ b/packages/core/test/verify.spec.ts
@@ -1,5 +1,4 @@
 import { expect, describe, it } from "vitest";
-import fetch from "node-fetch";
 import { hashMessage } from "@walletconnect/utils";
 
 import { Core, VERIFY_SERVER } from "../src";


### PR DESCRIPTION
## Description

This PR removes a few duplicate fetch implementations from WC and keeps only the ones by subdependencies (since downstream projects have to remove them). Instead packages now would use native fetch. It also puts a node 18.x requirement for fetch.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Unit tests.

## Fixes/Resolves (Optional)

Fixes #5102

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
