### PR TITLE
fix: 1ca tests flakiness

### DIFF
--- a/packages/sign-client/test/sdk/auth.spec.ts
+++ b/packages/sign-client/test/sdk/auth.spec.ts
@@ -177,7 +177,7 @@ describe("Authenticated Sessions", () => {
       name: "wallet",
       metadata: TEST_APP_METADATA_B,
     });
-    await Promise.all([
+    const result = await Promise.all([
       new Promise<void>((resolve) => {
         wallet.on("session_authenticate", async (payload) => {
           // validate that the dapp has both `session_authenticate` & `session_proposal` stored
@@ -231,8 +231,9 @@ describe("Authenticated Sessions", () => {
         wallet.pair({ uri });
         resolve();
       }),
-    ]);
-    const session = (await response()).session;
+      response(),
+    ]).then((result) => result[2]);
+    const session = result.session;
     const walletSession = wallet.session.get(session.topic);
     // approved namespaces on both sides must be equal
     expect(JSON.stringify(session.namespaces)).to.eq(JSON.stringify(walletSession.namespaces));
@@ -298,7 +299,7 @@ describe("Authenticated Sessions", () => {
       name: "wallet",
       metadata: TEST_APP_METADATA_B,
     });
-    await Promise.all([
+    const result = await Promise.all([
       new Promise<void>((resolve) => {
         wallet.on("session_authenticate", async (payload) => {
           const verifyContext = payload.verifyContext;
@@ -356,8 +357,9 @@ describe("Authenticated Sessions", () => {
         wallet.pair({ uri });
         resolve();
       }),
-    ]);
-    const session = (await response()).session;
+      response(),
+    ]).then((result) => result[2]);
+    const session = result.session;
     const walletSession = wallet.session.get(session.topic);
     // approved namespaces on both sides must be equal
     expect(JSON.stringify(session.namespaces)).to.eq(JSON.stringify(walletSession.namespaces));
@@ -418,7 +420,7 @@ describe("Authenticated Sessions", () => {
       name: "wallet",
       metadata: TEST_APP_METADATA_B,
     });
-    await Promise.all([
+    const result = await Promise.all([
       new Promise<void>((resolve) => {
         wallet.on("session_authenticate", async (payload) => {
           const authPayload = populateAuthPayload({
@@ -451,8 +453,9 @@ describe("Authenticated Sessions", () => {
         wallet.pair({ uri });
         resolve();
       }),
-    ]);
-    const session = (await response()).session;
+      response(),
+    ]).then((result) => result[2]);
+    const session = result.session;
     const walletSession = wallet.session.get(session.topic);
     // approved namespaces on both sides must be equal
     expect(JSON.stringify(session.namespaces)).to.eq(JSON.stringify(walletSession.namespaces));
@@ -511,7 +514,7 @@ describe("Authenticated Sessions", () => {
       name: "wallet",
       metadata: TEST_APP_METADATA_B,
     });
-    await Promise.all([
+    const result = await Promise.all([
       new Promise<void>((resolve) => {
         wallet.on("session_authenticate", async (payload) => {
           const authPayload = populateAuthPayload({
@@ -550,8 +553,9 @@ describe("Authenticated Sessions", () => {
         wallet.pair({ uri });
         resolve();
       }),
-    ]);
-    const { session, auths } = await response();
+      response(),
+    ]).then((result) => result[2]);
+    const { session, auths } = result;
     const walletSession = wallet.session.get(session.topic);
     // approved namespaces on both sides must be equal
     expect(JSON.stringify(session.namespaces)).to.eq(JSON.stringify(walletSession.namespaces));
@@ -611,7 +615,7 @@ describe("Authenticated Sessions", () => {
       name: "wallet",
       metadata: TEST_APP_METADATA_B,
     });
-    await Promise.all([
+    const result = await Promise.all([
       new Promise<void>((resolve) => {
         wallet.on("session_authenticate", async (payload) => {
           const authPayload = populateAuthPayload({
@@ -650,8 +654,9 @@ describe("Authenticated Sessions", () => {
         wallet.pair({ uri });
         resolve();
       }),
-    ]);
-    const { session, auths } = await response();
+      response(),
+    ]).then((result) => result[2]);
+    const { session, auths } = result;
     const walletSession = wallet.session.get(session.topic);
     expect(auths?.length).to.eq(supportedChains.length);
     // approved namespaces on both sides must be equal
@@ -712,7 +717,7 @@ describe("Authenticated Sessions", () => {
       name: "wallet",
       metadata: TEST_APP_METADATA_B,
     });
-    await Promise.all([
+    const result = await Promise.all([
       new Promise<void>((resolve) => {
         wallet.on("session_authenticate", async (payload) => {
           const authPayload = populateAuthPayload({
@@ -750,8 +755,9 @@ describe("Authenticated Sessions", () => {
         wallet.pair({ uri });
         resolve();
       }),
-    ]);
-    const { session, auths } = await response();
+      response(),
+    ]).then((result) => result[2]);
+    const { session, auths } = result;
     const walletSession = wallet.session.get(session.topic);
     expect(auths?.length).to.eq(supportedChains.length);
     // approved namespaces on both sides must be equal
@@ -812,7 +818,7 @@ describe("Authenticated Sessions", () => {
       name: "wallet",
       metadata: TEST_APP_METADATA_B,
     });
-    await Promise.all([
+    const result = await Promise.all([
       new Promise<void>((resolve) => {
         wallet.on("session_authenticate", async (payload) => {
           const authPayload = populateAuthPayload({
@@ -851,8 +857,9 @@ describe("Authenticated Sessions", () => {
         wallet.pair({ uri });
         resolve();
       }),
-    ]);
-    const { session, auths } = await response();
+      response(),
+    ]).then((result) => result[2]);
+    const { session, auths } = result;
     const walletSession = wallet.session.get(session.topic);
     expect(auths?.length).to.eq(supportedChains.length);
     // approved namespaces on both sides must be equal
@@ -906,7 +913,7 @@ describe("Authenticated Sessions", () => {
       name: "wallet",
       metadata: TEST_APP_METADATA_B,
     });
-    await Promise.all([
+    const result = await Promise.all([
       new Promise<void>((resolve) => {
         wallet.on("session_authenticate", async (payload) => {
           const auths: any[] = [];
@@ -938,8 +945,9 @@ describe("Authenticated Sessions", () => {
         wallet.pair({ uri });
         resolve();
       }),
-    ]);
-    const { session, auths } = await response();
+      response(),
+    ]).then((result) => result[2]);
+    const { session, auths } = result;
     const walletSession = wallet.session.get(session.topic);
     // approved namespaces on both sides must be equal
     expect(JSON.stringify(session.namespaces)).to.eq(JSON.stringify(walletSession.namespaces));
@@ -1002,7 +1010,7 @@ describe("Authenticated Sessions", () => {
       name: "wallet",
       metadata: TEST_APP_METADATA_B,
     });
-    await Promise.all([
+    const result = await Promise.all([
       new Promise<void>((resolve) => {
         wallet.on("session_proposal", async (payload) => {
           const approved = buildApprovedNamespaces({
@@ -1031,10 +1039,9 @@ describe("Authenticated Sessions", () => {
         wallet.pair({ uri: uri.replace("methods", "") });
         resolve();
       }),
-    ]);
-
-    const res = await response();
-    const session = res.session;
+      response(),
+    ]).then((result) => result[2]);
+    const session = result.session;
     await throttle(1000);
 
     await Promise.all([
@@ -1090,7 +1097,7 @@ describe("Authenticated Sessions", () => {
       name: "wallet",
       metadata: TEST_APP_METADATA_B,
     });
-    await Promise.all([
+    const result = await Promise.all([
       new Promise<void>((resolve) => {
         wallet.on("session_proposal", async (payload) => {
           const approved = buildApprovedNamespaces({
@@ -1119,10 +1126,9 @@ describe("Authenticated Sessions", () => {
         wallet.pair({ uri });
         resolve();
       }),
-    ]);
-
-    const res = await response();
-    const session = res.session;
+      response(),
+    ]).then((result) => result[2]);
+    const session = result.session;
     await throttle(1000);
 
     await Promise.all([
@@ -1244,7 +1250,7 @@ describe("Authenticated Sessions", () => {
     //@ts-expect-error
     wallet.core.pairing.registeredMethods = [];
     wallet.core.pairing.register({ methods: toRegisterMethods });
-    await Promise.all([
+    const result = await Promise.all([
       new Promise<void>((resolve) => {
         wallet.on("session_proposal", async (payload) => {
           // validate that the dapp has both `session_authenticate` & `session_proposal` stored
@@ -1284,8 +1290,9 @@ describe("Authenticated Sessions", () => {
         wallet.pair({ uri });
         resolve();
       }),
-    ]);
-    const { auths, session } = await response();
+      response(),
+    ]).then((result) => result[2]);
+    const { session, auths } = result;
     expect(auths).to.be.undefined;
     expect(session).to.exist;
     expect(session.namespaces.eip155).to.exist;


### PR DESCRIPTION
## Description
Implemented cache result in `createDelayedPromise` util so once the promise resolves, it will return the cached result when called again. This solves 1CA tests flakiness as calling `resolve` after it was already resolved was causing the tests to hang

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests


## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
