### PR TITLE
chore: exclude SDK init time from connect + pairing measurements

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -32,20 +32,38 @@ describe("Canary", () => {
         logger,
       });
       const initLatencyMs = Date.now() - initStart;
+      log(
+        `Client A (${await handshakeClient.core.crypto.getClientId()}) initialized in ${initLatencyMs}ms`,
+      );
       const handshakeStart = Date.now();
       await handshakeClient.core.relayer.transportOpen();
       const handshakeLatencyMs = Date.now() - handshakeStart;
+      log(
+        `Client A (${await handshakeClient.core.crypto.getClientId()}) initialized in ${handshakeLatencyMs}ms`,
+      );
       await handshakeClient.core.relayer.transportClose();
 
+      const aInitStart = Date.now();
       const A = await SignClient.init({
         ...TEST_SIGN_CLIENT_OPTIONS_A,
         logger,
       });
+      log(
+        `Client A (${await A.core.crypto.getClientId()}) initialized in ${
+          Date.now() - aInitStart
+        }ms`,
+      );
 
+      const bInitStart = Date.now();
       const B = await SignClient.init({
         ...TEST_SIGN_CLIENT_OPTIONS_B,
         logger,
       });
+      log(
+        `Client B (${await B.core.crypto.getClientId()}) initialized in ${
+          Date.now() - bInitStart
+        }ms`,
+      );
 
       const start = Date.now();
 

--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -37,7 +37,6 @@ describe("Canary", () => {
       const handshakeLatencyMs = Date.now() - handshakeStart;
       await handshakeClient.core.relayer.transportClose();
 
-      const start = Date.now();
       const A = await SignClient.init({
         ...TEST_SIGN_CLIENT_OPTIONS_A,
         logger,
@@ -47,6 +46,9 @@ describe("Canary", () => {
         ...TEST_SIGN_CLIENT_OPTIONS_B,
         logger,
       });
+
+      const start = Date.now();
+
       const clients = { A, B };
       log(
         `Clients initialized (relay '${TEST_RELAY_URL}'), client ids: A:'${await clients.A.core.crypto.getClientId()}';B:'${await clients.B.core.crypto.getClientId()}'`,


### PR DESCRIPTION
## Description

Exclude SDK init time from connect + pairing measurements

Since we measure this separately now, we don't need to measure it here.

[Slack conversation](https://reown-inc.slack.com/archives/C03RME3BS9L/p1732129752390569?thread_ts=1726068304.898209&cid=C03RME3BS9L)

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)

## How has this been tested?

Not tested