### PR TITLE
fix: allows passing `storage` param from EthereumProvider to UniversalProvider

### DIFF
--- a/providers/ethereum-provider/README.md
+++ b/providers/ethereum-provider/README.md
@@ -21,6 +21,8 @@ const provider = await EthereumProvider.init({
   events, // OPTIONAL ethereum events
   rpcMap, // OPTIONAL rpc urls for each chain
   metadata, // OPTIONAL metadata of your app
+  storage, // OPTIONAL custom storage implementation
+  storageOptions, // OPTIONAL storage config options
   qrModalOptions, // OPTIONAL - `undefined` by default
 });
 ```

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -578,6 +578,7 @@ export class EthereumProvider implements IEthereumProvider {
       metadata: this.rpc.metadata,
       disableProviderPing: opts.disableProviderPing,
       relayUrl: opts.relayUrl,
+      storage: opts.storage,
       storageOptions: opts.storageOptions,
       customStoragePrefix: opts.customStoragePrefix,
       telemetryEnabled: opts.telemetryEnabled,


### PR DESCRIPTION
## Description

The ﻿`EthereumProviderOptions`  type specified the ﻿`storage` parameter, but it was not utilized. For instance, in Wagmi walletConnect [connector](https://github.com/wevm/wagmi/blob/main/packages/connectors/src/walletConnect.ts#L252), the `﻿storage` parameter is allowed for use but has no effect (uses [EthereumProviderOptions](https://github.com/wevm/wagmi/blob/main/packages/connectors/src/walletConnect.ts#L27)).

PR adds missing `storage` param propagation from `EthereumProvider` to `UniversalProvider` init, so it allows usage of custom storage implementations. 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

I tested the `storage` param with Wagmi walletConnect connector and I'm finally able to use custom storage implementation.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
