### PR TITLE
change universal-provider to use merge from es-toolkit instead of lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11736,6 +11736,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.32.0.tgz",
+      "integrity": "sha512-ZfSfHP1l6ubgW/B/FRtqb9bYdMvI6jizbOSfbwwJNcOQ1QE6TFsC3jpQkZ900uUPSR3t3SU5Ds7UWKnYz+uP8Q==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/es5-ext": {
       "version": "0.10.64",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
@@ -19143,6 +19153,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -29914,8 +29925,8 @@
         "@walletconnect/sign-client": "2.18.0",
         "@walletconnect/types": "2.18.0",
         "@walletconnect/utils": "2.18.0",
-        "events": "3.3.0",
-        "lodash": "4.17.21"
+        "es-toolkit": "1.32.0",
+        "events": "3.3.0"
       },
       "devDependencies": {
         "cosmos-wallet": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -76,5 +76,6 @@
     "sinon": "14.0.0",
     "typescript": "4.7.4",
     "vitest": "0.22.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,5 @@
     "sinon": "14.0.0",
     "typescript": "4.7.4",
     "vitest": "0.22.1"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/providers/universal-provider/package.json
+++ b/providers/universal-provider/package.json
@@ -50,8 +50,8 @@
     "@walletconnect/sign-client": "2.18.0",
     "@walletconnect/types": "2.18.0",
     "@walletconnect/utils": "2.18.0",
-    "events": "3.3.0",
-    "lodash": "4.17.21"
+    "es-toolkit": "1.32.0",
+    "events": "3.3.0"
   },
   "devDependencies": {
     "cosmos-wallet": "1.2.0",

--- a/providers/universal-provider/src/utils/misc.ts
+++ b/providers/universal-provider/src/utils/misc.ts
@@ -8,7 +8,7 @@ import {
 } from "@walletconnect/utils";
 import { RPC_URL } from "../constants";
 import { Namespace, NamespaceConfig } from "../types";
-import merge from "lodash/merge";
+import { merge } from "es-toolkit";
 
 export function getRpcUrl(chainId: string, rpc: Namespace, projectId?: string): string | undefined {
   const chain = parseChainId(chainId);

--- a/providers/universal-provider/src/utils/misc.ts
+++ b/providers/universal-provider/src/utils/misc.ts
@@ -8,7 +8,7 @@ import {
 } from "@walletconnect/utils";
 import { RPC_URL } from "../constants";
 import { Namespace, NamespaceConfig } from "../types";
-import { merge } from "es-toolkit";
+import { merge } from "es-toolkit/compat";
 
 export function getRpcUrl(chainId: string, rpc: Namespace, projectId?: string): string | undefined {
   const chain = parseChainId(chainId);


### PR DESCRIPTION
## Description

changes the merge function used to be from lodash to es-toolkit https://github.com/toss/es-toolkit/tree/main

it should be compatible, and results in a much smaller bundle size for consumers.


## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

i cant run the tests because i dont know how to configure a relay

## Fixes/Resolves (Optional)

 #5628

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

i dont really know the process here. please let me know if there is something i can read / what i should do to help this go through
