### PR TITLE
chore: sets `trace` level logging on canary

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -16,7 +16,7 @@ import { SignClient } from "../../src";
 
 const environment = process.env.ENVIRONMENT || "dev";
 const region = process.env.REGION || "unknown";
-const logger = "trace";
+const logger = process.env.LOGGER || "error";
 const log = (log: string) => {
   // eslint-disable-next-line no-console
   console.log(log);

--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -16,7 +16,7 @@ import { SignClient } from "../../src";
 
 const environment = process.env.ENVIRONMENT || "dev";
 const region = process.env.REGION || "unknown";
-
+const logger = "trace";
 const log = (log: string) => {
   // eslint-disable-next-line no-console
   console.log(log);
@@ -29,11 +29,13 @@ describe("Canary", () => {
       const start = Date.now();
       const A = await SignClient.init({
         ...TEST_SIGN_CLIENT_OPTIONS_A,
+        logger,
       });
       const handshakeLatencyMs = Date.now() - start;
 
       const B = await SignClient.init({
         ...TEST_SIGN_CLIENT_OPTIONS_B,
+        logger,
       });
       const clients = { A, B };
       log(


### PR DESCRIPTION
## Description
Updated canary logger level to `trace` as per @chris13524's request 

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
runing `canary.spec.ts`

## Checklist

- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
