### PR TITLE
fix: unhandled on network drop when provider is not initialized

### DIFF
--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -287,7 +287,7 @@ export class Relayer extends IRelayer {
       }
     }
 
-    if (this.hasExperiencedNetworkDisruption || this.connected) {
+    if (this.provider.disconnect && (this.hasExperiencedNetworkDisruption || this.connected)) {
       await createExpiringPromise(this.provider.disconnect(), 2000, "provider.disconnect()").catch(
         () => this.onProviderDisconnect(),
       );

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -56,8 +56,10 @@ describe("Relayer", () => {
       await relayer.init();
       expect(relayer.provider).to.be.empty;
       expect(relayer.connected).to.be.false;
+      // @ts-expect-error - private property
       relayer.hasExperiencedNetworkDisruption = true;
-      await relayer.transportClose();
+      // @ts-expect-error - private method
+      await relayer.transportDisconnect();
     });
     it("initializes a MessageTracker", async () => {
       relayer.messages.init = initSpy;

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -51,6 +51,14 @@ describe("Relayer", () => {
       await disconnectSocket(relayer);
     });
 
+    it("should not throw unhandled on network disconnect when there is no provider instance", async () => {
+      relayer.messages.init = initSpy;
+      await relayer.init();
+      expect(relayer.provider).to.be.empty;
+      expect(relayer.connected).to.be.false;
+      relayer.hasExperiencedNetworkDisruption = true;
+      await relayer.transportClose();
+    });
     it("initializes a MessageTracker", async () => {
       relayer.messages.init = initSpy;
       await relayer.init();


### PR DESCRIPTION
## Description
fixed an unhandled exception in`provider.disconnect()` when `provider` is not initialized and `subscribeToNetworkChange` triggered disconnect flow   

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests, dogfooding 

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
