### PR TITLE
Revert "chore(deps): update node.js to v22 (#5471)"

### DIFF
--- a/packages/sign-client/Dockerfile
+++ b/packages/sign-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine as base
+FROM node:21-alpine as base
 
 WORKDIR /
 


### PR DESCRIPTION
This reverts commit 13ef9851f08e772616a6f6d36ef609fd22b5c2fa.

## Description

- https://github.com/WalletConnect/walletconnect-monorepo/pull/5471 seems to break the Docker CI step post-merge to `v2.0`, reverting for now.
- See: https://github.com/WalletConnect/walletconnect-monorepo/actions/runs/11688441802


