### PR TITLE
chore: doesn't init verify api in dev mode

### DIFF
--- a/packages/core/src/controllers/verify.ts
+++ b/packages/core/src/controllers/verify.ts
@@ -51,6 +51,7 @@ export class Verify extends IVerify {
   }
 
   public init = async () => {
+    if (this.isDevEnv) return;
     this.publicKey = await this.store.getItem(this.storeKey);
     if (this.publicKey && toMiliseconds(this.publicKey?.expiresAt) < Date.now()) {
       this.logger.debug("verify v2 public key expired");
@@ -62,7 +63,7 @@ export class Verify extends IVerify {
   };
 
   public register: IVerify["register"] = async (params) => {
-    if (!isBrowser()) return;
+    if (!isBrowser() || this.isDevEnv) return;
     const origin = window.location.origin;
     const { id, decryptedId } = params;
     const src = `${this.verifyUrlV3}/attestation?projectId=${this.core.projectId}&origin=${origin}&id=${id}&decryptedId=${decryptedId}`;


### PR DESCRIPTION
## Description
Disabled verify api during ci tests because its introducing additional latency and verify is not used during testing anyway. 

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

built the canary image from this branch 
![image](https://github.com/user-attachments/assets/a62da739-2fee-4668-bf1e-ee49cd847ee8)


## Checklist

- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
