### PR TITLE
chore(renovate): ignore deprecated `packages/web3wallet`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,5 +20,5 @@
       "schedule": ["at any time"]
     }
   ],
-  "ignorePaths": ["**/android/**", "**/ios/**"]
+  "ignorePaths": ["**/android/**", "**/ios/**", "packages/web3modal/**"]
 }


### PR DESCRIPTION
## Context

- Renovate is still continuously opening PRs on the `packages/web3wallet` path for non-critical updates.
- Ignore the path to avoid unnecessary PR noise and churn in the repo.