### PR TITLE
feat: scoped session properties

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -2954,7 +2954,7 @@ export class Engine extends IEngine {
       if (property === null || property === undefined) {
         const { message } = getInternalError(
           "MISSING_OR_INVALID",
-          `${type} must be contain an existing value for each key. Received: ${property} for key ${
+          `${type} must contain an existing value for each key. Received: ${property} for key ${
             Object.keys(properties)[index]
           }`,
         );

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -2679,16 +2679,16 @@ export class Engine extends IEngine {
     if (!isUndefined(scopedProperties)) {
       this.validateSessionProps(scopedProperties, "scopedProperties");
 
-      const approvedNamespaces = Object.keys(namespaces);
-      const scopedNamespaces = new Set(Object.keys(scopedProperties));
+      const approvedNamespaces = new Set(Object.keys(namespaces));
+      const scopedNamespaces = Object.keys(scopedProperties);
 
       // the approved scoped namespaces must be a subset of the approved namespaces
-      const valid = approvedNamespaces.every((ns) => scopedNamespaces.has(ns));
+      const valid = scopedNamespaces.every((ns) => approvedNamespaces.has(ns));
       if (!valid) {
         throw new Error(
           `Scoped properties must be a subset of approved namespaces, received: ${JSON.stringify(
             scopedProperties,
-          )}, approved namespaces: ${JSON.stringify(approvedNamespaces)}`,
+          )}, approved namespaces: ${Array.from(approvedNamespaces).join(", ")}`,
         );
       }
     }

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -189,8 +189,14 @@ export class Engine extends IEngine {
       optionalNamespaces: params.optionalNamespaces || {},
     };
     await this.isValidConnect(connectParams);
-    const { pairingTopic, requiredNamespaces, optionalNamespaces, sessionProperties, relays } =
-      connectParams;
+    const {
+      pairingTopic,
+      requiredNamespaces,
+      optionalNamespaces,
+      sessionProperties,
+      scopedProperties,
+      relays,
+    } = connectParams;
     let topic = pairingTopic;
     let uri: string | undefined;
     let active = false;
@@ -232,6 +238,7 @@ export class Engine extends IEngine {
       expiryTimestamp,
       pairingTopic: topic,
       ...(sessionProperties && { sessionProperties }),
+      ...(scopedProperties && { scopedProperties }),
       id: payloadId(),
     };
     const sessionConnectTarget = engineEvent("session_connect", proposal.id);
@@ -317,7 +324,8 @@ export class Engine extends IEngine {
       throw error;
     }
 
-    const { id, relayProtocol, namespaces, sessionProperties, sessionConfig } = params;
+    const { id, relayProtocol, namespaces, sessionProperties, scopedProperties, sessionConfig } =
+      params;
 
     const proposal = this.client.proposal.get(id);
 
@@ -353,6 +361,7 @@ export class Engine extends IEngine {
       controller: { publicKey: selfPublicKey, metadata: this.client.metadata },
       expiry: calcExpiry(SESSION_EXPIRY),
       ...(sessionProperties && { sessionProperties }),
+      ...(scopedProperties && { scopedProperties }),
       ...(sessionConfig && { sessionConfig }),
     };
     const transportType = TRANSPORT_TYPES.relay;
@@ -1919,8 +1928,15 @@ export class Engine extends IEngine {
     const { id, params } = payload;
     try {
       this.isValidSessionSettleRequest(params);
-      const { relay, controller, expiry, namespaces, sessionProperties, sessionConfig } =
-        payload.params;
+      const {
+        relay,
+        controller,
+        expiry,
+        namespaces,
+        sessionProperties,
+        scopedProperties,
+        sessionConfig,
+      } = payload.params;
       const pendingSession = [...this.pendingSessions.values()].find(
         (s) => s.sessionTopic === topic,
       );
@@ -1950,6 +1966,7 @@ export class Engine extends IEngine {
           metadata: controller.metadata,
         },
         ...(sessionProperties && { sessionProperties }),
+        ...(scopedProperties && { scopedProperties }),
         ...(sessionConfig && { sessionConfig }),
         transportType: TRANSPORT_TYPES.relay,
       };
@@ -2454,11 +2471,13 @@ export class Engine extends IEngine {
       payload: formatJsonRpcRequest(
         "wc_sessionPropose",
         {
+          ...proposal,
           requiredNamespaces: proposal.requiredNamespaces,
           optionalNamespaces: proposal.optionalNamespaces,
           relays: proposal.relays,
           proposer: proposal.proposer,
           sessionProperties: proposal.sessionProperties,
+          scopedProperties: proposal.scopedProperties,
         },
         proposal.id,
       ),
@@ -2570,8 +2589,14 @@ export class Engine extends IEngine {
       );
       throw new Error(message);
     }
-    const { pairingTopic, requiredNamespaces, optionalNamespaces, sessionProperties, relays } =
-      params;
+    const {
+      pairingTopic,
+      requiredNamespaces,
+      optionalNamespaces,
+      sessionProperties,
+      scopedProperties,
+      relays,
+    } = params;
     if (!isUndefined(pairingTopic)) await this.isValidPairingTopic(pairingTopic);
 
     if (!isValidRelays(relays, true)) {
@@ -2593,6 +2618,24 @@ export class Engine extends IEngine {
     if (!isUndefined(sessionProperties)) {
       this.validateSessionProps(sessionProperties, "sessionProperties");
     }
+
+    if (!isUndefined(scopedProperties)) {
+      this.validateSessionProps(scopedProperties, "scopedProperties");
+
+      const requestedNamespaces = Object.keys(requiredNamespaces || {}).concat(
+        Object.keys(optionalNamespaces || {}),
+      );
+
+      const scopedNamespaces = Object.keys(scopedProperties);
+      const valid = scopedNamespaces.every((ns) => requestedNamespaces.includes(ns));
+      if (!valid) {
+        throw new Error(
+          `Scoped properties must be a subset of required/optional namespaces, received: ${JSON.stringify(
+            scopedProperties,
+          )}, required/optional namespaces: ${JSON.stringify(requestedNamespaces)}`,
+        );
+      }
+    }
   };
 
   private validateNamespaces = (
@@ -2608,7 +2651,7 @@ export class Engine extends IEngine {
       throw new Error(
         getInternalError("MISSING_OR_INVALID", `approve() params: ${params}`).message,
       );
-    const { id, namespaces, relayProtocol, sessionProperties } = params;
+    const { id, namespaces, relayProtocol, sessionProperties, scopedProperties } = params;
 
     this.checkRecentlyDeleted(id);
     await this.isValidProposalId(id);
@@ -2631,6 +2674,23 @@ export class Engine extends IEngine {
 
     if (!isUndefined(sessionProperties)) {
       this.validateSessionProps(sessionProperties, "sessionProperties");
+    }
+
+    if (!isUndefined(scopedProperties)) {
+      this.validateSessionProps(scopedProperties, "scopedProperties");
+
+      const approvedNamespaces = Object.keys(namespaces);
+      const scopedNamespaces = new Set(Object.keys(scopedProperties));
+
+      // the approved scoped namespaces must be a subset of the approved namespaces
+      const valid = approvedNamespaces.every((ns) => scopedNamespaces.has(ns));
+      if (!valid) {
+        throw new Error(
+          `Scoped properties must be a subset of approved namespaces, received: ${JSON.stringify(
+            scopedProperties,
+          )}, approved namespaces: ${JSON.stringify(approvedNamespaces)}`,
+        );
+      }
     }
   };
 
@@ -2890,11 +2950,13 @@ export class Engine extends IEngine {
   };
 
   private validateSessionProps = (properties: ProposalTypes.SessionProperties, type: string) => {
-    Object.values(properties).forEach((property) => {
-      if (!isValidString(property, false)) {
+    Object.values(properties).forEach((property, index) => {
+      if (property === null || property === undefined) {
         const { message } = getInternalError(
           "MISSING_OR_INVALID",
-          `${type} must be in Record<string, string> format. Received: ${JSON.stringify(property)}`,
+          `${type} must be contain an existing value for each key. Received: ${property} for key ${
+            Object.keys(properties)[index]
+          }`,
         );
         throw new Error(message);
       }

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -2949,7 +2949,7 @@ export class Engine extends IEngine {
     return context;
   };
 
-  private validateSessionProps = (properties: ProposalTypes.SessionProperties, type: string) => {
+  private validateSessionProps = (properties: SessionTypes.ScopedProperties, type: string) => {
     Object.values(properties).forEach((property, index) => {
       if (property === null || property === undefined) {
         const { message } = getInternalError(

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -94,6 +94,48 @@ describe("Sign Client Integration", () => {
       expect(clients.B.metadata.redirect?.universal).to.exist;
       await deleteClients(clients);
     });
+    it("should set scopedProperties in session", async () => {
+      const clients = await initTwoClients();
+      const requestedScopedProperties = {
+        [Object.keys(TEST_CONNECT_PARAMS.requiredNamespaces)[0]]: "test",
+      };
+      const approvedScopedProperties = {
+        eip155: "approved",
+        polkadot: "approved",
+      };
+      const { uri, approval } = await clients.A.connect({
+        ...TEST_CONNECT_PARAMS,
+        scopedProperties: requestedScopedProperties,
+      });
+      if (!uri) throw new Error("URI is undefined");
+
+      await Promise.all([
+        new Promise<void>((resolve) => {
+          clients.B.once("session_proposal", async (params) => {
+            const { scopedProperties } = params.params;
+            expect(scopedProperties).to.exist;
+            expect(scopedProperties).to.deep.equal(requestedScopedProperties);
+
+            await clients.B.approve({
+              id: params.id,
+              namespaces: TEST_NAMESPACES,
+              scopedProperties: approvedScopedProperties,
+            });
+            resolve();
+          });
+        }),
+        clients.B.pair({ uri }),
+        approval(),
+      ]);
+      const dappSession = clients.A.session.getAll()[0];
+      const walletSession = clients.B.session.getAll()[0];
+      expect(dappSession.scopedProperties).to.deep.equal(approvedScopedProperties);
+      expect(walletSession.scopedProperties).to.deep.equal(approvedScopedProperties);
+      expect(dappSession.topic).to.eq(walletSession.topic);
+
+      console.log("dappSession", dappSession.scopedProperties);
+      await deleteClients(clients);
+    });
     it("should connect with out of order URIs", async () => {
       const clients = await initTwoClients();
       // load three proposals

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -100,7 +100,6 @@ describe("Sign Client Integration", () => {
         [Object.keys(TEST_CONNECT_PARAMS.requiredNamespaces)[0]]: "test",
       };
       const approvedScopedProperties = {
-        eip155: "approved",
         polkadot: "approved",
       };
       const { uri, approval } = await clients.A.connect({
@@ -133,7 +132,6 @@ describe("Sign Client Integration", () => {
       expect(walletSession.scopedProperties).to.deep.equal(approvedScopedProperties);
       expect(dappSession.topic).to.eq(walletSession.topic);
 
-      console.log("dappSession", dappSession.scopedProperties);
       await deleteClients(clients);
     });
     it("should connect with out of order URIs", async () => {

--- a/packages/sign-client/test/sdk/validation.spec.ts
+++ b/packages/sign-client/test/sdk/validation.spec.ts
@@ -122,9 +122,38 @@ describe("Sign Client Validation", () => {
       expect(connect).toHaveProperty("uri");
       expect(connect.uri).to.be.string;
     });
+    it("should reject connect with scopedProperties when not defined in requiredNamespaces or optionalNamespaces", async () => {
+      await expect(
+        clients.A.connect({
+          scopedProperties: {
+            "eip155:1": {},
+          },
+        }),
+      ).rejects.toThrowError(
+        `Scoped properties must be a subset of required/optional namespaces, received: {"eip155:1":{}}, required/optional namespaces: []`,
+      );
+    });
   });
 
   describe("approve", () => {
+    it("should reject approve with scopedProperties when not defined in namespaces", async () => {
+      const proposalId = await clients.A.connect(TEST_CONNECT_PARAMS).then(() => {
+        return clients.A.proposal.keys[0];
+      });
+      await expect(
+        clients.A.approve({
+          id: proposalId,
+          namespaces: TEST_APPROVE_PARAMS.namespaces,
+          scopedProperties: {
+            solana: "test",
+          },
+        }),
+      ).rejects.toThrowError(
+        `Scoped properties must be a subset of approved namespaces, received: {"solana":"test"}, approved namespaces: ${Object.keys(
+          TEST_APPROVE_PARAMS.namespaces,
+        ).join(", ")}`,
+      );
+    });
     it("throws when no params are passed", async () => {
       await expect(clients.A.approve()).rejects.toThrowError(
         "Missing or invalid. proposal id should be a number: undefined",

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -61,6 +61,7 @@ export declare namespace EngineTypes {
     requiredNamespaces?: ProposalTypes.RequiredNamespaces;
     optionalNamespaces?: ProposalTypes.OptionalNamespaces;
     sessionProperties?: ProposalTypes.SessionProperties;
+    scopedProperties?: ProposalTypes.ScopedProperties;
     pairingTopic?: string;
     relays?: RelayerTypes.ProtocolOptions[];
   }
@@ -73,6 +74,7 @@ export declare namespace EngineTypes {
     id: number;
     namespaces: SessionTypes.Namespaces;
     sessionProperties?: ProposalTypes.SessionProperties;
+    scopedProperties?: ProposalTypes.ScopedProperties;
     sessionConfig?: SessionTypes.SessionConfig;
     relayProtocol?: string;
   }

--- a/packages/types/src/sign-client/jsonrpc.ts
+++ b/packages/types/src/sign-client/jsonrpc.ts
@@ -43,6 +43,7 @@ export declare namespace JsonRpcTypes {
       relay: RelayerTypes.ProtocolOptions;
       namespaces: SessionTypes.Namespaces;
       sessionProperties?: ProposalTypes.SessionProperties;
+      scopedProperties?: ProposalTypes.ScopedProperties;
       sessionConfig?: SessionTypes.SessionConfig;
       expiry: number;
       controller: {

--- a/packages/types/src/sign-client/proposal.ts
+++ b/packages/types/src/sign-client/proposal.ts
@@ -14,6 +14,7 @@ export declare namespace ProposalTypes {
   type RequiredNamespaces = Record<string, RequiredNamespace>;
   type OptionalNamespaces = Record<string, RequiredNamespace>;
   type SessionProperties = Record<string, string>;
+  type ScopedProperties = Record<string, unknown>;
 
   export interface Struct {
     id: number;
@@ -30,6 +31,7 @@ export declare namespace ProposalTypes {
     requiredNamespaces: RequiredNamespaces;
     optionalNamespaces: OptionalNamespaces;
     sessionProperties?: SessionProperties;
+    scopedProperties?: ScopedProperties;
     pairingTopic: string;
   }
 }

--- a/packages/types/src/sign-client/session.ts
+++ b/packages/types/src/sign-client/session.ts
@@ -18,6 +18,9 @@ export declare namespace SessionTypes {
 
   type Namespaces = Record<string, Namespace>;
 
+  type SessionProperties = ProposalTypes.SessionProperties;
+  type ScopedProperties = ProposalTypes.ScopedProperties;
+
   interface SessionConfig {
     disableDeepLink?: boolean;
   }
@@ -32,7 +35,8 @@ export declare namespace SessionTypes {
     namespaces: Namespaces;
     requiredNamespaces: ProposalTypes.RequiredNamespaces;
     optionalNamespaces: ProposalTypes.OptionalNamespaces;
-    sessionProperties?: ProposalTypes.SessionProperties;
+    sessionProperties?: SessionProperties;
+    scopedProperties?: ScopedProperties;
     sessionConfig?: SessionConfig;
     self: {
       publicKey: string;

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -82,6 +82,7 @@ export interface ConnectOps {
   optionalChains?: number[];
   rpcMap?: EthereumRpcMap;
   pairingTopic?: string;
+  scopedProperties?: unknown;
 }
 
 export type AuthenticateParams = {
@@ -297,6 +298,10 @@ export class EthereumProvider implements IEthereumProvider {
               }
             });
           }
+          const scopedProperties = opts?.scopedProperties
+            ? { [this.namespace]: opts.scopedProperties }
+            : undefined;
+
           await this.signer
             .connect({
               namespaces: {
@@ -310,6 +315,7 @@ export class EthereumProvider implements IEthereumProvider {
                 },
               }),
               pairingTopic: opts?.pairingTopic,
+              scopedProperties,
             })
             .then((session?: SessionTypes.Struct) => {
               resolve(session);

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -45,7 +45,8 @@ export class UniversalProvider implements IUniversalProvider {
   public client!: SignClient;
   public namespaces?: NamespaceConfig;
   public optionalNamespaces?: NamespaceConfig;
-  public sessionProperties?: Record<string, string>;
+  public sessionProperties?: SessionTypes.SessionProperties;
+  public scopedProperties?: SessionTypes.ScopedProperties;
   public events: EventEmitter = new EventEmitter();
   public rpcProviders: RpcProviderMap = {};
   public session?: SessionTypes.Struct;
@@ -112,6 +113,7 @@ export class UniversalProvider implements IUniversalProvider {
         namespaces: this.namespaces,
         optionalNamespaces: this.optionalNamespaces,
         sessionProperties: this.sessionProperties,
+        scopedProperties: this.scopedProperties,
       });
     }
     const accounts = await this.requestAccounts();
@@ -190,6 +192,7 @@ export class UniversalProvider implements IUniversalProvider {
       requiredNamespaces: this.namespaces,
       optionalNamespaces: this.optionalNamespaces,
       sessionProperties: this.sessionProperties,
+      scopedProperties: this.scopedProperties,
     });
 
     if (uri) {
@@ -450,7 +453,7 @@ export class UniversalProvider implements IUniversalProvider {
   }
 
   private setNamespaces(params: ConnectParams): void {
-    const { namespaces, optionalNamespaces, sessionProperties } = params;
+    const { namespaces, optionalNamespaces, sessionProperties, scopedProperties } = params;
 
     if (namespaces && Object.keys(namespaces).length) {
       this.namespaces = namespaces;
@@ -459,6 +462,7 @@ export class UniversalProvider implements IUniversalProvider {
       this.optionalNamespaces = optionalNamespaces;
     }
     this.sessionProperties = sessionProperties;
+    this.scopedProperties = scopedProperties;
     this.persist("namespaces", namespaces);
     this.persist("optionalNamespaces", optionalNamespaces);
   }
@@ -527,6 +531,7 @@ export class UniversalProvider implements IUniversalProvider {
     this.namespaces = undefined;
     this.optionalNamespaces = undefined;
     this.sessionProperties = undefined;
+    this.scopedProperties = undefined;
     this.persist("namespaces", undefined);
     this.persist("optionalNamespaces", undefined);
     this.persist("sessionProperties", undefined);

--- a/providers/universal-provider/src/types/misc.ts
+++ b/providers/universal-provider/src/types/misc.ts
@@ -1,5 +1,5 @@
 import SignClient from "@walletconnect/sign-client";
-import { SignClientTypes, ProposalTypes, AuthTypes } from "@walletconnect/types";
+import { SignClientTypes, ProposalTypes, AuthTypes, SessionTypes } from "@walletconnect/types";
 import { JsonRpcProvider } from "@walletconnect/jsonrpc-provider";
 import { KeyValueStorageOptions, IKeyValueStorage } from "@walletconnect/keyvaluestorage";
 import { IEvents } from "@walletconnect/events";
@@ -53,7 +53,8 @@ export interface SessionNamespace extends Namespace {
 export interface ConnectParams {
   namespaces?: NamespaceConfig;
   optionalNamespaces?: NamespaceConfig;
-  sessionProperties?: ProposalTypes.Struct["sessionProperties"];
+  sessionProperties?: SessionTypes.SessionProperties;
+  scopedProperties?: SessionTypes.ScopedProperties;
   pairingTopic?: string;
   skipPairing?: boolean;
 }


### PR DESCRIPTION
## Description
Added `scopedProperties` to sign sessions. They are like `sessionProperties` but scoped to the `namespaces` in the session 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests, canary `2.19.0-canary-sp-0`

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
