### PR TITLE
fix: reconnection loop

### DIFF
--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -93,6 +93,7 @@ export class Relayer extends IRelayer {
    * meaning if we don't receive a message in 30 seconds, the connection can be considered dead
    */
   private heartBeatTimeout = toMiliseconds(THIRTY_SECONDS + ONE_SECOND);
+  private reconnectTimeout: NodeJS.Timeout | undefined;
 
   constructor(opts: RelayerOptions) {
     super(opts);
@@ -295,9 +296,14 @@ export class Relayer extends IRelayer {
           this.provider.connect(),
           toMiliseconds(ONE_MINUTE),
           `Socket stalled when trying to connect to ${this.relayUrl}`,
-        ).catch((e) => {
-          reject(e);
-        });
+        )
+          .catch((e) => {
+            reject(e);
+          })
+          .finally(() => {
+            clearTimeout(this.reconnectTimeout);
+            this.reconnectTimeout = undefined;
+          });
         this.subscriber.start().catch((error) => {
           this.logger.error(error);
           this.onDisconnectHandler();
@@ -536,7 +542,8 @@ export class Relayer extends IRelayer {
     this.events.emit(RELAYER_EVENTS.disconnect);
     this.connectionAttemptInProgress = false;
     if (this.transportExplicitlyClosed) return;
-    setTimeout(async () => {
+    if (this.reconnectTimeout) return;
+    this.reconnectTimeout = setTimeout(async () => {
       await this.transportOpen().catch((error) => this.logger.error(error));
     }, toMiliseconds(RELAYER_RECONNECT_TIMEOUT));
   }

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -283,6 +283,23 @@ describe("Relayer", () => {
         // the identifier should be the same
         expect(relayer.core.crypto.randomSessionIdentifier).to.eq(randomSessionIdentifier);
       });
+      it("should connect once regardless of the number of disconnect events", async () => {
+        const disconnectsToEmit = 10;
+        let disconnectsReceived = 0;
+        let connectReceived = 0;
+        relayer.on(RELAYER_EVENTS.connect, () => {
+          connectReceived++;
+        });
+        relayer.on(RELAYER_EVENTS.disconnect, () => {
+          disconnectsReceived++;
+        });
+        await Promise.all(
+          Array.from(Array(disconnectsToEmit).keys()).map(() => relayer.onDisconnectHandler()),
+        );
+        await throttle(1000);
+        expect(connectReceived).to.eq(1);
+        expect(disconnectsReceived).to.eq(disconnectsToEmit);
+      });
 
       it("should close transport 10 seconds after init if NOT active", async () => {
         relayer = new Relayer({


### PR DESCRIPTION
## Description
Fixing a bug where the relayer could go into reconnection loop when multiple disconnect events are received at the same time. It was observed that such issue appears on Safari with the native web socket

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
integration tests, dogfooding

## Fixes/Resolves (Optional)
https://walletconnect.slack.com/archives/C04DB2EAHE3/p1724737009124569

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
