### PR TITLE
fix: crash if terminate is undefined

### DIFF
--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -448,16 +448,16 @@ export class Relayer extends IRelayer {
 
   private resetPingTimeout = () => {
     if (!isNode()) return;
-    try {
-      clearTimeout(this.pingTimeout);
-      this.pingTimeout = setTimeout(() => {
+    clearTimeout(this.pingTimeout);
+    this.pingTimeout = setTimeout(() => {
+      try {
         this.logger.debug({}, "pingTimeout: Connection stalled, terminating...");
         //@ts-expect-error
-        this.provider?.connection?.socket?.terminate();
-      }, this.heartBeatTimeout);
-    } catch (e) {
-      this.logger.warn(e, (e as Error)?.message);
-    }
+        this.provider?.connection?.socket?.terminate?.();
+      } catch (e) {
+        this.logger.warn(e, (e as Error)?.message);
+      }
+    }, this.heartBeatTimeout);
   };
 
   private async createProvider() {

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -362,6 +362,30 @@ describe("Relayer", () => {
         expect(relayer.connected).to.be.true;
         expect(wsConnection.url.startsWith(RELAYER_DEFAULT_RELAY_URL)).to.be.true;
       });
+      it("should not throw an error if terminate() is not available", async () => {
+        const relayer = new Relayer({
+          core,
+          relayUrl: TEST_CORE_OPTIONS.relayUrl,
+          projectId: TEST_CORE_OPTIONS.projectId,
+        });
+        await relayer.init();
+        relayer.subscriber.subscriptions.set(randomTopic, {
+          topic: randomTopic,
+          id: randomTopic,
+          relay: { protocol: "irn" },
+        });
+        await relayer.transportOpen();
+        expect(relayer.connected).to.be.true;
+        //@ts-expect-error - private property
+        relayer.provider.connection.socket.terminate = undefined;
+        //@ts-expect-error - private property
+        relayer.heartBeatTimeout = 1000;
+        //@ts-expect-error - private method
+        relayer.resetPingTimeout();
+        await throttle(2000);
+        await relayer.transportClose();
+        expect(relayer.connected).to.be.false;
+      });
     });
   });
   describe("packageName and bundleId validations", () => {


### PR DESCRIPTION
## Description
Fixed a bug reported in https://github.com/WalletConnect/walletconnect-monorepo/issues/5588 where in some terminal environments the process crashes because `terminate()` is not a function. We use `ws` version that has this method but package overrites in the implementing apps could cause this version mismatch to happen 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
test that simulates `terminate()` being `undefined` resulting in no unhandled errors

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
