### PR TITLE
refactor: scraps auto reconnect in `Universal Provider`

### DIFF
--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -244,7 +244,7 @@ export class UniversalProvider implements IUniversalProvider {
   }
 
   public abortPairingAttempt() {
-    this.logger.warn("abortPairingAttempt is deprecated.");
+    this.logger.warn("abortPairingAttempt is deprecated. This is now a no-op.");
   }
 
   // ---------- Private ----------------------------------------------- //

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -1,4 +1,4 @@
-import SignClient, { PROPOSAL_EXPIRY_MESSAGE } from "@walletconnect/sign-client";
+import SignClient from "@walletconnect/sign-client";
 import { SessionTypes } from "@walletconnect/types";
 import { JsonRpcResult } from "@walletconnect/jsonrpc-types";
 import { getSdkError, isValidArray, parseNamespaceKey } from "@walletconnect/utils";

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -53,8 +53,6 @@ export class UniversalProvider implements IUniversalProvider {
   public logger: Logger;
   public uri: string | undefined;
 
-  private shouldAbortPairingAttempt = false;
-  private maxPairingAttempts = 10;
   private disableProviderPing = false;
 
   static async init(opts: UniversalProviderOpts) {
@@ -187,44 +185,25 @@ export class UniversalProvider implements IUniversalProvider {
   }
 
   public async pair(pairingTopic: string | undefined): Promise<SessionTypes.Struct> {
-    this.shouldAbortPairingAttempt = false;
-    let pairingAttempts = 0;
-    do {
-      if (this.shouldAbortPairingAttempt) {
-        throw new Error("Pairing aborted");
-      }
+    const { uri, approval } = await this.client.connect({
+      pairingTopic,
+      requiredNamespaces: this.namespaces,
+      optionalNamespaces: this.optionalNamespaces,
+      sessionProperties: this.sessionProperties,
+    });
 
-      if (pairingAttempts >= this.maxPairingAttempts) {
-        throw new Error("Max auto pairing attempts reached");
-      }
+    if (uri) {
+      this.uri = uri;
+      this.events.emit("display_uri", uri);
+    }
 
-      const { uri, approval } = await this.client.connect({
-        pairingTopic,
-        requiredNamespaces: this.namespaces,
-        optionalNamespaces: this.optionalNamespaces,
-        sessionProperties: this.sessionProperties,
-      });
+    const session = await approval();
+    this.session = session;
+    // assign namespaces from session if not already defined
+    const approved = populateNamespacesChains(session.namespaces) as NamespaceConfig;
+    this.namespaces = mergeRequiredOptionalNamespaces(this.namespaces, approved);
+    this.persist("namespaces", this.namespaces);
 
-      if (uri) {
-        this.uri = uri;
-        this.events.emit("display_uri", uri);
-      }
-
-      await approval()
-        .then((session) => {
-          this.session = session;
-          // assign namespaces from session if not already defined
-          const approved = populateNamespacesChains(session.namespaces) as NamespaceConfig;
-          this.namespaces = mergeRequiredOptionalNamespaces(this.namespaces, approved);
-          this.persist("namespaces", this.namespaces);
-        })
-        .catch((error) => {
-          if (error.message !== PROPOSAL_EXPIRY_MESSAGE) {
-            throw error;
-          }
-          pairingAttempts++;
-        });
-    } while (!this.session);
     this.onConnect();
     return this.session;
   }
@@ -265,7 +244,7 @@ export class UniversalProvider implements IUniversalProvider {
   }
 
   public abortPairingAttempt() {
-    this.shouldAbortPairingAttempt = true;
+    this.logger.warn("abortPairingAttempt is deprecated.");
   }
 
   // ---------- Private ----------------------------------------------- //

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -1529,6 +1529,3 @@ const validateProvider = async (params: ValidateProviderParams) => {
     }
   }
 };
-function toMiliseconds(arg0: any): number {
-  throw new Error("Function not implemented.");
-}


### PR DESCRIPTION
## Description
There was old logic in `Universal Provider` that was automatically sending new session proposal if the previous one expires `10` times before finally rejecting. This PR scraps that behaviour as its too wasteful on resources and should be handled by the apps anyway. 

Also added `proposal_expire` listener in Sign's `connect` handler as `connect` wasn't actually rejecting when the proposal expires but when the `session_proposal.ttl` was reached without response from peer client  

canary deployment: https://appkit-laboratory-git-chore-test-2181-canary-ws-2-reown-com.vercel.app/

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests 

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
