### PR TITLE
refactor:  `.org` relay url

### DIFF
--- a/packages/core/src/constants/relayer.ts
+++ b/packages/core/src/constants/relayer.ts
@@ -4,8 +4,7 @@ export const RELAYER_DEFAULT_PROTOCOL = "irn";
 
 export const RELAYER_DEFAULT_LOGGER = "error";
 
-export const RELAYER_DEFAULT_RELAY_URL = "wss://relay.walletconnect.com";
-export const RELAYER_FAILOVER_RELAY_URL = "wss://relay.walletconnect.org";
+export const RELAYER_DEFAULT_RELAY_URL = "wss://relay.walletconnect.org";
 
 export const RELAYER_CONTEXT = "relayer";
 

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -48,7 +48,6 @@ import {
   RELAYER_PROVIDER_EVENTS,
   RELAYER_SUBSCRIBER_SUFFIX,
   RELAYER_DEFAULT_RELAY_URL,
-  RELAYER_FAILOVER_RELAY_URL,
   SUBSCRIBER_EVENTS,
   RELAYER_RECONNECT_TIMEOUT,
   RELAYER_TRANSPORT_CUTOFF,
@@ -118,16 +117,8 @@ export class Relayer extends IRelayer {
     this.logger.trace(`Initialized`);
     this.registerEventListeners();
     await Promise.all([this.messages.init(), this.subscriber.init()]);
-    try {
-      await this.transportOpen();
-    } catch {
-      this.logger.warn(
-        `Connection via ${this.relayUrl} failed, attempting to connect via failover domain ${RELAYER_FAILOVER_RELAY_URL}...`,
-      );
-      await this.restartTransport(RELAYER_FAILOVER_RELAY_URL);
-    }
+    await this.transportOpen();
     this.initialized = true;
-
     setTimeout(async () => {
       if (this.subscriber.topics.length === 0 && this.subscriber.pending.size === 0) {
         this.logger.info(`No topics subscribed to after init, closing transport`);

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -1,4 +1,3 @@
-import { RELAYER_FAILOVER_RELAY_URL } from "./../src/constants/relayer";
 import { expect, describe, it, beforeEach, afterEach } from "vitest";
 import { getDefaultLoggerOptions, pino } from "@walletconnect/logger";
 import { JsonRpcProvider } from "@walletconnect/jsonrpc-provider";
@@ -7,6 +6,7 @@ import {
   Core,
   CORE_DEFAULT,
   Relayer,
+  RELAYER_DEFAULT_RELAY_URL,
   RELAYER_EVENTS,
   RELAYER_PROVIDER_EVENTS,
   RELAYER_SUBSCRIBER_SUFFIX,
@@ -301,16 +301,15 @@ describe("Relayer", () => {
         await throttle(RELAYER_TRANSPORT_CUTOFF + 1_000); // +1 sec buffer
         expect(relayer.connected).to.be.true;
       });
-      it(`should fall back to ${RELAYER_FAILOVER_RELAY_URL} if the default relayUrl is not reachable`, async () => {
+      it(`should connect to ${RELAYER_DEFAULT_RELAY_URL} relay url`, async () => {
         relayer = new Relayer({
           core,
-          relayUrl: "wss://relay.blocked.not.real",
           projectId: TEST_CORE_OPTIONS.projectId,
         });
         await relayer.init();
         const wsConnection = relayer.provider.connection as unknown as WebSocket;
         expect(relayer.connected).to.be.true;
-        expect(wsConnection.url.startsWith(RELAYER_FAILOVER_RELAY_URL)).to.be.true;
+        expect(wsConnection.url.startsWith(RELAYER_DEFAULT_RELAY_URL)).to.be.true;
       });
     });
   });


### PR DESCRIPTION
## Description
Set `.org` relay url to be used by default and removed the now redundant fallback logic 

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests 

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
