### PR TITLE
chore(docs): update EthereumProvider install step

### DIFF
--- a/providers/ethereum-provider/README.md
+++ b/providers/ethereum-provider/README.md
@@ -5,7 +5,7 @@ Ethereum Provider for WalletConnect Protocol.
 ## Installation
 
 ```
-npm i @walletconnect/ethereum-provider @walletconnect/modal
+npm i @walletconnect/ethereum-provider
 ```
 
 ## Initialization


### PR DESCRIPTION
## Description

* Manually installing `@walletconnect/modal` as peerDep is redundant.