### PR TITLE
refactor: publishes session settle request before the session propose…

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -304,6 +304,12 @@ export class Engine extends IEngine {
     };
     await this.client.session.set(sessionTopic, session);
     try {
+      await this.sendRequest({
+        topic: sessionTopic,
+        method: "wc_sessionSettle",
+        params: sessionSettle,
+        throwOnFailedPublish: true,
+      });
       await this.sendResult<"wc_sessionPropose">({
         id,
         topic: pairingTopic,
@@ -313,12 +319,6 @@ export class Engine extends IEngine {
           },
           responderPublicKey: selfPublicKey,
         },
-        throwOnFailedPublish: true,
-      });
-      await this.sendRequest({
-        topic: sessionTopic,
-        method: "wc_sessionSettle",
-        params: sessionSettle,
         throwOnFailedPublish: true,
       });
     } catch (error) {


### PR DESCRIPTION
## Description
Updated the `approve` flow to send `sessionSettle` request before sending the `sessionPropose` response. This change is aimed speed up the pairing time up ~200ms because the session settle request will be available in the dapp client mailbox at the time of subscribing rather than being available after that 
1pager: https://www.notion.so/walletconnect/Publish-session-settlement-request-before-session-proposal-response-438d59c14f57442b85623002f4030c6a

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
n/a

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
