### PR TITLE
chore: disables auto init event

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -195,7 +195,6 @@ export class Core extends ICore {
       await this.relayer.init();
       await this.heartbeat.init();
       await this.pairing.init();
-      this.eventClient.init();
       this.linkModeSupportedApps = (await this.storage.getItem(WALLETCONNECT_LINK_MODE_APPS)) || [];
 
       this.initialized = true;


### PR DESCRIPTION
## Description
Disabled auto init event as it will be explicitely called now by WalletKit only
https://linear.app/reown/issue/WK-373/only-call-init-analytics-event-from-walletkit-not-low-level-core
## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
