### PR TITLE
feat: verify context session authenticate

### DIFF
--- a/packages/sign-client/src/constants/verify.ts
+++ b/packages/sign-client/src/constants/verify.ts
@@ -1,1 +1,6 @@
-export const METHODS_TO_VERIFY = ["wc_sessionPropose", "wc_sessionRequest", "wc_authRequest"];
+export const METHODS_TO_VERIFY = [
+  "wc_sessionPropose",
+  "wc_sessionRequest",
+  "wc_authRequest",
+  "wc_sessionAuthenticate",
+];

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -1879,6 +1879,7 @@ export class Engine extends IEngine {
         topic,
         params: payload.params,
         id: payload.id,
+        verifyContext,
       });
     } catch (err: any) {
       this.client.logger.error(err);

--- a/packages/sign-client/test/sdk/auth.spec.ts
+++ b/packages/sign-client/test/sdk/auth.spec.ts
@@ -49,6 +49,10 @@ describe("Authenticated Sessions", () => {
       Promise.race<void>([
         new Promise((resolve) => {
           wallet.on("session_authenticate", async (payload) => {
+            const verifyContext = payload.verifyContext;
+            expect(verifyContext).to.exist;
+            expect(verifyContext.verified.validation).to.eq("UNKNOWN");
+
             // validate that the dapp has both `session_authenticate` & `session_proposal` stored
             // and expirer configured
             const pendingProposals = dapp.proposal.getAll();
@@ -297,6 +301,10 @@ describe("Authenticated Sessions", () => {
     await Promise.all([
       new Promise<void>((resolve) => {
         wallet.on("session_authenticate", async (payload) => {
+          const verifyContext = payload.verifyContext;
+          expect(verifyContext).to.exist;
+          expect(verifyContext.verified.validation).to.eq("UNKNOWN");
+
           // validate that the dapp has both `session_authenticate` & `session_proposal` stored
           // and expirer configured
           const pendingProposals = dapp.proposal.getAll();

--- a/packages/types/src/sign-client/client.ts
+++ b/packages/types/src/sign-client/client.ts
@@ -53,7 +53,9 @@ export declare namespace SignClientTypes {
       event: { name: string; data: any };
       chainId: string;
     }>;
-    session_authenticate: BaseEventArgs<AuthTypes.AuthRequestEventArgs>;
+    session_authenticate: {
+      verifyContext: Verify.Context;
+    } & BaseEventArgs<AuthTypes.AuthRequestEventArgs>;
     proposal_expire: { id: number };
     session_request_expire: { id: number };
   }

--- a/packages/web3wallet/src/types/client.ts
+++ b/packages/web3wallet/src/types/client.ts
@@ -1,12 +1,5 @@
 import EventEmmiter, { EventEmitter } from "events";
-import {
-  ICore,
-  CoreTypes,
-  ProposalTypes,
-  Verify,
-  AuthTypes,
-  SignClientTypes,
-} from "@walletconnect/types";
+import { ICore, CoreTypes, SignClientTypes } from "@walletconnect/types";
 import { AuthClientTypes } from "@walletconnect/auth-client";
 import { IWeb3WalletEngine } from "./engine";
 import { Logger } from "@walletconnect/logger";

--- a/packages/web3wallet/src/types/client.ts
+++ b/packages/web3wallet/src/types/client.ts
@@ -28,16 +28,9 @@ export declare namespace Web3WalletTypes {
     params: T;
   }
 
-  type SessionRequest = BaseEventArgs<{
-    request: { method: string; params: any };
-    chainId: string;
-  }> & {
-    verifyContext: Verify.Context;
-  };
+  type SessionRequest = SignClientTypes.EventArguments["session_request"];
 
-  type SessionProposal = Omit<BaseEventArgs<ProposalTypes.Struct>, "topic"> & {
-    verifyContext: Verify.Context;
-  };
+  type SessionProposal = SignClientTypes.EventArguments["session_proposal"];
 
   type AuthRequest = BaseEventArgs<AuthClientTypes.AuthRequestEventArgs>;
 
@@ -47,7 +40,7 @@ export declare namespace Web3WalletTypes {
 
   type SessionRequestExpire = { id: number };
 
-  type SessionAuthenticate = BaseEventArgs<AuthTypes.AuthRequestEventArgs>;
+  type SessionAuthenticate = SignClientTypes.EventArguments["session_authenticate"];
 
   type SignConfig = SignClientTypes.Options["signConfig"];
 

--- a/packages/web3wallet/test/sign.spec.ts
+++ b/packages/web3wallet/test/sign.spec.ts
@@ -930,6 +930,10 @@ describe("Sign Integration", () => {
       await Promise.all([
         new Promise<void>((resolve) => {
           web3Wallet.on("session_authenticate", async (payload) => {
+            const verifyContext = payload.verifyContext;
+            expect(verifyContext).to.exist;
+            expect(verifyContext.verified.validation).to.eq("UNKNOWN");
+
             const auths: any[] = [];
             for (const chain of payload.params.authPayload.chains) {
               const message = web3Wallet.formatAuthMessage({


### PR DESCRIPTION
## Description

- Added verify context to session authenticate event payload
- Included wc_sessionAuthenticate protocol method to `methods to verify`

This is done so 1CA requests can be verified by `verify api` as currently they result in `unknown` validations

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
