### PR TITLE
feat: auto publish to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish to NPM
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install dependencies and build 🔧
+        run: npm ci && npm run build
+      - name: Publish package on NPM 📦
+        run: npm run npm-publish:latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:ignoreUnhandled": "npm run test:ignoreUnhandled --workspaces --if-present",
     "check": "npm run lint; npm run build; npm run test",
     "reset": "npm run clean; npm run check",
-    "new-version": "lerna version --no-private --no-git-tag-version --exact && ./scripts/update_relayer_sdk_version.sh && ./scripts/update_web3wallet_version.sh; npm i",
+    "new-version": "lerna version --no-private --no-git-tag-version --exact && ./scripts/update_relayer_sdk_version.sh && ./scripts/update_web3wallet_version.sh && npm i",
     "pre-publish": "npm run new-version; npm run reset",
     "npm-publish:rc": "lerna exec --no-private -- npm publish --access public --tag rc",
     "npm-publish:latest": "lerna exec --no-private -- npm publish --access public --tag latest",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:ignoreUnhandled": "npm run test:ignoreUnhandled --workspaces --if-present",
     "check": "npm run lint; npm run build; npm run test",
     "reset": "npm run clean; npm run check",
-    "new-version": "lerna version --no-private --no-git-tag-version --exact && ./scripts/update_relayer_sdk_version.sh",
+    "new-version": "lerna version --no-private --no-git-tag-version --exact && ./scripts/update_relayer_sdk_version.sh && ./scripts/update_web3wallet_version.sh; npm i",
     "pre-publish": "npm run new-version; npm run reset",
     "npm-publish:rc": "lerna exec --no-private -- npm publish --access public --tag rc",
     "npm-publish:latest": "lerna exec --no-private -- npm publish --access public --tag latest",

--- a/packages/web3wallet/package.json
+++ b/packages/web3wallet/package.json
@@ -2,7 +2,7 @@
   "name": "@walletconnect/web3wallet",
   "description": "Web3Wallet for WalletConnect Protocol",
   "version": "1.13.0",
-  "private": true,
+  "private": false,
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",

--- a/scripts/update_web3wallet_version.sh
+++ b/scripts/update_web3wallet_version.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Context: https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+set -Eeuo pipefail
+
+file_location="packages/web3wallet/package.json"
+
+# Get the next version from lerna.json.
+lerna_file="lerna.json"
+lerna_version=$(grep -E '"version": "(.*)"' $lerna_file | sed -E 's/"version": "(.*)"/\1/' | sed 's/^[[:space:]]*//')
+
+IFS='.' read -r -a VERSION_PARTS <<< "$lerna_version"
+MAJOR_VERSION=${VERSION_PARTS[0]}
+MINOR_VERSION=${VERSION_PARTS[1]}
+PATCH_VERSION=${VERSION_PARTS[2]}
+echo "major version: $MAJOR_VERSION"
+echo "minor version: $MINOR_VERSION"
+echo "patch version: $PATCH_VERSION"
+
+# web3wallet version is always one major & one minor version behind the lerna version
+next_web3wallet_version="$((MAJOR_VERSION - 1)).$((MINOR_VERSION - 1)).$PATCH_VERSION"
+
+echo "[SCRIPT] Updating Web3wallet version to $next_web3wallet_version in $file_location..."
+# Use sed to update the value in the file
+if [ "$(uname)" = "Darwin" ]; then
+  # MacOS requires an empty string as the second argument to -i
+  sed -i '' -E "s/\"version\": \"[^\"]+\"/\"version\": \"$next_web3wallet_version\"/" "$file_location"
+else
+  sed -i -E "s/\"version\": \"[^\"]+\"/\"version\": \"$next_web3wallet_version\"/" "$file_location"
+fi
+
+echo "[SCRIPT] Version updated to $next_web3wallet_version in $file_location"
+
+echo "[SCRIPT] ...Done!"


### PR DESCRIPTION
## Description
- Added bash script to set `web3wallet` sdk version automatically relative to the main monorepo version
- Added workflow to auto publish to npm when new release is created

TODO: add npm token secret to the repo

## New release flow
1. npm run pre-release
2. git tag `<the version>`
3. push the tag
4. create release on gh

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
bash script tested, auto publish todo

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
