### PR TITLE
fix: subscribe timeout rejection

### DIFF
--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -167,6 +167,12 @@ export class Relayer extends IRelayer {
     if (opts?.transportType === "relay") {
       await this.toEstablishConnection();
     }
+    // throw unless explicitly set to false
+    const shouldThrowOnFailure =
+      typeof opts?.internal?.throwOnFailedPublish === "undefined"
+        ? true
+        : opts?.internal?.throwOnFailedPublish;
+
     let id = this.subscriber.topicMap.get(topic)?.[0] || "";
     let resolvePromise: () => void;
     const onSubCreated = (subscription: SubscriberTypes.Active) => {
@@ -181,13 +187,19 @@ export class Relayer extends IRelayer {
         resolvePromise = resolve;
         this.subscriber.on(SUBSCRIBER_EVENTS.created, onSubCreated);
       }),
-      new Promise<void>(async (resolve) => {
-        const result = await this.subscriber.subscribe(topic, {
-          internal: {
-            throwOnFailedPublish: true,
-          },
-          ...opts,
-        });
+      new Promise<void>(async (resolve, reject) => {
+        const result = await this.subscriber
+          .subscribe(topic, {
+            internal: {
+              throwOnFailedPublish: shouldThrowOnFailure,
+            },
+            ...opts,
+          })
+          .catch((error) => {
+            if (shouldThrowOnFailure) {
+              reject(error);
+            }
+          });
         id = result || id;
         resolve();
       }),

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -182,7 +182,12 @@ export class Relayer extends IRelayer {
         this.subscriber.on(SUBSCRIBER_EVENTS.created, onSubCreated);
       }),
       new Promise<void>(async (resolve) => {
-        const result = await this.subscriber.subscribe(topic, opts);
+        const result = await this.subscriber.subscribe(topic, {
+          internal: {
+            throwOnFailedPublish: true,
+          },
+          ...opts,
+        });
         id = result || id;
         resolve();
       }),

--- a/packages/core/src/controllers/subscriber.ts
+++ b/packages/core/src/controllers/subscriber.ts
@@ -224,7 +224,6 @@ export class Subscriber extends ISubscriber {
     relay: RelayerTypes.ProtocolOptions,
     opts?: RelayerTypes.SubscribeOptions,
   ) {
-    
     if (opts?.transportType === TRANSPORT_TYPES.relay) {
       await this.restartToComplete();
     }
@@ -248,18 +247,18 @@ export class Subscriber extends ISubscriber {
         }, toMiliseconds(ONE_SECOND));
         return subId;
       }
-      const subscribe = await createExpiringPromise(
+      const subscribe = createExpiringPromise(
         this.relayer.request(request).catch((e) => this.logger.warn(e)),
         this.subscribeTimeout,
+        `Subscribing to ${topic} failed, please try again`,
       );
       const result = await subscribe;
-
       // return null to indicate that the subscription failed
       return result ? subId : null;
     } catch (err) {
       this.logger.debug(`Outgoing Relay Subscribe Payload stalled`);
       this.relayer.events.emit(RELAYER_EVENTS.connection_stalled);
-      if(opts?.internal?.throwOnFailedPublish) {
+      if (opts?.internal?.throwOnFailedPublish) {
         throw err;
       }
     }

--- a/packages/core/src/controllers/subscriber.ts
+++ b/packages/core/src/controllers/subscriber.ts
@@ -101,7 +101,7 @@ export class Subscriber extends ISubscriber {
       const relay = getRelayProtocolName(opts);
       const params = { topic, relay, transportType: opts?.transportType };
       this.pending.set(topic, params);
-      const id = await this.rpcSubscribe(topic, relay, opts?.transportType);
+      const id = await this.rpcSubscribe(topic, relay, opts);
       if (typeof id === "string") {
         this.onSubscribe(id, params);
         this.logger.debug(`Successfully Subscribed Topic`);
@@ -222,9 +222,10 @@ export class Subscriber extends ISubscriber {
   private async rpcSubscribe(
     topic: string,
     relay: RelayerTypes.ProtocolOptions,
-    transportType: RelayerTypes.TransportType = TRANSPORT_TYPES.relay,
+    opts?: RelayerTypes.SubscribeOptions,
   ) {
-    if (transportType === TRANSPORT_TYPES.relay) {
+    
+    if (opts?.transportType === TRANSPORT_TYPES.relay) {
       await this.restartToComplete();
     }
     const api = getRelayProtocolApi(relay.protocol);
@@ -239,7 +240,7 @@ export class Subscriber extends ISubscriber {
     try {
       const subId = hashMessage(topic + this.clientId);
       // in link mode, allow the app to update its network state (i.e. active airplane mode) with small delay before attempting to subscribe
-      if (transportType === TRANSPORT_TYPES.link_mode) {
+      if (opts?.transportType === TRANSPORT_TYPES.link_mode) {
         setTimeout(() => {
           if (this.relayer.connected || this.relayer.connecting) {
             this.relayer.request(request).catch((e) => this.logger.warn(e));
@@ -247,7 +248,6 @@ export class Subscriber extends ISubscriber {
         }, toMiliseconds(ONE_SECOND));
         return subId;
       }
-
       const subscribe = await createExpiringPromise(
         this.relayer.request(request).catch((e) => this.logger.warn(e)),
         this.subscribeTimeout,
@@ -259,6 +259,9 @@ export class Subscriber extends ISubscriber {
     } catch (err) {
       this.logger.debug(`Outgoing Relay Subscribe Payload stalled`);
       this.relayer.events.emit(RELAYER_EVENTS.connection_stalled);
+      if(opts?.internal?.throwOnFailedPublish) {
+        throw err;
+      }
     }
     return null;
   }

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -125,16 +125,20 @@ describe("Relayer", () => {
         projectId: TEST_CORE_OPTIONS.projectId,
       });
       await relayer.init();
+      await relayer.transportOpen();
     });
     afterEach(async () => {
       await disconnectSocket(relayer);
     });
 
     it("returns the id provided by calling `subscriber.subscribe` with the passed topic", async () => {
-      const spy = Sinon.spy((topic) => {
-        relayer.subscriber.events.emit(SUBSCRIBER_EVENTS.created, { topic });
-        return topic;
-      });
+      const spy = Sinon.spy(
+        (topic) =>
+          new Promise((resolve) => {
+            relayer.subscriber.events.emit(SUBSCRIBER_EVENTS.created, { topic });
+            resolve(topic);
+          }),
+      );
       relayer.subscriber.subscribe = spy;
 
       const testTopic = "abc123";
@@ -149,10 +153,13 @@ describe("Relayer", () => {
     });
 
     it("should subscribe multiple topics", async () => {
-      const spy = Sinon.spy((topic) => {
-        relayer.subscriber.events.emit(SUBSCRIBER_EVENTS.created, { topic });
-        return topic;
-      });
+      const spy = Sinon.spy(
+        (topic) =>
+          new Promise((resolve) => {
+            relayer.subscriber.events.emit(SUBSCRIBER_EVENTS.created, { topic });
+            resolve(topic);
+          }),
+      );
       relayer.subscriber.subscribe = spy;
       const subscriber = relayer.subscriber as ISubscriber;
       // record the number of listeners before subscribing

--- a/packages/types/src/core/relayer.ts
+++ b/packages/types/src/core/relayer.ts
@@ -29,6 +29,9 @@ export declare namespace RelayerTypes {
   export interface SubscribeOptions {
     relay?: ProtocolOptions;
     transportType?: TransportType;
+    internal?: {
+      throwOnFailedPublish?: boolean;
+    };
   }
 
   export interface UnsubscribeOptions {


### PR DESCRIPTION
## Description
fixed a bug where `rpcSubscribe` didn't throw when subscriber timeout was reached
Context: https://walletconnect.slack.com/archives/C06HXQ9K32T/p1728086800794779

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
