### PR TITLE
fix: reconnect race condition

### DIFF
--- a/.changeset/witty-shoes-walk.md
+++ b/.changeset/witty-shoes-walk.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/core": patch
+"@walletconnect/react-native-compat": patch
+"@walletconnect/sign-client": patch
+"@walletconnect/types": patch
+"@walletconnect/utils": patch
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/signer-connection": patch
+"@walletconnect/universal-provider": patch
+---
+
+fixes a race condition in the `relayer` where `toEstablishConnection` could trigger new ws connection even though one already exists and enter into a loop

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -651,6 +651,10 @@ export class Relayer extends IRelayer {
   private async toEstablishConnection() {
     await this.confirmOnlineStateOrThrow();
     if (this.connected) return;
+    if (this.connectPromise) {
+      await this.connectPromise;
+      return;
+    }
     await this.connect();
   }
 }

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -386,6 +386,50 @@ describe("Relayer", () => {
         await relayer.transportClose();
         expect(relayer.connected).to.be.false;
       });
+      it("should not run into a race condition when reconnecting if toEstablishConnection is called while connecting is in progress", async () => {
+        const relayer = new Relayer({
+          core,
+          relayUrl: TEST_CORE_OPTIONS.relayUrl,
+          projectId: TEST_CORE_OPTIONS.projectId,
+        });
+        await relayer.init();
+        relayer.subscriber.subscriptions.set(randomTopic, {
+          topic: randomTopic,
+          id: randomTopic,
+          relay: { protocol: "irn" },
+        });
+
+        // artificially slow down the connect method
+        // and call `toEstablishConnection` multiple times while connecting is in progress
+        // to ensure `connect` is called only once
+        const originalConnect = relayer.connect.bind(relayer);
+        let connectCalled = 0;
+        vi.spyOn(relayer, "connect").mockImplementation(() => {
+          return new Promise<void>((resolve) => {
+            connectCalled++;
+            setTimeout(async () => {
+              await originalConnect();
+              resolve();
+            }, 2000);
+          });
+        });
+
+        await Promise.all([
+          relayer.transportOpen(),
+          new Promise<void>(async (resolve) => {
+            await throttle(500);
+            const a = Array.from(Array(10).keys()).map(() => {
+              relayer.toEstablishConnection();
+            });
+            await Promise.all(a);
+            resolve();
+          }),
+        ]);
+
+        await throttle(1000);
+        expect(connectCalled).to.eq(1);
+        await relayer.transportClose();
+      });
     });
   });
   describe("packageName and bundleId validations", () => {

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -386,7 +386,7 @@ describe("Relayer", () => {
         await relayer.transportClose();
         expect(relayer.connected).to.be.false;
       });
-      it("should not run into a race condition when reconnecting if toEstablishConnection is called while connecting is in progress", async () => {
+      it("should not run into a race condition when `toEstablishConnection` is called while connecting is in progress", async () => {
         const relayer = new Relayer({
           core,
           relayUrl: TEST_CORE_OPTIONS.relayUrl,


### PR DESCRIPTION
## Description
This PR resolves a bug within the `relayer` where there could be a delay between `ws.connect` event and its `readyState` being `1`(connected) thus causing `toEstablishConnection` to trigger new ws connection. This is problematic and it could cause a loop as the `subscriber` subscribes when a websocket is connected

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
implemented tests as well as manually via the repro steps in the issue

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
