### PR TITLE
chore: prep for `2.15.0` release

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/*",
     "providers/*"
   ],
-  "version": "2.14.0"
+  "version": "2.15.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27458,7 +27458,7 @@
     },
     "packages/core": {
       "name": "@walletconnect/core",
-      "version": "2.14.0-canary.5",
+      "version": "2.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
@@ -27472,8 +27472,8 @@
         "@walletconnect/relay-auth": "1.0.4",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.14.0-canary.5",
-        "@walletconnect/utils": "2.14.0-canary.5",
+        "@walletconnect/types": "2.15.0",
+        "@walletconnect/utils": "2.15.0",
         "events": "3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "3.1.0"
@@ -27495,7 +27495,7 @@
     },
     "packages/react-native-compat": {
       "name": "@walletconnect/react-native-compat",
-      "version": "2.14.0-canary.5",
+      "version": "2.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "events": "3.3.0",
@@ -27516,17 +27516,17 @@
     },
     "packages/sign-client": {
       "name": "@walletconnect/sign-client",
-      "version": "2.14.0-canary.5",
+      "version": "2.15.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@walletconnect/core": "2.14.0-canary.5",
+        "@walletconnect/core": "2.15.0",
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.14.0-canary.5",
-        "@walletconnect/utils": "2.14.0-canary.5",
+        "@walletconnect/types": "2.15.0",
+        "@walletconnect/utils": "2.15.0",
         "events": "3.3.0"
       },
       "devDependencies": {
@@ -27538,7 +27538,7 @@
     },
     "packages/types": {
       "name": "@walletconnect/types",
-      "version": "2.14.0-canary.5",
+      "version": "2.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
@@ -27551,7 +27551,7 @@
     },
     "packages/utils": {
       "name": "@walletconnect/utils",
-      "version": "2.14.0-canary.5",
+      "version": "2.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
@@ -27562,7 +27562,7 @@
         "@walletconnect/relay-api": "1.0.11",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.14.0-canary.5",
+        "@walletconnect/types": "2.15.0",
         "@walletconnect/window-getters": "1.0.1",
         "@walletconnect/window-metadata": "1.0.1",
         "detect-browser": "5.3.0",
@@ -27604,17 +27604,17 @@
     },
     "packages/web3wallet": {
       "name": "@walletconnect/web3wallet",
-      "version": "2.14.0-canary.5",
+      "version": "1.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/auth-client": "2.1.2",
-        "@walletconnect/core": "2.14.0-canary.5",
+        "@walletconnect/core": "2.15.0",
         "@walletconnect/jsonrpc-provider": "1.0.14",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.14.0-canary.5",
-        "@walletconnect/types": "2.14.0-canary.5",
-        "@walletconnect/utils": "2.14.0-canary.5"
+        "@walletconnect/sign-client": "2.15.0",
+        "@walletconnect/types": "2.15.0",
+        "@walletconnect/utils": "2.15.0"
       },
       "devDependencies": {
         "@ethersproject/wallet": "5.7.0"
@@ -27622,7 +27622,7 @@
     },
     "providers/ethereum-provider": {
       "name": "@walletconnect/ethereum-provider",
-      "version": "2.14.0-canary.5",
+      "version": "2.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -27630,10 +27630,10 @@
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/modal": "2.6.2",
-        "@walletconnect/sign-client": "2.14.0-canary.5",
-        "@walletconnect/types": "2.14.0-canary.5",
-        "@walletconnect/universal-provider": "2.14.0-canary.5",
-        "@walletconnect/utils": "2.14.0-canary.5",
+        "@walletconnect/sign-client": "2.15.0",
+        "@walletconnect/types": "2.15.0",
+        "@walletconnect/universal-provider": "2.15.0",
+        "@walletconnect/utils": "2.15.0",
         "events": "3.3.0"
       },
       "devDependencies": {
@@ -27654,14 +27654,14 @@
     },
     "providers/signer-connection": {
       "name": "@walletconnect/signer-connection",
-      "version": "2.14.0-canary.5",
+      "version": "2.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/sign-client": "2.14.0-canary.5",
-        "@walletconnect/types": "2.14.0-canary.5",
-        "@walletconnect/utils": "2.14.0-canary.5",
+        "@walletconnect/sign-client": "2.15.0",
+        "@walletconnect/types": "2.15.0",
+        "@walletconnect/utils": "2.15.0",
         "events": "3.3.0",
         "uint8arrays": "3.1.0"
       }
@@ -27676,7 +27676,7 @@
     },
     "providers/universal-provider": {
       "name": "@walletconnect/universal-provider",
-      "version": "2.14.0-canary.5",
+      "version": "2.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -27684,9 +27684,9 @@
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.14.0-canary.5",
-        "@walletconnect/types": "2.14.0-canary.5",
-        "@walletconnect/utils": "2.14.0-canary.5",
+        "@walletconnect/sign-client": "2.15.0",
+        "@walletconnect/types": "2.15.0",
+        "@walletconnect/utils": "2.15.0",
         "events": "3.3.0"
       },
       "devDependencies": {
@@ -33670,8 +33670,8 @@
         "@walletconnect/relay-auth": "1.0.4",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.14.0-canary.5",
-        "@walletconnect/utils": "2.14.0-canary.5",
+        "@walletconnect/types": "2.15.0",
+        "@walletconnect/utils": "2.15.0",
         "events": "3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "3.1.0"
@@ -33706,10 +33706,10 @@
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/modal": "2.6.2",
-        "@walletconnect/sign-client": "2.14.0-canary.5",
-        "@walletconnect/types": "2.14.0-canary.5",
-        "@walletconnect/universal-provider": "2.14.0-canary.5",
-        "@walletconnect/utils": "2.14.0-canary.5",
+        "@walletconnect/sign-client": "2.15.0",
+        "@walletconnect/types": "2.15.0",
+        "@walletconnect/universal-provider": "2.15.0",
+        "@walletconnect/utils": "2.15.0",
         "ethereum-test-network": "0.1.6",
         "ethers": "5.6.9",
         "events": "3.3.0",
@@ -33898,7 +33898,7 @@
       "version": "file:packages/sign-client",
       "requires": {
         "@aws-sdk/client-cloudwatch": "3.450.0",
-        "@walletconnect/core": "2.14.0-canary.5",
+        "@walletconnect/core": "2.15.0",
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-provider": "1.0.14",
@@ -33907,8 +33907,8 @@
         "@walletconnect/logger": "2.1.2",
         "@walletconnect/relay-api": "1.0.11",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.14.0-canary.5",
-        "@walletconnect/utils": "2.14.0-canary.5",
+        "@walletconnect/types": "2.15.0",
+        "@walletconnect/utils": "2.15.0",
         "events": "3.3.0"
       }
     },
@@ -33917,9 +33917,9 @@
       "requires": {
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/sign-client": "2.14.0-canary.5",
-        "@walletconnect/types": "2.14.0-canary.5",
-        "@walletconnect/utils": "2.14.0-canary.5",
+        "@walletconnect/sign-client": "2.15.0",
+        "@walletconnect/types": "2.15.0",
+        "@walletconnect/utils": "2.15.0",
         "events": "3.3.0",
         "uint8arrays": "3.1.0"
       },
@@ -33964,9 +33964,9 @@
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.14.0-canary.5",
-        "@walletconnect/types": "2.14.0-canary.5",
-        "@walletconnect/utils": "2.14.0-canary.5",
+        "@walletconnect/sign-client": "2.15.0",
+        "@walletconnect/types": "2.15.0",
+        "@walletconnect/utils": "2.15.0",
         "cosmos-wallet": "1.2.0",
         "ethereum-test-network": "0.1.6",
         "ethers": "5.7.0",
@@ -34156,7 +34156,7 @@
         "@walletconnect/relay-api": "1.0.11",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.14.0-canary.5",
+        "@walletconnect/types": "2.15.0",
         "@walletconnect/window-getters": "1.0.1",
         "@walletconnect/window-metadata": "1.0.1",
         "detect-browser": "5.3.0",
@@ -34199,13 +34199,13 @@
       "requires": {
         "@ethersproject/wallet": "5.7.0",
         "@walletconnect/auth-client": "2.1.2",
-        "@walletconnect/core": "2.14.0-canary.5",
+        "@walletconnect/core": "2.15.0",
         "@walletconnect/jsonrpc-provider": "1.0.14",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.14.0-canary.5",
-        "@walletconnect/types": "2.14.0-canary.5",
-        "@walletconnect/utils": "2.14.0-canary.5"
+        "@walletconnect/sign-client": "2.15.0",
+        "@walletconnect/types": "2.15.0",
+        "@walletconnect/utils": "2.15.0"
       }
     },
     "@walletconnect/window-getters": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/core",
   "description": "Core for WalletConnect Protocol",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -42,8 +42,8 @@
     "@walletconnect/relay-auth": "1.0.4",
     "@walletconnect/safe-json": "1.0.2",
     "@walletconnect/time": "1.0.2",
-    "@walletconnect/types": "2.14.0",
-    "@walletconnect/utils": "2.14.0",
+    "@walletconnect/types": "2.15.0",
+    "@walletconnect/utils": "2.15.0",
     "events": "3.3.0",
     "lodash.isequal": "4.5.0",
     "uint8arrays": "3.1.0"

--- a/packages/core/src/constants/relayer.ts
+++ b/packages/core/src/constants/relayer.ts
@@ -34,7 +34,7 @@ export const RELAYER_STORAGE_OPTIONS = {
 
 // Updated automatically via `new-version` npm script.
 
-export const RELAYER_SDK_VERSION = "2.14.0";
+export const RELAYER_SDK_VERSION = "2.15.0";
 
 // delay to wait before closing the transport connection after init if not active
 export const RELAYER_TRANSPORT_CUTOFF = 10_000;

--- a/packages/react-native-compat/package.json
+++ b/packages/react-native-compat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/react-native-compat",
   "description": "Shims for WalletConnect Protocol in React Native Projects",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/sign-client",
   "description": "Sign Client for WalletConnect Protocol",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -38,14 +38,14 @@
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },
   "dependencies": {
-    "@walletconnect/core": "2.14.0",
+    "@walletconnect/core": "2.15.0",
     "@walletconnect/events": "1.0.1",
     "@walletconnect/heartbeat": "1.2.2",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/logger": "2.1.2",
     "@walletconnect/time": "1.0.2",
-    "@walletconnect/types": "2.14.0",
-    "@walletconnect/utils": "2.14.0",
+    "@walletconnect/types": "2.15.0",
+    "@walletconnect/utils": "2.15.0",
     "events": "3.3.0"
   },
   "devDependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/types",
   "description": "Typings for WalletConnect Protocol",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/utils",
   "description": "Utilities for WalletConnect Protocol",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -39,7 +39,7 @@
     "@walletconnect/relay-api": "1.0.11",
     "@walletconnect/safe-json": "1.0.2",
     "@walletconnect/time": "1.0.2",
-    "@walletconnect/types": "2.14.0",
+    "@walletconnect/types": "2.15.0",
     "@walletconnect/window-getters": "1.0.1",
     "@walletconnect/window-metadata": "1.0.1",
     "detect-browser": "5.3.0",

--- a/packages/web3wallet/package.json
+++ b/packages/web3wallet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/web3wallet",
   "description": "Web3Wallet for WalletConnect Protocol",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "private": true,
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
@@ -30,13 +30,13 @@
   },
   "dependencies": {
     "@walletconnect/auth-client": "2.1.2",
-    "@walletconnect/core": "2.14.0",
+    "@walletconnect/core": "2.15.0",
     "@walletconnect/jsonrpc-provider": "1.0.14",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/logger": "2.1.2",
-    "@walletconnect/sign-client": "2.14.0",
-    "@walletconnect/types": "2.14.0",
-    "@walletconnect/utils": "2.14.0"
+    "@walletconnect/sign-client": "2.15.0",
+    "@walletconnect/types": "2.15.0",
+    "@walletconnect/utils": "2.15.0"
   },
   "devDependencies": {
     "@ethersproject/wallet": "5.7.0"

--- a/providers/ethereum-provider/package.json
+++ b/providers/ethereum-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/ethereum-provider",
   "description": "Ethereum Provider for WalletConnect Protocol",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {
@@ -48,10 +48,10 @@
     "@walletconnect/jsonrpc-types": "1.0.4",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/modal": "2.6.2",
-    "@walletconnect/sign-client": "2.14.0",
-    "@walletconnect/types": "2.14.0",
-    "@walletconnect/universal-provider": "2.14.0",
-    "@walletconnect/utils": "2.14.0",
+    "@walletconnect/sign-client": "2.15.0",
+    "@walletconnect/types": "2.15.0",
+    "@walletconnect/universal-provider": "2.15.0",
+    "@walletconnect/utils": "2.15.0",
     "events": "3.3.0"
   },
   "devDependencies": {

--- a/providers/signer-connection/package.json
+++ b/providers/signer-connection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/signer-connection",
   "description": "Signer Connection for WalletConnect Protocol",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -39,9 +39,9 @@
   "dependencies": {
     "@walletconnect/jsonrpc-types": "1.0.4",
     "@walletconnect/jsonrpc-utils": "1.0.8",
-    "@walletconnect/sign-client": "2.14.0",
-    "@walletconnect/types": "2.14.0",
-    "@walletconnect/utils": "2.14.0",
+    "@walletconnect/sign-client": "2.15.0",
+    "@walletconnect/types": "2.15.0",
+    "@walletconnect/utils": "2.15.0",
     "events": "3.3.0",
     "uint8arrays": "3.1.0"
   }

--- a/providers/universal-provider/package.json
+++ b/providers/universal-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/universal-provider",
   "description": "Universal Provider for WalletConnect Protocol",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {
@@ -45,9 +45,9 @@
     "@walletconnect/jsonrpc-types": "1.0.4",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/logger": "2.1.2",
-    "@walletconnect/sign-client": "2.14.0",
-    "@walletconnect/types": "2.14.0",
-    "@walletconnect/utils": "2.14.0",
+    "@walletconnect/sign-client": "2.15.0",
+    "@walletconnect/types": "2.15.0",
+    "@walletconnect/utils": "2.15.0",
     "events": "3.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Release Checklist

- [x] **Canary Version QA**

  - [x] I have thoroughly tested the release using a canary version: `2.15.0-rc.0` & `1.14.0-rc.0`
  - [x] The canary version has been verified to work as expected.
  - [x] All major features and changes have been tested and validated.

- [ ] **Web3Modal Team QA**

  - [ ] The Web3Modal team has tested the release for compatibility and functionality.
  - [ ] The release is backwards compatible with Web3Modal.
  - [ ] Any reported issues or bugs have been addressed or documented.

- [ ] **React Native Team QA**

  - [ ] The React Native team has tested the release for compatibility and functionality (if relevant).
  - [ ] The release works correctly in React Native environments and is backwards compatible with Web3Modal React Native.
  - [ ] Any reported issues or bugs have been addressed or documented.

## Related Issues and Pull Requests

* chore: prep for `2.14.0` release by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/5195
* refactor: removes session approval peer acknowledgment delay by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/5197
* chore(deps): update docker/build-push-action action to v6 by @renovate in https://github.com/WalletConnect/walletconnect-monorepo/pull/4641
* chore(deps): update actions/add-to-project action to v1.0.2 by @renovate in https://github.com/WalletConnect/walletconnect-monorepo/pull/5101
* chore: fix some comments by @renshuncui in https://github.com/WalletConnect/walletconnect-monorepo/pull/4640
* AlgorandProvider #877 #2760 by @scholtz in https://github.com/WalletConnect/walletconnect-monorepo/pull/5201
* chore: fix typo by @riyueguang in https://github.com/WalletConnect/walletconnect-monorepo/pull/5216
* chore: change handshake canary to only measure 1 client initialization by @chris13524 in https://github.com/WalletConnect/walletconnect-monorepo/pull/5250
* refactor: session settle response  by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/5259
* refactor: publishes session settle request before the session propose… by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/5246
* feat: verify v2 by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/5236
* chore: partially dedupe fetch implementations and use native fetch instead by @talentlessguy in https://github.com/WalletConnect/walletconnect-monorepo/pull/5112

## Test deployments
https://github.com/WalletConnect/web-examples/pull/673

## Definition of Done

- [x] The release has been tested using a canary version.
- [ ] The release has been reviewed and approved by the Web3Modal team (if relevant).
- [ ] The release has been reviewed and approved by the React Native team (if relevant).
- [x] All necessary documentation, including API changes or new features, has been updated.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] All tests (unit, integration, etc.) pass successfully.
- [x] The release has been properly versioned and tagged.
- [x] The release notes and changelog have been updated to reflect the changes made.

Please ensure that all the items on the checklist have been completed before merging the release.