### PR TITLE
chore(relay-test-urls): revert Relay test URLs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "editor.codeActionsOnSave": {
-    "source.organizeImports": false
+    "source.organizeImports": "never"
   },
   "editor.formatOnSave": true,
   "editor.tabSize": 2,

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,26 +1,16 @@
 import { EventEmitter } from "events";
 
-import KeyValueStorage from "@walletconnect/keyvaluestorage";
 import { HeartBeat } from "@walletconnect/heartbeat";
+import KeyValueStorage from "@walletconnect/keyvaluestorage";
 import {
+  ChunkLoggerController,
   generateChildLogger,
+  generatePlatformLogger,
   getDefaultLoggerOptions,
   getLoggerContext,
-  generatePlatformLogger,
-  ChunkLoggerController,
 } from "@walletconnect/logger";
 import { CoreTypes, ICore } from "@walletconnect/types";
 
-import {
-  Crypto,
-  Relayer,
-  Pairing,
-  JsonRpcHistory,
-  Expirer,
-  Verify,
-  EchoClient,
-  EventClient,
-} from "./controllers";
 import {
   CORE_CONTEXT,
   CORE_DEFAULT,
@@ -32,6 +22,16 @@ import {
   WALLETCONNECT_CLIENT_ID,
   WALLETCONNECT_LINK_MODE_APPS,
 } from "./constants";
+import {
+  Crypto,
+  EchoClient,
+  EventClient,
+  Expirer,
+  JsonRpcHistory,
+  Pairing,
+  Relayer,
+  Verify,
+} from "./controllers";
 
 export class Core extends ICore {
   public readonly protocol = CORE_PROTOCOL;

--- a/packages/sign-client/test/shared/values.ts
+++ b/packages/sign-client/test/shared/values.ts
@@ -6,9 +6,9 @@ export const TEST_RELAY_URL = process.env.TEST_RELAY_URL
   ? process.env.TEST_RELAY_URL
   : "ws://0.0.0.0:5555";
 
-export const TEST_RELAY_URL_US = "wss://us-east-1.relay.walletconnect.org";
-export const TEST_RELAY_URL_EU = "wss://eu-central-1.relay.walletconnect.org";
-export const TEST_RELAY_URL_AP = "wss://ap-southeast-1.relay.walletconnect.org";
+export const TEST_RELAY_URL_US = "wss://us-east-1.relay.walletconnect.com";
+export const TEST_RELAY_URL_EU = "wss://eu-central-1.relay.walletconnect.com";
+export const TEST_RELAY_URL_AP = "wss://ap-southeast-1.relay.walletconnect.com";
 
 // See https://github.com/WalletConnect/push-webhook-test-server
 export const TEST_WEBHOOK_ENDPOINT = "https://webhook-push-test.walletconnect.com/";


### PR DESCRIPTION
## Description

[getRegionEndpointPermutations](https://github.com/WalletConnect/walletconnect-monorepo/blob/dc12515f8e07fd2755a58c0ed5b3d1534dc9021c/packages/sign-client/test/xregion/xregion.spec.ts#L66) is relying on Relay TEST_URLs to generate staging URLs but these aren't configured on AWS.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Current tests cover it

## Checklist

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules

