### PR TITLE
chore: change handshake canary to only measure 1 client initialization

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -30,12 +30,12 @@ describe("Canary", () => {
       const A = await SignClient.init({
         ...TEST_SIGN_CLIENT_OPTIONS_A,
       });
+      const handshakeLatencyMs = Date.now() - start;
 
       const B = await SignClient.init({
         ...TEST_SIGN_CLIENT_OPTIONS_B,
       });
       const clients = { A, B };
-      const handshakeLatencyMs = Date.now() - start;
       log(
         `Clients initialized (relay '${TEST_RELAY_URL}'), client ids: A:'${await clients.A.core.crypto.getClientId()}';B:'${await clients.B.core.crypto.getClientId()}'`,
       );


### PR DESCRIPTION
## Description

Changes the `handshakeLatencyMs` metric to only measure a single client initialization. This gives more precise data and makes it easier to understand what's going on. E.g. if connection delay goes up 500ms then this metric should go up 500ms not 1000ms

[Slack conversation](https://walletconnect.slack.com/archives/C03RME3BS9L/p1722965150960179)

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)

## How has this been tested?

Not tested