### PR TITLE
fix: subscriber publish fail

### DIFF
--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -188,6 +188,21 @@ describe("Relayer", () => {
       );
     });
 
+    it("should throw when subscribe publish fails", async () => {
+      await relayer.transportOpen();
+      await relayer.toEstablishConnection();
+      relayer.subscriber.subscribeTimeout = 5_000;
+      relayer.request = () => {
+        return new Promise<void>((resolve) => {
+          resolve();
+        });
+      };
+      const topic = generateRandomBytes32();
+      await expect(relayer.subscribe(topic)).rejects.toThrow(
+        `Subscribing to ${topic} failed, please try again`,
+      );
+    });
+
     it("should be able to resubscribe on topic that already exists", async () => {
       const topic = generateRandomBytes32();
       const id = await relayer.subscribe(topic);


### PR DESCRIPTION
## Description
fixed an issue where failed subscription attempts were retried instead of throwing an error

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests and in canary - `2.17.1-canary-0`

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
