### PR TITLE
chore: 2.17.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/*",
     "providers/*"
   ],
-  "version": "2.16.3"
+  "version": "2.17.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27517,7 +27517,7 @@
     },
     "packages/core": {
       "name": "@walletconnect/core",
-      "version": "2.16.3",
+      "version": "2.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
@@ -27531,8 +27531,8 @@
         "@walletconnect/relay-auth": "1.0.4",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.16.3",
-        "@walletconnect/utils": "2.16.3",
+        "@walletconnect/types": "2.17.0",
+        "@walletconnect/utils": "2.17.0",
         "events": "3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "3.1.0"
@@ -27554,7 +27554,7 @@
     },
     "packages/react-native-compat": {
       "name": "@walletconnect/react-native-compat",
-      "version": "2.16.3",
+      "version": "2.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "events": "3.3.0",
@@ -27575,17 +27575,17 @@
     },
     "packages/sign-client": {
       "name": "@walletconnect/sign-client",
-      "version": "2.16.3",
+      "version": "2.17.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@walletconnect/core": "2.16.3",
+        "@walletconnect/core": "2.17.0",
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.16.3",
-        "@walletconnect/utils": "2.16.3",
+        "@walletconnect/types": "2.17.0",
+        "@walletconnect/utils": "2.17.0",
         "events": "3.3.0"
       },
       "devDependencies": {
@@ -27597,7 +27597,7 @@
     },
     "packages/types": {
       "name": "@walletconnect/types",
-      "version": "2.16.3",
+      "version": "2.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
@@ -27610,7 +27610,7 @@
     },
     "packages/utils": {
       "name": "@walletconnect/utils",
-      "version": "2.16.3",
+      "version": "2.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
@@ -27622,7 +27622,7 @@
         "@walletconnect/relay-auth": "1.0.4",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.16.3",
+        "@walletconnect/types": "2.17.0",
         "@walletconnect/window-getters": "1.0.1",
         "@walletconnect/window-metadata": "1.0.1",
         "detect-browser": "5.3.0",
@@ -27645,17 +27645,17 @@
     },
     "packages/web3wallet": {
       "name": "@walletconnect/web3wallet",
-      "version": "1.15.3",
+      "version": "1.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/auth-client": "2.1.2",
-        "@walletconnect/core": "2.16.3",
+        "@walletconnect/core": "2.17.0",
         "@walletconnect/jsonrpc-provider": "1.0.14",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.16.3",
-        "@walletconnect/types": "2.16.3",
-        "@walletconnect/utils": "2.16.3"
+        "@walletconnect/sign-client": "2.17.0",
+        "@walletconnect/types": "2.17.0",
+        "@walletconnect/utils": "2.17.0"
       },
       "devDependencies": {
         "@ethersproject/wallet": "5.7.0"
@@ -27663,7 +27663,7 @@
     },
     "providers/ethereum-provider": {
       "name": "@walletconnect/ethereum-provider",
-      "version": "2.16.3",
+      "version": "2.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -27671,10 +27671,10 @@
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/modal": "2.7.0",
-        "@walletconnect/sign-client": "2.16.3",
-        "@walletconnect/types": "2.16.3",
-        "@walletconnect/universal-provider": "2.16.3",
-        "@walletconnect/utils": "2.16.3",
+        "@walletconnect/sign-client": "2.17.0",
+        "@walletconnect/types": "2.17.0",
+        "@walletconnect/universal-provider": "2.17.0",
+        "@walletconnect/utils": "2.17.0",
         "events": "3.3.0"
       },
       "devDependencies": {
@@ -27695,14 +27695,14 @@
     },
     "providers/signer-connection": {
       "name": "@walletconnect/signer-connection",
-      "version": "2.16.3",
+      "version": "2.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/sign-client": "2.16.3",
-        "@walletconnect/types": "2.16.3",
-        "@walletconnect/utils": "2.16.3",
+        "@walletconnect/sign-client": "2.17.0",
+        "@walletconnect/types": "2.17.0",
+        "@walletconnect/utils": "2.17.0",
         "events": "3.3.0",
         "uint8arrays": "3.1.0"
       }
@@ -27717,7 +27717,7 @@
     },
     "providers/universal-provider": {
       "name": "@walletconnect/universal-provider",
-      "version": "2.16.3",
+      "version": "2.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -27725,9 +27725,9 @@
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.16.3",
-        "@walletconnect/types": "2.16.3",
-        "@walletconnect/utils": "2.16.3",
+        "@walletconnect/sign-client": "2.17.0",
+        "@walletconnect/types": "2.17.0",
+        "@walletconnect/utils": "2.17.0",
         "events": "3.3.0"
       },
       "devDependencies": {
@@ -33734,8 +33734,8 @@
         "@walletconnect/relay-auth": "1.0.4",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.16.3",
-        "@walletconnect/utils": "2.16.3",
+        "@walletconnect/types": "2.17.0",
+        "@walletconnect/utils": "2.17.0",
         "events": "3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "3.1.0"
@@ -33770,10 +33770,10 @@
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/modal": "2.7.0",
-        "@walletconnect/sign-client": "2.16.3",
-        "@walletconnect/types": "2.16.3",
-        "@walletconnect/universal-provider": "2.16.3",
-        "@walletconnect/utils": "2.16.3",
+        "@walletconnect/sign-client": "2.17.0",
+        "@walletconnect/types": "2.17.0",
+        "@walletconnect/universal-provider": "2.17.0",
+        "@walletconnect/utils": "2.17.0",
         "ethereum-test-network": "0.1.6",
         "ethers": "5.6.9",
         "events": "3.3.0",
@@ -33962,7 +33962,7 @@
       "version": "file:packages/sign-client",
       "requires": {
         "@aws-sdk/client-cloudwatch": "3.450.0",
-        "@walletconnect/core": "2.16.3",
+        "@walletconnect/core": "2.17.0",
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-provider": "1.0.14",
@@ -33971,8 +33971,8 @@
         "@walletconnect/logger": "2.1.2",
         "@walletconnect/relay-api": "1.0.11",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.16.3",
-        "@walletconnect/utils": "2.16.3",
+        "@walletconnect/types": "2.17.0",
+        "@walletconnect/utils": "2.17.0",
         "events": "3.3.0"
       }
     },
@@ -33981,9 +33981,9 @@
       "requires": {
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/sign-client": "2.16.3",
-        "@walletconnect/types": "2.16.3",
-        "@walletconnect/utils": "2.16.3",
+        "@walletconnect/sign-client": "2.17.0",
+        "@walletconnect/types": "2.17.0",
+        "@walletconnect/utils": "2.17.0",
         "events": "3.3.0",
         "uint8arrays": "3.1.0"
       },
@@ -34028,9 +34028,9 @@
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.16.3",
-        "@walletconnect/types": "2.16.3",
-        "@walletconnect/utils": "2.16.3",
+        "@walletconnect/sign-client": "2.17.0",
+        "@walletconnect/types": "2.17.0",
+        "@walletconnect/utils": "2.17.0",
         "cosmos-wallet": "1.2.0",
         "ethereum-test-network": "0.1.6",
         "ethers": "5.7.0",
@@ -34221,7 +34221,7 @@
         "@walletconnect/relay-auth": "1.0.4",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.16.3",
+        "@walletconnect/types": "2.17.0",
         "@walletconnect/window-getters": "1.0.1",
         "@walletconnect/window-metadata": "1.0.1",
         "detect-browser": "5.3.0",
@@ -34245,13 +34245,13 @@
       "requires": {
         "@ethersproject/wallet": "5.7.0",
         "@walletconnect/auth-client": "2.1.2",
-        "@walletconnect/core": "2.16.3",
+        "@walletconnect/core": "2.17.0",
         "@walletconnect/jsonrpc-provider": "1.0.14",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.16.3",
-        "@walletconnect/types": "2.16.3",
-        "@walletconnect/utils": "2.16.3"
+        "@walletconnect/sign-client": "2.17.0",
+        "@walletconnect/types": "2.17.0",
+        "@walletconnect/utils": "2.17.0"
       }
     },
     "@walletconnect/window-getters": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/core",
   "description": "Core for WalletConnect Protocol",
-  "version": "2.16.3",
+  "version": "2.17.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -42,8 +42,8 @@
     "@walletconnect/relay-auth": "1.0.4",
     "@walletconnect/safe-json": "1.0.2",
     "@walletconnect/time": "1.0.2",
-    "@walletconnect/types": "2.16.3",
-    "@walletconnect/utils": "2.16.3",
+    "@walletconnect/types": "2.17.0",
+    "@walletconnect/utils": "2.17.0",
     "events": "3.3.0",
     "lodash.isequal": "4.5.0",
     "uint8arrays": "3.1.0"

--- a/packages/core/src/constants/relayer.ts
+++ b/packages/core/src/constants/relayer.ts
@@ -34,7 +34,7 @@ export const RELAYER_STORAGE_OPTIONS = {
 
 // Updated automatically via `new-version` npm script.
 
-export const RELAYER_SDK_VERSION = "2.16.3";
+export const RELAYER_SDK_VERSION = "2.17.0";
 
 // delay to wait before closing the transport connection after init if not active
 export const RELAYER_TRANSPORT_CUTOFF = 10_000;

--- a/packages/react-native-compat/package.json
+++ b/packages/react-native-compat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/react-native-compat",
   "description": "Shims for WalletConnect Protocol in React Native Projects",
-  "version": "2.16.3",
+  "version": "2.17.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",

--- a/packages/sign-client/package.json
+++ b/packages/sign-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/sign-client",
   "description": "Sign Client for WalletConnect Protocol",
-  "version": "2.16.3",
+  "version": "2.17.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -38,14 +38,14 @@
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },
   "dependencies": {
-    "@walletconnect/core": "2.16.3",
+    "@walletconnect/core": "2.17.0",
     "@walletconnect/events": "1.0.1",
     "@walletconnect/heartbeat": "1.2.2",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/logger": "2.1.2",
     "@walletconnect/time": "1.0.2",
-    "@walletconnect/types": "2.16.3",
-    "@walletconnect/utils": "2.16.3",
+    "@walletconnect/types": "2.17.0",
+    "@walletconnect/utils": "2.17.0",
     "events": "3.3.0"
   },
   "devDependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/types",
   "description": "Typings for WalletConnect Protocol",
-  "version": "2.16.3",
+  "version": "2.17.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/utils",
   "description": "Utilities for WalletConnect Protocol",
-  "version": "2.16.3",
+  "version": "2.17.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -40,7 +40,7 @@
     "@walletconnect/relay-auth": "1.0.4",
     "@walletconnect/safe-json": "1.0.2",
     "@walletconnect/time": "1.0.2",
-    "@walletconnect/types": "2.16.3",
+    "@walletconnect/types": "2.17.0",
     "@walletconnect/window-getters": "1.0.1",
     "@walletconnect/window-metadata": "1.0.1",
     "detect-browser": "5.3.0",

--- a/packages/web3wallet/package.json
+++ b/packages/web3wallet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/web3wallet",
   "description": "Web3Wallet for WalletConnect Protocol",
-  "version": "1.15.3",
+  "version": "1.16.0",
   "private": false,
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
@@ -30,13 +30,13 @@
   },
   "dependencies": {
     "@walletconnect/auth-client": "2.1.2",
-    "@walletconnect/core": "2.16.3",
+    "@walletconnect/core": "2.17.0",
     "@walletconnect/jsonrpc-provider": "1.0.14",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/logger": "2.1.2",
-    "@walletconnect/sign-client": "2.16.3",
-    "@walletconnect/types": "2.16.3",
-    "@walletconnect/utils": "2.16.3"
+    "@walletconnect/sign-client": "2.17.0",
+    "@walletconnect/types": "2.17.0",
+    "@walletconnect/utils": "2.17.0"
   },
   "devDependencies": {
     "@ethersproject/wallet": "5.7.0"

--- a/providers/ethereum-provider/package.json
+++ b/providers/ethereum-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/ethereum-provider",
   "description": "Ethereum Provider for WalletConnect Protocol",
-  "version": "2.16.3",
+  "version": "2.17.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {
@@ -48,10 +48,10 @@
     "@walletconnect/jsonrpc-types": "1.0.4",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/modal": "2.7.0",
-    "@walletconnect/sign-client": "2.16.3",
-    "@walletconnect/types": "2.16.3",
-    "@walletconnect/universal-provider": "2.16.3",
-    "@walletconnect/utils": "2.16.3",
+    "@walletconnect/sign-client": "2.17.0",
+    "@walletconnect/types": "2.17.0",
+    "@walletconnect/universal-provider": "2.17.0",
+    "@walletconnect/utils": "2.17.0",
     "events": "3.3.0"
   },
   "devDependencies": {

--- a/providers/signer-connection/package.json
+++ b/providers/signer-connection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/signer-connection",
   "description": "Signer Connection for WalletConnect Protocol",
-  "version": "2.16.3",
+  "version": "2.17.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",
@@ -39,9 +39,9 @@
   "dependencies": {
     "@walletconnect/jsonrpc-types": "1.0.4",
     "@walletconnect/jsonrpc-utils": "1.0.8",
-    "@walletconnect/sign-client": "2.16.3",
-    "@walletconnect/types": "2.16.3",
-    "@walletconnect/utils": "2.16.3",
+    "@walletconnect/sign-client": "2.17.0",
+    "@walletconnect/types": "2.17.0",
+    "@walletconnect/utils": "2.17.0",
     "events": "3.3.0",
     "uint8arrays": "3.1.0"
   }

--- a/providers/universal-provider/package.json
+++ b/providers/universal-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/universal-provider",
   "description": "Universal Provider for WalletConnect Protocol",
-  "version": "2.16.3",
+  "version": "2.17.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "repository": {
@@ -45,9 +45,9 @@
     "@walletconnect/jsonrpc-types": "1.0.4",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/logger": "2.1.2",
-    "@walletconnect/sign-client": "2.16.3",
-    "@walletconnect/types": "2.16.3",
-    "@walletconnect/utils": "2.16.3",
+    "@walletconnect/sign-client": "2.17.0",
+    "@walletconnect/types": "2.17.0",
+    "@walletconnect/utils": "2.17.0",
     "events": "3.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Release Checklist

- [x] **Canary Version QA**

  - [x] I have thoroughly tested the release using a canary version: `2.17.0-rc-1`
  - [x] The canary version has been verified to work as expected.
  - [x] All major features and changes have been tested and validated.

- [ ] **Web3Modal Team QA**

  - [ ] The Web3Modal team has tested the release for compatibility and functionality.
  - [ ] The release is backwards compatible with Web3Modal.
  - [ ] Any reported issues or bugs have been addressed or documented.

- [ ] **React Native Team QA**

  - [ ] The React Native team has tested the release for compatibility and functionality (if relevant).
  - [ ] The release works correctly in React Native environments and is backwards compatible with Web3Modal React Native.
  - [ ] Any reported issues or bugs have been addressed or documented.

## What's Changed
* chore: `2.16.2` release by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/5369
* chore(dot-org): use walletconnect.org for the relay and rpc urls by @Cali93 in https://github.com/WalletConnect/walletconnect-monorepo/pull/5393
* chore(deps-dev): bump vite from 3.2.10 to 3.2.11 by @dependabot in https://github.com/WalletConnect/walletconnect-monorepo/pull/5367
* chore(deps): bump micromatch from 4.0.5 to 4.0.8 by @dependabot in https://github.com/WalletConnect/walletconnect-monorepo/pull/5297
* chore(relay-test-urls): revert Relay test URLs by @Cali93 in https://github.com/WalletConnect/walletconnect-monorepo/pull/5396
* chore(deps): update actions/setup-node action to v4 by @renovate in https://github.com/WalletConnect/walletconnect-monorepo/pull/5338
* chore(deps): update actions/checkout action to v4 by @renovate in https://github.com/WalletConnect/walletconnect-monorepo/pull/5337
* chore(deps-dev): bump axios from 1.6.2 to 1.7.7 by @dependabot in https://github.com/WalletConnect/walletconnect-monorepo/pull/5330
* chore: 2.16.3 release by @Cali93 in https://github.com/WalletConnect/walletconnect-monorepo/pull/5397
* fix:  json parse unhandled by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/5404
* feat: tg mini apps support by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/5403
* fix: enables pairing via base64 encoded uri by @ganchoradkov in https://github.com/WalletConnect/walletconnect-monorepo/pull/5407


**Full Changelog**: https://github.com/WalletConnect/walletconnect-monorepo/compare/2.16.2...2.17.0

## test deployments
https://github.com/reown-com/web-examples/pull/733

## Definition of Done

- [x] The release has been tested using a canary version.
- [ ] The release has been reviewed and approved by the Web3Modal team (if relevant).
- [ ] The release has been reviewed and approved by the React Native team (if relevant).
- [ ] All necessary documentation, including API changes or new features, has been updated.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] All tests (unit, integration, etc.) pass successfully.
- [ ] The release has been properly versioned and tagged.
- [ ] The release notes and changelog have been updated to reflect the changes made.

Please ensure that all the items on the checklist have been completed before merging the release.