### PR TITLE
fix: set iframe deeplink target to `_top`

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -413,14 +413,7 @@ export async function handleDeeplinkRedirect({
         return;
       }
 
-      let target = "_self";
-      if (isIframe()) {
-        target = "_top";
-      } else if (isTelegram() || link.startsWith("https://") || link.startsWith("http://")) {
-        target = "_blank";
-      }
-
-      window.open(link, target, "noreferrer noopener");
+      openDeeplink(link);
     } else if (env === ENV_MAP.reactNative) {
       // global.Linking is set by react-native-compat
       if (typeof (global as any)?.Linking !== "undefined") {
@@ -445,6 +438,17 @@ export function formatDeeplinkUrl(deeplink: string, requestId: number, sessionTo
     link = `${link}/wc?${payload}`;
   }
   return link;
+}
+
+export function openDeeplink(url: string) {
+  let target = "_self";
+  if (isIframe()) {
+    target = "_top";
+  } else if (isTelegram() || url.startsWith("https://") || url.startsWith("http://")) {
+    target = "_blank";
+  }
+
+  window.open(url, target, "noreferrer noopener");
 }
 
 export async function getDeepLink(storage: IKeyValueStorage, key: string) {

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -413,11 +413,14 @@ export async function handleDeeplinkRedirect({
         return;
       }
 
-      if (link.startsWith("https://") || link.startsWith("http://")) {
-        window.open(link, "_blank", "noreferrer noopener");
-      } else {
-        window.open(link, isTelegram() ? "_blank" : "_self", "noreferrer noopener");
+      let target = "_self";
+      if (isIframe()) {
+        target = "_top";
+      } else if (isTelegram() || link.startsWith("https://") || link.startsWith("http://")) {
+        target = "_blank";
       }
+
+      window.open(link, target, "noreferrer noopener");
     } else if (env === ENV_MAP.reactNative) {
       // global.Linking is set by react-native-compat
       if (typeof (global as any)?.Linking !== "undefined") {
@@ -499,6 +502,14 @@ export function isTelegram() {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       Boolean((window as any).TelegramWebviewProxyProto))
   );
+}
+
+export function isIframe() {
+  try {
+    return window.self !== window.top;
+  } catch {
+    return false;
+  }
 }
 
 export function toBase64(input: string, removePadding = false): string {

--- a/packages/utils/test/misc.spec.ts
+++ b/packages/utils/test/misc.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   calcExpiry,
   formatDeeplinkUrl,
@@ -8,6 +8,7 @@ import {
   hasOverlap,
   isExpired,
   toBase64,
+  openDeeplink,
 } from "../src";
 
 const RELAY_URL = "wss://relay.walletconnect.org";
@@ -188,6 +189,64 @@ describe("Misc", () => {
       expect(formatted).to.eql(expectedDeepLink);
       const decoded = atob(formatted.split("startapp=")[1]);
       expect(decoded).to.eql(partToEncode);
+    });
+
+    describe("openDeeplink", () => {
+      const previousWindow = globalThis.window;
+
+      beforeEach(() => {
+        Object.assign(globalThis, {
+          window: {
+            open: vi.fn(),
+          },
+        });
+      });
+
+      afterAll(() => {
+        Object.assign(globalThis, {
+          window: previousWindow,
+        });
+      });
+
+      it("should target '_blank' if link starts with 'https://'", () => {
+        const url = "https://example.com";
+        openDeeplink(url);
+        expect(window.open).toHaveBeenCalledWith(url, "_blank", "noreferrer noopener");
+      });
+
+      it("should target '_blank' if link starts with 'http://'", () => {
+        const url = "http://example.com";
+        openDeeplink(url);
+        expect(window.open).toHaveBeenCalledWith(url, "_blank", "noreferrer noopener");
+      });
+
+      it("should target '_blank' for telegram deep link", () => {
+        Object.assign(window, {
+          Telegram: {},
+        });
+
+        const url = "scheme://example.com";
+        openDeeplink(url);
+        expect(window.open).toHaveBeenCalledWith(url, "_blank", "noreferrer noopener");
+
+        (window as any).Telegram = undefined;
+      });
+
+      it("should target '_top' if is an iframe", () => {
+        Object.assign(window, {
+          top: {},
+        });
+
+        const url = "scheme://example.com";
+        openDeeplink(url);
+        expect(window.open).toHaveBeenCalledWith(url, "_top", "noreferrer noopener");
+      });
+
+      it("should target '_self' for other cases", () => {
+        const url = "scheme://example.com";
+        openDeeplink(url);
+        expect(window.open).toHaveBeenCalledWith(url, "_self", "noreferrer noopener");
+      });
     });
   });
 });

--- a/packages/utils/test/misc.spec.ts
+++ b/packages/utils/test/misc.spec.ts
@@ -9,6 +9,7 @@ import {
   isExpired,
   toBase64,
   openDeeplink,
+  isIframe,
 } from "../src";
 
 const RELAY_URL = "wss://relay.walletconnect.org";
@@ -247,6 +248,27 @@ describe("Misc", () => {
         openDeeplink(url);
         expect(window.open).toHaveBeenCalledWith(url, "_self", "noreferrer noopener");
       });
+    });
+  });
+
+  describe("isIframe", () => {
+    const previousWindow = globalThis.window;
+
+    afterEach(() => {
+      Object.assign(globalThis, { window: previousWindow });
+    });
+
+    it("should return true if window.top is not equal to window", () => {
+      Object.assign(globalThis, {
+        window: {
+          top: {},
+        },
+      });
+      expect(isIframe()).to.be.true;
+    });
+
+    it("should return false if window.top is equal to window", () => {
+      expect(isIframe()).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Description

This PR is fixing how to handle deeplinks when Universal Provider is running through an `iframe`.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your configuration.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modul
