### PR TITLE
chore: removes redundant clientId() call during subscriber init

### DIFF
--- a/packages/core/src/controllers/subscriber.ts
+++ b/packages/core/src/controllers/subscriber.ts
@@ -53,7 +53,7 @@ export class Subscriber extends ISubscriber {
     super(relayer, logger);
     this.relayer = relayer;
     this.logger = generateChildLogger(logger, this.name);
-    this.clientId = ""; // assigned when used via this.getClientId()
+    this.clientId = ""; // assigned when calling this.getClientId()
   }
 
   public init: ISubscriber["init"] = async () => {

--- a/packages/core/test/subscriber.spec.ts
+++ b/packages/core/test/subscriber.spec.ts
@@ -103,6 +103,8 @@ describe("Subscriber", () => {
 
   describe("init", () => {
     it("registers event listeners", async () => {
+      expect(subscriber.clientId).to.equal("");
+
       const topic = generateRandomBytes32();
       const emitSpy = Sinon.spy();
       subscriber.events.emit = emitSpy;
@@ -114,6 +116,8 @@ describe("Subscriber", () => {
       relayer.provider.events.emit(RELAYER_PROVIDER_EVENTS.disconnect);
       expect(subscriber.subscriptions.size).to.equal(0);
       expect(subscriber.topics.length).to.equal(0);
+
+      expect(subscriber.clientId).to.not.equal("");
     });
   });
 


### PR DESCRIPTION
## Description
Removed redundant setting of `clientId` during subscriber init. The value is still used and required to set subscription IDs but should be fetched when needed instead of during init. This change also has the benefit of[ speeding up the sdk init](https://reown-inc.slack.com/archives/C04SYT4LU2W/p1738148328310009?thread_ts=1737968810.323199&cid=C04SYT4LU2W) 

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests 

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
