### PR TITLE
refactor: use viem for eip191 signature validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29977,7 +29977,7 @@
         "elliptic": "6.6.1",
         "query-string": "7.1.3",
         "uint8arrays": "3.1.0",
-        "viem": "^2.23.2"
+        "viem": "2.23.2"
       },
       "devDependencies": {
         "@stablelib/x25519": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,12 @@
         "vitest": "0.22.1"
       }
     },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
+      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==",
+      "license": "MIT"
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
@@ -3506,6 +3512,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
       "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3570,6 +3577,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
       "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3591,6 +3599,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
       "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3610,6 +3619,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
       "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3748,6 +3758,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
       "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3768,6 +3779,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
       "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3825,6 +3837,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
       "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3926,6 +3939,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
       "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3968,6 +3982,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
       "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3992,6 +4007,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
@@ -4007,6 +4023,7 @@
       "version": "4.12.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
       "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ethersproject/solidity": {
@@ -4060,6 +4077,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
       "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -6124,6 +6142,42 @@
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
+      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
+      "integrity": "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.8.1",
+        "@noble/hashes": "~1.7.1",
+        "@scure/base": "~1.2.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
+      "integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.7.1",
+        "@scure/base": "~1.2.4"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@sentry/core": {
       "version": "5.30.0",
@@ -9167,6 +9221,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -17844,6 +17899,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isows": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
+      "integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -18133,6 +18203,7 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
       "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -29890,7 +29961,6 @@
       "version": "2.18.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ethersproject/transactions": "5.7.0",
         "@noble/ciphers": "1.2.1",
         "@noble/curves": "1.8.1",
         "@noble/hashes": "1.7.1",
@@ -29906,13 +29976,136 @@
         "detect-browser": "5.3.0",
         "elliptic": "6.6.1",
         "query-string": "7.1.3",
-        "uint8arrays": "3.1.0"
+        "uint8arrays": "3.1.0",
+        "viem": "^2.23.2"
       },
       "devDependencies": {
         "@stablelib/x25519": "1.0.3",
         "@types/elliptic": "6.4.18",
         "@types/lodash.isequal": "4.5.6",
         "@walletconnect/jsonrpc-types": "1.0.4"
+      }
+    },
+    "packages/utils/node_modules/abitype": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
+      "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.22.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "packages/utils/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "packages/utils/node_modules/ox": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.7.tgz",
+      "integrity": "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "packages/utils/node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/utils/node_modules/viem": {
+      "version": "2.23.2",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.23.2.tgz",
+      "integrity": "sha512-NVmW/E0c5crMOtbEAqMF0e3NmvQykFXhLOc/CkLIXOlzHSA6KXVz3CYVmaKqBF8/xtjsjHAGjdJN3Ru1kFJLaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.8.1",
+        "@noble/hashes": "1.7.1",
+        "@scure/bip32": "1.6.2",
+        "@scure/bip39": "1.5.4",
+        "abitype": "1.0.8",
+        "isows": "1.0.6",
+        "ox": "0.6.7",
+        "ws": "8.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "packages/utils/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "providers/ethereum-provider": {

--- a/packages/core/src/controllers/events.ts
+++ b/packages/core/src/controllers/events.ts
@@ -187,7 +187,7 @@ export class EventClient extends IEventClient {
 
     if (this.events.size === 0) return;
 
-    const eventsToSend = [];
+    const eventsToSend: EventClientTypes.Event[] = [];
     // exclude events without type as they can be considered `in progress`
     for (const [_, event] of this.events) {
       if (event.props.type) {

--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -266,7 +266,8 @@ export class Pairing implements IPairing {
     const payload = formatJsonRpcResult(id, result);
     const message = await this.core.crypto.encode(topic, payload);
     const record = await this.core.history.get(topic, id);
-    const opts = PAIRING_RPC_OPTS[record.request.method].res;
+    const method = record.request.method as PairingJsonRpcTypes.WcMethod;
+    const opts = PAIRING_RPC_OPTS[method].res;
     await this.core.relayer.publish(topic, message, opts);
     await this.core.history.resolve(payload);
   };
@@ -275,8 +276,10 @@ export class Pairing implements IPairing {
     const payload = formatJsonRpcError(id, error);
     const message = await this.core.crypto.encode(topic, payload);
     const record = await this.core.history.get(topic, id);
-    const opts = PAIRING_RPC_OPTS[record.request.method]
-      ? PAIRING_RPC_OPTS[record.request.method].res
+    const method = record.request.method as PairingJsonRpcTypes.WcMethod;
+
+    const opts = PAIRING_RPC_OPTS[method]
+      ? PAIRING_RPC_OPTS[method].res
       : PAIRING_RPC_OPTS.unregistered_method.res;
 
     await this.core.relayer.publish(topic, message, opts);

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -1553,7 +1553,8 @@ export class Engine extends IEngine {
       const redirectURL = getLinkModeURL(appLink, topic, message);
       await (global as any).Linking.openURL(redirectURL, this.client.name);
     } else {
-      const opts = ENGINE_RPC_OPTS[record.request.method].res;
+      const method = record.request.method as JsonRpcTypes.WcMethod;
+      const opts = ENGINE_RPC_OPTS[method].res;
 
       opts.tvf = {
         ...tvf,
@@ -1604,7 +1605,8 @@ export class Engine extends IEngine {
       const redirectURL = getLinkModeURL(appLink, topic, message);
       await (global as any).Linking.openURL(redirectURL, this.client.name);
     } else {
-      const opts = rpcOpts || ENGINE_RPC_OPTS[record.request.method].res;
+      const method = record.request.method as JsonRpcTypes.WcMethod;
+      const opts = rpcOpts || ENGINE_RPC_OPTS[method].res;
       // await is intentionally omitted to speed up performance
       this.client.core.relayer.publish(topic, message, opts);
     }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -31,7 +31,6 @@
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },
   "dependencies": {
-    "@ethersproject/transactions": "5.7.0",
     "@noble/ciphers": "1.2.1",
     "@noble/curves": "1.8.1",
     "@noble/hashes": "1.7.1",
@@ -47,7 +46,8 @@
     "detect-browser": "5.3.0",
     "elliptic": "6.6.1",
     "query-string": "7.1.3",
-    "uint8arrays": "3.1.0"
+    "uint8arrays": "3.1.0",
+    "viem": "^2.23.2"
   },
   "devDependencies": {
     "@stablelib/x25519": "1.0.3",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -47,7 +47,7 @@
     "elliptic": "6.6.1",
     "query-string": "7.1.3",
     "uint8arrays": "3.1.0",
-    "viem": "^2.23.2"
+    "viem": "2.23.2"
   },
   "devDependencies": {
     "@stablelib/x25519": "1.0.3",

--- a/packages/utils/src/cacao.ts
+++ b/packages/utils/src/cacao.ts
@@ -255,13 +255,11 @@ export function addResourceToRecap(recap: RecapType, resource: string, actions: 
     ...actions,
   };
   const keys = Object.keys(recap.att)?.sort((a, b) => a.localeCompare(b));
-  const sorted = keys.reduce(
-    (obj, key) => {
-      obj.att[key] = recap.att[key];
-      return obj;
-    },
-    { att: {} },
-  );
+  const baseRecap: RecapType = { att: {} };
+  const sorted = keys.reduce((obj, key) => {
+    obj.att[key] = recap.att[key];
+    return obj;
+  }, baseRecap);
   return sorted;
 }
 
@@ -311,7 +309,7 @@ export function mergeRecaps(recap1: RecapType, recap2: RecapType) {
   const keys = Object.keys(recap1.att)
     .concat(Object.keys(recap2.att))
     .sort((a, b) => a.localeCompare(b));
-  const mergedRecap = { att: {} };
+  const mergedRecap: RecapType = { att: {} };
   keys.forEach((key) => {
     const actions = Object.keys(recap1.att?.[key] || {})
       .concat(Object.keys(recap2.att?.[key] || {}))
@@ -343,7 +341,7 @@ export function formatStatementFromRecap(statement = "", recap: RecapType) {
     });
     //
     actions.sort((a, b) => a.action.localeCompare(b.action));
-    const uniqueAbilities = {};
+    const uniqueAbilities: Record<string, string[]> = {};
     actions.forEach((action: any) => {
       if (!uniqueAbilities[action.ability]) {
         uniqueAbilities[action.ability] = [];

--- a/packages/utils/src/memoryStore.ts
+++ b/packages/utils/src/memoryStore.ts
@@ -1,4 +1,4 @@
-const memoryStore = {};
+const memoryStore: Record<string, any> = {};
 
 export abstract class MemoryStore {
   static get<T = unknown>(key: string) {

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -246,7 +246,7 @@ export function mapEntries<A = any, B = any>(
   obj: Record<string, A>,
   cb: (x: A) => B,
 ): Record<string, B> {
-  const res = {};
+  const res: any = {};
   Object.keys(obj).forEach((key) => {
     res[key] = cb(obj[key]);
   });

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -54,7 +54,7 @@ export function getRequiredNamespacesFromNamespaces(
   const validNamespacesError = isValidNamespaces(namespaces, caller);
   if (validNamespacesError) throw new Error(validNamespacesError.message);
 
-  const required = {};
+  const required: ProposalTypes.RequiredNamespaces = {};
   for (const [namespace, values] of Object.entries(namespaces)) {
     required[namespace] = {
       methods: values.methods,
@@ -91,7 +91,7 @@ export function buildApprovedNamespaces(
   const normalizedOptional = normalizeNamespaces(optionalNamespaces);
 
   // build approved namespaces
-  const namespaces = {};
+  const namespaces: SessionTypes.Namespaces = {};
   Object.keys(supportedNamespaces).forEach((namespace) => {
     const supportedChains = supportedNamespaces[namespace].chains;
     const supportedMethods = supportedNamespaces[namespace].methods;
@@ -116,7 +116,7 @@ export function buildApprovedNamespaces(
   const err = isConformingNamespaces(requiredNamespaces, namespaces, "approve()");
   if (err) throw new Error(err.message);
 
-  const approvedNamespaces = {};
+  const approvedNamespaces: SessionTypes.Namespaces = {};
 
   // if both required & optional namespaces are empty, return all supported namespaces by the wallet
   if (!Object.keys(requiredNamespaces).length && !Object.keys(optionalNamespaces).length)
@@ -230,7 +230,7 @@ export function normalizeNamespaces(
 }
 
 export function getNamespacesFromAccounts(accounts: string[]) {
-  const namespaces = {};
+  const namespaces: SessionTypes.Namespaces = {};
   accounts?.forEach((account) => {
     const [namespace, chainId] = account.split(":");
     if (!namespaces[namespace]) {
@@ -238,10 +238,11 @@ export function getNamespacesFromAccounts(accounts: string[]) {
         accounts: [],
         chains: [],
         events: [],
+        methods: [],
       };
     }
     namespaces[namespace].accounts.push(account);
-    namespaces[namespace].chains.push(`${namespace}:${chainId}`);
+    namespaces[namespace].chains?.push(`${namespace}:${chainId}`);
   });
 
   return namespaces;

--- a/packages/utils/src/signatures.ts
+++ b/packages/utils/src/signatures.ts
@@ -1,5 +1,5 @@
 import { keccak_256 } from "@noble/hashes/sha3";
-import { recoverAddress } from "@ethersproject/transactions";
+import { recoverAddress } from "viem";
 import { AuthTypes } from "@walletconnect/types";
 import { parseChainId } from "./caip";
 const DEFAULT_RPC_URL = "https://rpc.walletconnect.org/v1";
@@ -21,7 +21,7 @@ export async function verifySignature(
   // Determine if this signature is from an EOA or a contract.
   switch (cacaoSignature.t) {
     case "eip191":
-      return isValidEip191Signature(address, reconstructedMessage, cacaoSignature.s);
+      return await isValidEip191Signature(address, reconstructedMessage, cacaoSignature.s);
     case "eip1271":
       return await isValidEip1271Signature(
         address,
@@ -39,12 +39,16 @@ export async function verifySignature(
   }
 }
 
-export function isValidEip191Signature(
+export async function isValidEip191Signature(
   address: string,
   message: string,
   signature: string,
-): boolean {
-  const recoveredAddress = recoverAddress(hashEthereumMessage(message), signature);
+): Promise<boolean> {
+  const recoveredAddress = await recoverAddress({
+    hash: hashEthereumMessage(message) as `0x${string}`,
+    signature: signature as `0x${string}`,
+  });
+  console.log("recoveredAddress: ", recoveredAddress);
   return recoveredAddress.toLowerCase() === address.toLowerCase();
 }
 

--- a/packages/utils/src/signatures.ts
+++ b/packages/utils/src/signatures.ts
@@ -48,7 +48,6 @@ export async function isValidEip191Signature(
     hash: hashEthereumMessage(message) as `0x${string}`,
     signature: signature as `0x${string}`,
   });
-  console.log("recoveredAddress: ", recoveredAddress);
   return recoveredAddress.toLowerCase() === address.toLowerCase();
 }
 

--- a/packages/utils/src/uri.ts
+++ b/packages/utils/src/uri.ts
@@ -63,9 +63,10 @@ export function formatRelayParams(relay: RelayerTypes.ProtocolOptions, delimiter
   const prefix = "relay";
   const params: any = {};
   Object.keys(relay).forEach((key) => {
-    const k = prefix + delimiter + key;
-    if (relay[key]) {
-      params[k] = relay[key];
+    const typedKey = key as keyof typeof relay;
+    const k = prefix + delimiter + typedKey;
+    if (relay[typedKey]) {
+      params[k] = relay[typedKey];
     }
   });
   return params;

--- a/packages/utils/src/validators.ts
+++ b/packages/utils/src/validators.ts
@@ -447,7 +447,7 @@ export function isConformingNamespaces(
 }
 
 function parseNamespaces(namespaces: ProposalTypes.RequiredNamespaces) {
-  const parsed = {};
+  const parsed: ProposalTypes.RequiredNamespaces = {};
   Object.keys(namespaces).forEach((key) => {
     // e.g. `eip155:1`
     const isInlineChainDefinition = key.includes(":");
@@ -477,7 +477,7 @@ function filterDuplicateNamespaces(namespaces: string[]) {
 }
 
 function parseApprovedNamespaces(namespaces: SessionTypes.Namespaces) {
-  const parsed = {};
+  const parsed: SessionTypes.Namespaces = {};
   Object.keys(namespaces).forEach((key) => {
     const isInlineChainDefinition = key.includes(":");
     if (isInlineChainDefinition) {

--- a/packages/utils/test/signatures.spec.ts
+++ b/packages/utils/test/signatures.spec.ts
@@ -1,6 +1,6 @@
 import { AuthTypes } from "@walletconnect/types";
 import { describe, expect, it } from "vitest";
-import { verifySignature } from "../src";
+import { isValidEip191Signature, verifySignature } from "../src";
 
 describe("utils/signature", () => {
   describe("EIP-1271 signatures", () => {
@@ -88,6 +88,34 @@ Expiration Time: 2022-10-11T23:03:35.700Z`;
       ).rejects.toThrow(
         `isValidEip1271Signature failed: chainId must be in CAIP-2 format, received: ${invalidChainIdThree}`,
       );
+    });
+  });
+  describe("EIP-191 signatures", () => {
+    it("should validate a valid signature", async () => {
+      const address = "0x13A2Ff792037AA2cd77fE1f4B522921ac59a9C52";
+      const message = `Hello AppKit!`;
+      const signature =
+        "0xd7ec09eb8ecb1ba9af45380e14d3ef1a1ec2376e0adfc0a9b591e7c3519a00d702cbe063aa55ff681265eed2d1646a217f0bf23f12ab4cd326455ab4134e12691b";
+      const isValid = await isValidEip191Signature(address, message, signature);
+      expect(isValid).toBe(true);
+    });
+    it("should fail to validate an invalid signature", async () => {
+      const address = "0x13A2Ff792037AA2cd77fE1f4B522921ac59a9C52";
+      const message = `Hello AppKit!`;
+      const signature = "0xd7ec09eb8ecb1ba9af45380e14d3ef1a1ec2376e0adfc0a9b591e";
+      await expect(isValidEip191Signature(address, message, signature)).rejects.toThrow();
+    });
+    it("should fail to validate a valid signature with wrong address", async () => {
+      const address = "0x13A2Ff792037AA2cd77fE1f4B522921ac59a9C54";
+      const message = `Hello AppKit!`;
+      const signature = "0xd7ec09eb8ecb1ba9af45380e14d3ef1a1ec2376e0adfc0a9b591e";
+      await expect(isValidEip191Signature(address, message, signature)).rejects.toThrow();
+    });
+    it("should fail to validate an valid signature with wrong message", async () => {
+      const address = "0x13A2Ff792037AA2cd77fE1f4B522921ac59a9C52";
+      const message = `Hello AppKit! 0xyadayada`;
+      const signature = "0xd7ec09eb8ecb1ba9af45380e14d3ef1a1ec2376e0adfc0a9b591e";
+      await expect(isValidEip191Signature(address, message, signature)).rejects.toThrow();
     });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,8 +31,7 @@
     "strict": true,
     "strictFunctionTypes": true,
     "strictNullChecks": true,
-    "strictPropertyInitialization": true,
-    "suppressImplicitAnyIndexErrors": true
+    "strictPropertyInitialization": true
   },
   "include": ["**/package.json", "packages", "providers"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "target": "ES2020",
     "moduleResolution": "Node",
     "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noLib": false,


### PR DESCRIPTION
## Description
Replaces `@ethersproject/transactions` with `viem` because `ethers` depends on problematic `elliptic` version
canary - https://www.npmjs.com/package/@walletconnect/utils/v/2.18.1-canary-viem-1
## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests 


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
