### PR TITLE
feat: change sign-client ECR repo

### DIFF
--- a/.github/workflows/ci_sign_client.yml
+++ b/.github/workflows/ci_sign_client.yml
@@ -21,8 +21,9 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ECR_DEPLOYER }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ECR_PUBLISHER_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_ECR_PUBLISHER_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
 
       - name: Login to Amazon ECR
         id: login-ecr


### PR DESCRIPTION
We are moving canaries into a different AWS account.

@ganchoradkov can you please add the following secrets to this repo
https://team-reown.1password.com/app#/everything/Search/t4ntljt7ggo2tdyspp44reqlbmfxe3jahtuvtgkkngbfvvzx2svi?itemListId=sign-cl

`AWS_ECR_PUBLISHER_ACCESS_KEY_ID: $username`
`AWS_ECR_PUBLISHER_SECRET_ACCESS_KEY: $password`

The old one can be removed if it's not being used for anything else (doesn't seem like it)