### PR TITLE
chore: fix measure handshake latency measurement in canary

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -26,12 +26,22 @@ describe("Canary", () => {
   const metric_prefix = "HappyPath.connects";
   describe("HappyPath", () => {
     it("connects", async () => {
+      const initStart = Date.now();
+      const handshakeClient = await SignClient.init({
+        ...TEST_SIGN_CLIENT_OPTIONS_A,
+        logger,
+      });
+      const initLatencyMs = Date.now() - initStart;
+      const handshakeStart = Date.now();
+      await handshakeClient.core.relayer.transportOpen();
+      const handshakeLatencyMs = Date.now() - handshakeStart;
+      await handshakeClient.core.relayer.transportClose();
+
       const start = Date.now();
       const A = await SignClient.init({
         ...TEST_SIGN_CLIENT_OPTIONS_A,
         logger,
       });
-      const handshakeLatencyMs = Date.now() - start;
 
       const B = await SignClient.init({
         ...TEST_SIGN_CLIENT_OPTIONS_B,
@@ -80,6 +90,7 @@ describe("Canary", () => {
           successful,
           latencyMs,
           [
+            { initLatency: initLatencyMs },
             { handshakeLatency: handshakeLatencyMs },
             { proposePairingLatency: clientAConnectLatencyMs },
             { settlePairingLatency: settlePairingLatencyMs - clientAConnectLatencyMs },


### PR DESCRIPTION
## Description

Updates the metrics for measuring handshake latency. Since the relay connection is now deferred it made the handshake measurement incorrect since it was measuring SDK initialization time. This PR fixes the measurement by triggering a connection explicitly. This PR also adds a new measurement for the SDK initialization time because it appears to be non-zero.

[Slack conversation](https://reown-inc.slack.com/archives/C03RME3BS9L/p1726068304898209)

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)

## How has this been tested?

Not tested