### PR TITLE
refactor: replaced `lodash` with `es-toolkit`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19278,6 +19278,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -30140,26 +30141,6 @@
         "ethers": "5.6.9",
         "uint8arrays": "3.1.0",
         "web3": "1.7.5"
-      }
-    },
-    "providers/ethereum-provider/node_modules/@walletconnect/universal-provider": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.19.0.tgz",
-      "integrity": "sha512-e9JvadT5F8QwdLmd7qBrmACq04MT7LQEe1m3X2Fzvs3DWo8dzY8QbacnJy4XSv5PCdxMWnua+2EavBk8nrI9QA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@walletconnect/events": "1.0.1",
-        "@walletconnect/jsonrpc-http-connection": "1.0.8",
-        "@walletconnect/jsonrpc-provider": "1.0.14",
-        "@walletconnect/jsonrpc-types": "1.0.4",
-        "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.19.0",
-        "@walletconnect/types": "2.19.0",
-        "@walletconnect/utils": "2.19.0",
-        "events": "3.3.0",
-        "lodash": "4.17.21"
       }
     },
     "providers/signer-connection": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11842,6 +11842,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.32.0.tgz",
+      "integrity": "sha512-ZfSfHP1l6ubgW/B/FRtqb9bYdMvI6jizbOSfbwwJNcOQ1QE6TFsC3jpQkZ900uUPSR3t3SU5Ds7UWKnYz+uP8Q==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/es5-ext": {
       "version": "0.10.64",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
@@ -30132,6 +30142,26 @@
         "web3": "1.7.5"
       }
     },
+    "providers/ethereum-provider/node_modules/@walletconnect/universal-provider": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.19.0.tgz",
+      "integrity": "sha512-e9JvadT5F8QwdLmd7qBrmACq04MT7LQEe1m3X2Fzvs3DWo8dzY8QbacnJy4XSv5PCdxMWnua+2EavBk8nrI9QA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/jsonrpc-http-connection": "1.0.8",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "2.1.2",
+        "@walletconnect/sign-client": "2.19.0",
+        "@walletconnect/types": "2.19.0",
+        "@walletconnect/utils": "2.19.0",
+        "events": "3.3.0",
+        "lodash": "4.17.21"
+      }
+    },
     "providers/signer-connection": {
       "name": "@walletconnect/signer-connection",
       "version": "2.19.0",
@@ -30161,8 +30191,8 @@
         "@walletconnect/sign-client": "2.19.0",
         "@walletconnect/types": "2.19.0",
         "@walletconnect/utils": "2.19.0",
-        "events": "3.3.0",
-        "lodash": "4.17.21"
+        "es-toolkit": "1.32.0",
+        "events": "3.3.0"
       },
       "devDependencies": {
         "cosmos-wallet": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7589,23 +7589,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash.isequal": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.6.tgz",
-      "integrity": "sha512-Ww4UGSe3DmtvLLJm2F16hDwEQSv7U0Rr8SujLUA2wHI2D2dm8kPu6Et+/y303LfjTIwSBKXB/YTUcAKpem/XEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
@@ -11843,9 +11826,9 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.32.0.tgz",
-      "integrity": "sha512-ZfSfHP1l6ubgW/B/FRtqb9bYdMvI6jizbOSfbwwJNcOQ1QE6TFsC3jpQkZ900uUPSR3t3SU5Ds7UWKnYz+uP8Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.33.0.tgz",
+      "integrity": "sha512-X13Q/ZSc+vsO1q600bvNK4bxgXMkHcf//RxCmYDaRY5DAcT+eoXjY5hoAPGMdRnWQjvyLEcyauG3b6hz76LNqg==",
       "license": "MIT",
       "workspaces": [
         "docs",
@@ -19294,13 +19277,6 @@
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.ismatch": {
@@ -29886,13 +29862,11 @@
         "@walletconnect/types": "2.19.0",
         "@walletconnect/utils": "2.19.0",
         "@walletconnect/window-getters": "1.0.1",
+        "es-toolkit": "1.33.0",
         "events": "3.3.0",
-        "lodash.isequal": "4.5.0",
         "uint8arrays": "3.1.0"
       },
-      "devDependencies": {
-        "@types/lodash.isequal": "4.5.6"
-      },
+      "devDependencies": {},
       "engines": {
         "node": ">=18"
       }
@@ -29978,7 +29952,6 @@
       "devDependencies": {
         "@stablelib/x25519": "1.0.3",
         "@types/elliptic": "6.4.18",
-        "@types/lodash.isequal": "4.5.6",
         "@walletconnect/jsonrpc-types": "1.0.4"
       }
     },
@@ -30172,7 +30145,7 @@
         "@walletconnect/sign-client": "2.19.0",
         "@walletconnect/types": "2.19.0",
         "@walletconnect/utils": "2.19.0",
-        "es-toolkit": "1.32.0",
+        "es-toolkit": "1.33.0",
         "events": "3.3.0"
       },
       "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,12 +46,10 @@
     "@walletconnect/utils": "2.19.0",
     "@walletconnect/window-getters": "1.0.1",
     "events": "3.3.0",
-    "lodash.isequal": "4.5.0",
-    "uint8arrays": "3.1.0"
+    "uint8arrays": "3.1.0",
+    "es-toolkit": "1.33.0"
   },
-  "devDependencies": {
-    "@types/lodash.isequal": "4.5.6"
-  },
+  "devDependencies": {},
   "engines": {
     "node": ">=18"
   }

--- a/packages/core/src/controllers/store.ts
+++ b/packages/core/src/controllers/store.ts
@@ -7,7 +7,7 @@ import {
   isUndefined,
 } from "@walletconnect/utils";
 import { CORE_STORAGE_PREFIX, STORE_STORAGE_VERSION } from "../constants";
-import isEqual from "lodash.isequal";
+import { isEqual } from "es-toolkit/compat";
 
 export class Store<Key, Data extends Record<string, any>> extends IStore<Key, Data> {
   public map = new Map<Key, Data>();

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -53,7 +53,6 @@
   "devDependencies": {
     "@stablelib/x25519": "1.0.3",
     "@types/elliptic": "6.4.18",
-    "@types/lodash.isequal": "4.5.6",
     "@walletconnect/jsonrpc-types": "1.0.4"
   }
 }

--- a/providers/universal-provider/package.json
+++ b/providers/universal-provider/package.json
@@ -51,7 +51,7 @@
     "@walletconnect/types": "2.19.0",
     "@walletconnect/utils": "2.19.0",
     "events": "3.3.0",
-    "lodash": "4.17.21"
+    "es-toolkit": "1.32.0"
   },
   "devDependencies": {
     "cosmos-wallet": "1.2.0",

--- a/providers/universal-provider/package.json
+++ b/providers/universal-provider/package.json
@@ -51,7 +51,7 @@
     "@walletconnect/types": "2.19.0",
     "@walletconnect/utils": "2.19.0",
     "events": "3.3.0",
-    "es-toolkit": "1.32.0"
+    "es-toolkit": "1.33.0"
   },
   "devDependencies": {
     "cosmos-wallet": "1.2.0",

--- a/providers/universal-provider/src/utils/misc.ts
+++ b/providers/universal-provider/src/utils/misc.ts
@@ -8,7 +8,7 @@ import {
 } from "@walletconnect/utils";
 import { RPC_URL } from "../constants";
 import { Namespace, NamespaceConfig } from "../types";
-import merge from "lodash/merge";
+import { merge } from "es-toolkit/compat";
 
 export function getRpcUrl(chainId: string, rpc: Namespace, projectId?: string): string | undefined {
   const chain = parseChainId(chainId);


### PR DESCRIPTION
## Description
Replaced `lodash` with `es-toolkit` based on https://github.com/WalletConnect/walletconnect-monorepo/pull/5629 due to the conflicts in the main PR.

bundle size reduction after the change 
-  unpacked 3.54 MB down from 3.74 MB
https://www.npmjs.com/package/@walletconnect/universal-provider/v/2.19.0-canary-es-toolkit-2?activeTab=code

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
ci tests

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
