### PR TITLE
docs: fix expired links to document due to rebranding

### DIFF
--- a/packages/sign-client/README.md
+++ b/packages/sign-client/README.md
@@ -10,7 +10,7 @@ This library provides a Sign Client for WalletConnect v2.0 Protocol for both Dap
 
 Check out documentation [here](https://docs.walletconnect.com/).
 
-Also available quick start for [Dapps](https://docs.walletconnect.com/2.0/javascript/sign/dapp-usage) and for [Wallets](https://docs.walletconnect.com/2.0/javascript/sign/wallet-usage)
+Also available quick start for [Dapps](https://docs.reown.com/api/sign/dapp-usage) and for [Wallets](https://docs.reown.com/api/sign/wallet-usage)
 
 ## License
 


### PR DESCRIPTION
## Description

While checking the document, I found that some links are expired and not work anymore.
They are now fixed and pointed to the correct link now.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

No test is needed 

## Checklist

- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
