### PR TITLE
chore(dot-org): use walletconnect.org for the relay and rpc urls

### DIFF
--- a/packages/core/src/constants/events.ts
+++ b/packages/core/src/constants/events.ts
@@ -84,4 +84,4 @@ export const EVENTS_STORAGE_CONTEXT = "event-client";
 
 export const EVENTS_STORAGE_CLEANUP_INTERVAL = 86400;
 
-export const EVENTS_CLIENT_API_URL = "https://pulse.walletconnect.com/batch";
+export const EVENTS_CLIENT_API_URL = "https://pulse.walletconnect.org/batch";

--- a/packages/sign-client/src/constants/client.ts
+++ b/packages/sign-client/src/constants/client.ts
@@ -10,7 +10,7 @@ export const SIGN_CLIENT_DEFAULT = {
   name: SIGN_CLIENT_CONTEXT,
   logger: "error",
   controller: false,
-  relayUrl: "wss://relay.walletconnect.com",
+  relayUrl: "wss://relay.walletconnect.org",
 };
 
 export const SIGN_CLIENT_EVENTS: Record<SignClientTypes.Event, SignClientTypes.Event> = {

--- a/packages/sign-client/test/shared/values.ts
+++ b/packages/sign-client/test/shared/values.ts
@@ -1,4 +1,4 @@
-import { SignClientTypes, RelayerTypes } from "@walletconnect/types";
+import { RelayerTypes, SignClientTypes } from "@walletconnect/types";
 
 export const PACKAGE_NAME = "sign-client";
 
@@ -6,9 +6,9 @@ export const TEST_RELAY_URL = process.env.TEST_RELAY_URL
   ? process.env.TEST_RELAY_URL
   : "ws://0.0.0.0:5555";
 
-export const TEST_RELAY_URL_US = "wss://us-east-1.relay.walletconnect.com";
-export const TEST_RELAY_URL_EU = "wss://eu-central-1.relay.walletconnect.com";
-export const TEST_RELAY_URL_AP = "wss://ap-southeast-1.relay.walletconnect.com";
+export const TEST_RELAY_URL_US = "wss://us-east-1.relay.walletconnect.org";
+export const TEST_RELAY_URL_EU = "wss://eu-central-1.relay.walletconnect.org";
+export const TEST_RELAY_URL_AP = "wss://ap-southeast-1.relay.walletconnect.org";
 
 // See https://github.com/WalletConnect/push-webhook-test-server
 export const TEST_WEBHOOK_ENDPOINT = "https://webhook-push-test.walletconnect.com/";

--- a/packages/utils/src/signatures.ts
+++ b/packages/utils/src/signatures.ts
@@ -1,7 +1,7 @@
-import { AuthTypes } from "@walletconnect/types";
 import { hashMessage } from "@ethersproject/hash";
 import { recoverAddress } from "@ethersproject/transactions";
-const DEFAULT_RPC_URL = "https://rpc.walletconnect.com/v1";
+import { AuthTypes } from "@walletconnect/types";
+const DEFAULT_RPC_URL = "https://rpc.walletconnect.org/v1";
 
 export async function verifySignature(
   address: string,

--- a/packages/utils/test/cacao.spec.ts
+++ b/packages/utils/test/cacao.spec.ts
@@ -1,13 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
-  base64Encode,
-  buildNamespacesFromAuth,
   createEncodedRecap,
   createRecap,
   decodeRecap,
   encodeRecap,
   formatMessage,
-  formatStatementFromRecap,
   getChainsFromRecap,
   getCommonValuesInArrays,
   getDecodedRecapFromResources,

--- a/packages/utils/test/misc.spec.ts
+++ b/packages/utils/test/misc.spec.ts
@@ -1,14 +1,14 @@
-import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   calcExpiry,
-  isExpired,
   formatRelayRpcUrl,
-  hasOverlap,
   formatUA,
   getSearchParamFromURL,
+  hasOverlap,
+  isExpired,
 } from "../src";
 
-const RELAY_URL = "wss://relay.walletconnect.com";
+const RELAY_URL = "wss://relay.walletconnect.org";
 
 const PROJECT_ID = "27e484dcd9e3efcfd25a83a78777cdf1";
 

--- a/providers/ethereum-provider/src/constants/values.ts
+++ b/providers/ethereum-provider/src/constants/values.ts
@@ -2,4 +2,4 @@ export const PROTOCOL = "wc";
 export const WC_VERSION = 2;
 export const CONTEXT = "ethereum_provider";
 export const STORAGE_KEY = `${PROTOCOL}@${WC_VERSION}:${CONTEXT}:`;
-export const RPC_URL = "https://rpc.walletconnect.com/v1/";
+export const RPC_URL = "https://rpc.walletconnect.org/v1/";

--- a/providers/universal-provider/README.md
+++ b/providers/universal-provider/README.md
@@ -36,7 +36,8 @@ await provider.connect({
       chains: ["eip155:80001"],
       events: ["chainChanged", "accountsChanged"],
       rpcMap: {
-        80001: "https://rpc.walletconnect.com?chainId=eip155:80001&projectId=<your walletconnect project id>",
+        80001:
+          "https://rpc.walletconnect.org?chainId=eip155:80001&projectId=<your walletconnect project id>",
       },
     },
     pairingTopic: "<123...topic>", // optional topic to connect to
@@ -122,6 +123,5 @@ const updatedDefaultChainId = await web3.eth.getChainId();
 - The rest of the methods of the class are very similar, mainly centering around
   httpProvider and for the most part will be 90% similar to other providers
   given similar structure of chainId. For example `eip155:1` or
-  `solana:mainnetBeta`. 
-- Export provider under `providers/universal-provider/src/providers/index.ts` 
-
+  `solana:mainnetBeta`.
+- Export provider under `providers/universal-provider/src/providers/index.ts`

--- a/providers/universal-provider/src/constants/values.ts
+++ b/providers/universal-provider/src/constants/values.ts
@@ -1,6 +1,6 @@
 export const LOGGER = "error";
 
-export const RELAY_URL = "wss://relay.walletconnect.com";
+export const RELAY_URL = "wss://relay.walletconnect.org";
 
 export const PROTOCOL = "wc";
 export const WC_VERSION = 2;
@@ -8,7 +8,7 @@ export const CONTEXT = "universal_provider";
 
 export const STORAGE = `${PROTOCOL}@${WC_VERSION}:${CONTEXT}:`;
 
-export const RPC_URL = "https://rpc.walletconnect.com/v1/";
+export const RPC_URL = "https://rpc.walletconnect.org/v1/";
 
 export const GENERIC_SUBPROVIDER_NAME = "generic";
 


### PR DESCRIPTION
## Description

We should use walletconnect.org everywhere.

## Type of change

- [X] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)

## How has this been tested?

Covered by existing tests

## Fixes/Resolves (Optional)

Users in some regions getting blocked by their ISPs

## Checklist

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
