### PR TITLE
refactor: reduce reconnect timeout

### DIFF
--- a/packages/core/src/constants/relayer.ts
+++ b/packages/core/src/constants/relayer.ts
@@ -1,5 +1,3 @@
-import { ONE_SECOND } from "@walletconnect/time";
-
 export const RELAYER_DEFAULT_PROTOCOL = "irn";
 
 export const RELAYER_DEFAULT_LOGGER = "error";
@@ -28,7 +26,7 @@ export const RELAYER_PROVIDER_EVENTS = {
   error: "error",
 };
 
-export const RELAYER_RECONNECT_TIMEOUT = ONE_SECOND;
+export const RELAYER_RECONNECT_TIMEOUT = 0.1;
 
 export const RELAYER_STORAGE_OPTIONS = {
   database: ":memory:",

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -299,7 +299,7 @@ export class Relayer extends IRelayer {
           reject(e);
         });
         this.subscriber.start().catch((error) => {
-          this.logger.warn(error);
+          this.logger.error(error);
           this.onDisconnectHandler();
         });
         this.hasExperiencedNetworkDisruption = false;
@@ -477,13 +477,13 @@ export class Relayer extends IRelayer {
   };
 
   private onConnectHandler = () => {
-    this.logger.trace("wss connected");
+    this.logger.trace("relayer connected");
     this.startPingTimeout();
     this.events.emit(RELAYER_EVENTS.connect);
   };
 
   private onDisconnectHandler = () => {
-    this.logger.trace("wss disconnected");
+    this.logger.trace("relayer disconnected");
     this.onProviderDisconnect();
   };
 

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -298,7 +298,10 @@ export class Relayer extends IRelayer {
         ).catch((e) => {
           reject(e);
         });
-        this.subscriber.start().catch((error) => this.logger.warn(error));
+        this.subscriber.start().catch((error) => {
+          this.logger.warn(error);
+          this.onDisconnectHandler();
+        });
         this.hasExperiencedNetworkDisruption = false;
         resolve();
       });
@@ -474,11 +477,13 @@ export class Relayer extends IRelayer {
   };
 
   private onConnectHandler = () => {
+    this.logger.trace("wss connected");
     this.startPingTimeout();
     this.events.emit(RELAYER_EVENTS.connect);
   };
 
   private onDisconnectHandler = () => {
+    this.logger.trace("wss disconnected");
     this.onProviderDisconnect();
   };
 

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -298,7 +298,7 @@ export class Relayer extends IRelayer {
         ).catch((e) => {
           reject(e);
         });
-        await this.subscriber.start();
+        this.subscriber.start().catch((error) => this.logger.warn(error));
         this.hasExperiencedNetworkDisruption = false;
         resolve();
       });

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -272,7 +272,7 @@ describe("Relayer", () => {
         const randomSessionIdentifier = relayer.core.crypto.randomSessionIdentifier;
         await relayer.provider.connection.close();
         expect(relayer.connected).to.be.false;
-        await relayer.restartTransport();
+        await throttle(1000);
         expect(relayer.connected).to.be.true;
         // the identifier should be the same
         expect(relayer.core.crypto.randomSessionIdentifier).to.eq(randomSessionIdentifier);


### PR DESCRIPTION
## Description
- Reduced reconnect timeout to 0.1 seconds
- Removed await from `subscriber.start` start as it blocks the client initialization during the batch fetch & subscriptions

Both these changes would make the client perform and feel faster especially when the client has many persisted topics

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

benchmarked with 500 topics/no mailbox msgs - 
before(wait for subscribe): `1106 ms`
after(don't wait for subscribe): `155 ms`

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
