### PR TITLE
feat: make sign-client test webhook delay configurable

### DIFF
--- a/packages/sign-client/test/sdk/integration/push.spec.ts
+++ b/packages/sign-client/test/sdk/integration/push.spec.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import {
   deleteClients,
   TEST_EMIT_PARAMS,
+  TEST_WEBHOOK_DELAY_MS,
   TEST_WEBHOOK_ENDPOINT,
   throttle,
   Clients,
@@ -29,7 +30,7 @@ describe("Push", () => {
 
     // Relay processes webhooks in background
     // Extend some time to relay to process it
-    await throttle(1000);
+    await throttle(TEST_WEBHOOK_DELAY_MS);
 
     const url = `${TEST_WEBHOOK_ENDPOINT}/${await clients.B.core.crypto.getClientId()}`.replace(
       "did:key:",

--- a/packages/sign-client/test/shared/values.ts
+++ b/packages/sign-client/test/shared/values.ts
@@ -12,6 +12,9 @@ export const TEST_RELAY_URL_AP = "wss://ap-southeast-1.relay.walletconnect.com";
 
 // See https://github.com/WalletConnect/push-webhook-test-server
 export const TEST_WEBHOOK_ENDPOINT = "https://webhook-push-test.walletconnect.com/";
+export const TEST_WEBHOOK_DELAY_MS = process.env.TEST_WEBHOOK_DELAY_MS
+  ? process.env.TEST_WEBHOOK_DELAY_MS
+  : 1000;
 
 export const TEST_PROJECT_ID = process.env.TEST_PROJECT_ID
   ? process.env.TEST_PROJECT_ID


### PR DESCRIPTION
Makes webhook delay configurable in sign client integration tests.