### PR TITLE
fix: handshake canary metric

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -36,7 +36,8 @@ describe("Canary", () => {
         `Client A (${await handshakeClient.core.crypto.getClientId()}) initialized in ${initLatencyMs}ms`,
       );
       const handshakeStart = Date.now();
-      await handshakeClient.core.relayer.transportOpen();
+      //@ts-expect-error
+      await handshakeClient.core.relayer.connect();
       const handshakeLatencyMs = Date.now() - handshakeStart;
       log(
         `Client A (${await handshakeClient.core.crypto.getClientId()}) initialized in ${handshakeLatencyMs}ms`,


### PR DESCRIPTION
## Description
Fixing a degration in canary handshake metrics after merging https://github.com/WalletConnect/walletconnect-monorepo/pull/5654 which caused handshake to be 0ms because socket wasn't actually started 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
metrics chart showing correct values

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
