### PR TITLE
fix: problematic session completion

### DIFF
--- a/packages/sign-client/src/constants/client.ts
+++ b/packages/sign-client/src/constants/client.ts
@@ -26,6 +26,7 @@ export const SIGN_CLIENT_EVENTS: Record<SignClientTypes.Event, SignClientTypes.E
   proposal_expire: "proposal_expire",
   session_authenticate: "session_authenticate",
   session_request_expire: "session_request_expire",
+  session_connect: "session_connect",
 };
 
 export const SIGN_CLIENT_STORAGE_OPTIONS = {

--- a/packages/sign-client/test/sdk/validation.spec.ts
+++ b/packages/sign-client/test/sdk/validation.spec.ts
@@ -30,8 +30,10 @@ describe("Sign Client Validation", () => {
     clients = await initTwoClients();
     await testConnectMethod(clients);
     pairingTopic = clients.A.pairing.keys[0];
-    proposalId = clients.A.proposal.keys[0];
     topic = clients.A.session.keys[0];
+    proposalId = await clients.A.connect({}).then(() => {
+      return clients.A.proposal.keys[0];
+    });
   });
 
   afterAll(async () => {

--- a/packages/types/src/sign-client/client.ts
+++ b/packages/types/src/sign-client/client.ts
@@ -22,7 +22,8 @@ export declare namespace SignClientTypes {
     | "session_event"
     | "session_authenticate"
     | "proposal_expire"
-    | "session_request_expire";
+    | "session_request_expire"
+    | "session_connect";
 
   interface BaseEventArgs<T = unknown> {
     id: number;
@@ -60,6 +61,7 @@ export declare namespace SignClientTypes {
     } & BaseEventArgs<AuthTypes.AuthRequestEventArgs>;
     proposal_expire: { id: number };
     session_request_expire: { id: number };
+    session_connect: { session: SessionTypes.Struct };
   }
 
   type Metadata = CoreTypes.Metadata;


### PR DESCRIPTION
## Description
Fixed an annoying `Missing or invalid. Record was recently deleted - pairing` issue [reported here](https://reown-inc.slack.com/archives/C07BNE1C39C/p1740145763566439?thread_ts=1740059889.947619&cid=C07BNE1C39C) which happens because Sign Client engine used single non unique event for completing a session - `session_connect`. When the client had multiple pending proposals, establishing a session was triggering  the `session_connect` listener for all others resulting in the error log. This also means that the other pending proposals can no longer finalize a session because their `session_connect` listener was wrongly triggered. 

I've implemented
- unique `session_connect`+`proposalId`  listener for each proposal allowing multiple sessions to be established at the same time
- refactored the session settle behaviour to not rely on event listeners. This allows the sdk to complete a session even after restart
- added new client event `session_connect` to allow apps to subscribe for new sessions completed after client restart 
 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests


## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
