### PR TITLE
chore: parsing optional fields in formatMessage function

### DIFF
--- a/packages/utils/src/cacao.ts
+++ b/packages/utils/src/cacao.ts
@@ -61,6 +61,9 @@ export const formatMessage = (cacao: AuthTypes.FormatMessageParams, iss: string)
   const chainId = `Chain ID: ${getDidChainId(iss)}`;
   const nonce = `Nonce: ${cacao.nonce}`;
   const issuedAt = `Issued At: ${cacao.iat}`;
+  const expirationTime = cacao.exp ? `Expiration Time: ${cacao.exp}` : undefined;
+  const notBefore = cacao.nbf ? `Not Before: ${cacao.nbf}` : undefined;
+  const requestId = cacao.requestId ? `Request ID: ${cacao.requestId}` : undefined;
   const resources = cacao.resources
     ? `Resources:${cacao.resources.map((resource) => `\n- ${resource}`).join("")}`
     : undefined;
@@ -81,6 +84,9 @@ export const formatMessage = (cacao: AuthTypes.FormatMessageParams, iss: string)
     chainId,
     nonce,
     issuedAt,
+    expirationTime,
+    notBefore,
+    requestId,
     resources,
   ]
     .filter((val) => val !== undefined && val !== null) // remove unnecessary empty lines

--- a/packages/utils/test/cacao.spec.ts
+++ b/packages/utils/test/cacao.spec.ts
@@ -330,5 +330,40 @@ describe("URI", () => {
       expect(message).to.include(`Resources:`);
       expect(message).to.include(request.resources[0]);
     });
+
+    it("should add optional params to siwe message", () => {
+      const request = {
+        type: "caip122",
+        chains: ["eip155:1"],
+        aud: "https://example.com",
+        domain: "http://localhost:3000",
+        version: "1",
+        nonce: "1",
+        iat: "2024-02-19T09:29:21.394Z",
+        exp: "2024-02-25T09:29:21.394Z",
+        nbf: "2024-02-20T09:29:21.394Z",
+        requestId: "123",
+        statement: "Requesting access to your account",
+        resources: [
+          "https://example.com",
+          "urn:recap:eyJhdHQiOnsiZWlwMTU1Ijp7InJlcXVlc3QvZXRoX2NoYWluSWQiOlt7fV0sInJlcXVlc3QvZXRoX3NpZ25UeXBlZERhdGFfdjQiOlt7fV0sInB1c2gvcGVyc29uYWxfc2lnbiI6W3t9XX0sImh0dHBzOi8vbm90aWZ5LndhbGxldGNvbm5lY3QuY29tIjp7Im1hbmFnZS9hbGwtYXBwcy1ub3RpZmljYXRpb25zIjpbe31dLCJlbWl0L2FsZXJ0cyI6W3t9XX19fQ",
+        ],
+      };
+
+      const message = formatMessage(
+        request as any,
+        "did:pkh:eip155:1:0x3613699A6c5D8BC97a08805876c8005543125F09",
+      );
+
+      expect(message).to.include("Version: 1");
+      expect(message).to.include("Nonce: 1");
+      expect(message).to.include(`URI: ${request.aud}`);
+      expect(message).to.include(`Issued At: ${request.iat}`);
+      expect(message).to.include(`Expiration Time: ${request.exp}`);
+      expect(message).to.include(`Not Before: ${request.nbf}`);
+      expect(message).to.include(`Request ID: ${request.requestId}`);
+      expect(message).to.include(`Resources:`);
+      expect(message).to.include(request.resources[0]);
+    });
   });
 });


### PR DESCRIPTION
## Description
* Added missing optional params to formatMessage function to comply with EIP-4361 [specs](https://docs.login.xyz/general-information/siwe-overview/eip-4361#message-field-descriptions)

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Tested the function in react-native when generating a message with `Expiration Time`, `Request Id` and `Not Before` params

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information

Thanks @thiagobrez for reporting