### PR TITLE
Fix: 1271 sig validation chainId validation

### DIFF
--- a/packages/utils/src/cacao.ts
+++ b/packages/utils/src/cacao.ts
@@ -39,7 +39,7 @@ export async function validateSignedCacao(params: { cacao: AuthTypes.Cacao; proj
     walletAddress,
     reconstructed,
     signature,
-    getDidChainId(payload.iss) as string,
+    getNamespacedDidChainId(payload.iss) as string,
     projectId as string,
   );
 

--- a/packages/utils/src/signatures.ts
+++ b/packages/utils/src/signatures.ts
@@ -1,6 +1,7 @@
 import { hashMessage } from "@ethersproject/hash";
 import { recoverAddress } from "@ethersproject/transactions";
 import { AuthTypes } from "@walletconnect/types";
+import { parseChainId } from "./caip";
 const DEFAULT_RPC_URL = "https://rpc.walletconnect.org/v1";
 
 export async function verifySignature(
@@ -49,6 +50,12 @@ export async function isValidEip1271Signature(
   projectId: string,
   baseRpcUrl?: string,
 ) {
+  const parsedChain = parseChainId(chainId);
+  if (!parsedChain.namespace || !parsedChain.reference) {
+    throw new Error(
+      `isValidEip1271Signature failed: chainId must be in CAIP-2 format, received: ${chainId}`,
+    );
+  }
   try {
     const eip1271MagicValue = "0x1626ba7e";
     const dynamicTypeOffset = "0000000000000000000000000000000000000000000000000000000000000040";

--- a/packages/utils/test/signatures.spec.ts
+++ b/packages/utils/test/signatures.spec.ts
@@ -47,5 +47,47 @@ Expiration Time: 2022-10-11T23:03:35.700Z`;
       );
       expect(isValid).toBe(false);
     });
+    it("fails for a bad chainid", async () => {
+      const cacaoSignature: AuthTypes.CacaoSignature = {
+        t: "eip1271",
+        s: "0xdead5719b2504095116db01baaf276361efd3a73c28cf8cc28dabefa945b8d536011289ac0a3b048600c1e692ff173ca944246cf7ceb319ac2262d27b395c82b1c",
+      };
+      const invalidChainIdOne = "1";
+      await expect(
+        verifySignature(
+          address,
+          reconstructedMessage,
+          cacaoSignature,
+          invalidChainIdOne,
+          projectId,
+        ),
+      ).rejects.toThrow(
+        `isValidEip1271Signature failed: chainId must be in CAIP-2 format, received: ${invalidChainIdOne}`,
+      );
+      const invalidChainIdTwo = ":1";
+      await expect(
+        verifySignature(
+          address,
+          reconstructedMessage,
+          cacaoSignature,
+          invalidChainIdTwo,
+          projectId,
+        ),
+      ).rejects.toThrow(
+        `isValidEip1271Signature failed: chainId must be in CAIP-2 format, received: ${invalidChainIdTwo}`,
+      );
+      const invalidChainIdThree = "1:";
+      await expect(
+        verifySignature(
+          address,
+          reconstructedMessage,
+          cacaoSignature,
+          invalidChainIdThree,
+          projectId,
+        ),
+      ).rejects.toThrow(
+        `isValidEip1271Signature failed: chainId must be in CAIP-2 format, received: ${invalidChainIdThree}`,
+      );
+    });
   });
 });


### PR DESCRIPTION
## Description
Fixed a bug where we were not passing CAIP2 formatted `chainId` for 1271 signature validation 
## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
