### PR TITLE
fix: enforces origin url to be verified to produce verify context

### DIFF
--- a/packages/core/src/controllers/verify.ts
+++ b/packages/core/src/controllers/verify.ts
@@ -118,7 +118,13 @@ export class Verify extends IVerify {
       const decoded = decodeJWT(attestationId) as unknown as { payload: JwkPayload };
       if (decoded.payload.id !== encryptedId) return;
       const validation = await this.isValidJwtAttestation(attestationId);
-      if (validation) return validation;
+      if (validation) {
+        if (!validation.isVerified) {
+          this.logger.warn("resolve: jwt attestation: origin url not verified");
+          return;
+        }
+        return validation;
+      }
     }
     if (!hash) return;
     const verifyUrl = this.getVerifyUrl(params?.verifyUrl);
@@ -243,6 +249,7 @@ export class Verify extends IVerify {
     return {
       origin: validation.payload.origin,
       isScam: validation.payload.isScam,
+      isVerified: validation.payload.isVerified,
     };
   };
 }

--- a/packages/core/src/controllers/verify.ts
+++ b/packages/core/src/controllers/verify.ts
@@ -57,9 +57,6 @@ export class Verify extends IVerify {
       this.logger.debug("verify v2 public key expired");
       await this.removePublicKey();
     }
-    if (!this.publicKey) {
-      await this.fetchAndPersistPublicKey();
-    }
   };
 
   public register: IVerify["register"] = async (params) => {

--- a/packages/utils/src/crypto.ts
+++ b/packages/utils/src/crypto.ts
@@ -230,8 +230,5 @@ export function verifyP256Jwt<T>(token: string, keyData: P256KeyDataType) {
     throw new Error("Invalid signature");
   }
   const data = decodeJWT(token) as unknown as { payload: T };
-  return {
-    ...data.payload,
-    isVerified: isValid,
-  };
+  return data.payload;
 }

--- a/packages/utils/test/crypto.spec.ts
+++ b/packages/utils/test/crypto.spec.ts
@@ -135,7 +135,7 @@ describe("Crypto", () => {
     console.log("result", result);
     expect(result).to.exist;
     expect(result).to.exist;
-    expect(result.isVerified).to.be.true;
+    expect(result.isVerified).to.be.false;
     expect(result.exp).to.exist;
     expect(result.origin).to.exist;
     expect(result.isScam).to.be.null;


### PR DESCRIPTION
## Description
- Added additional check for `isVerified` jwt payload to ensure only verified urls are presented with verify context 
- Disabled fetching public key on init

Context
https://walletconnect.slack.com/archives/C03TFK9BSGJ/p1725431068942349
https://walletconnect.slack.com/archives/C03TFK9BSGJ/p1725476737367669
## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
https://github.com/WalletConnect/web3modal/pull/2795

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
