### PR TITLE
[DO NOT MERGE] fix: prevent network modal from opening randomly on reconnect

### DIFF
--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -619,6 +619,7 @@ export class EthereumProvider implements IEthereumProvider {
           ...options,
           universalProvider: this.signer as any,
           manualWCControl: true,
+          enableNetworkSwitch: false,
         });
       } catch (e) {
         throw new Error("To use QR modal, please install @reown/appkit package");


### PR DESCRIPTION
## Description

When attempting to reconnect after disconnecting, the EP opens the appkit account modal view. This happens because the appkit state is not reset after disconnection.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Tested on Uniswap and locally

## Examples/Screenshots (Optional)

https://github.com/user-attachments/assets/afdf678d-6c6e-474c-bce3-56676438b31c

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
