### PR TITLE
fix: subscriber's cached subs

### DIFF
--- a/.changeset/silent-rooms-watch.md
+++ b/.changeset/silent-rooms-watch.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/core": patch
+"@walletconnect/react-native-compat": patch
+"@walletconnect/sign-client": patch
+"@walletconnect/types": patch
+"@walletconnect/utils": patch
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/signer-connection": patch
+"@walletconnect/universal-provider": patch
+---
+
+fixed a bug where calling `subscriber.onDisable` multiple times was overriding the `cached` subscriptions with an empty array

--- a/packages/core/src/controllers/subscriber.ts
+++ b/packages/core/src/controllers/subscriber.ts
@@ -196,7 +196,11 @@ export class Subscriber extends ISubscriber {
   }
 
   private onDisable() {
-    this.cached = this.values;
+    // only write to this.cached if there are active subscriptions
+    // as this.cached can be overridden if onDisable is called multiple times
+    if (this.values.length > 0) {
+      this.cached = this.values;
+    }
     this.subscriptions.clear();
     this.topicMap.clear();
   }

--- a/packages/core/test/subscriber.spec.ts
+++ b/packages/core/test/subscriber.spec.ts
@@ -81,6 +81,20 @@ describe("Subscriber", () => {
         ),
       ).to.be.true;
     });
+
+    it("should keep cached subscriptions when onDisable is called multiple times", async () => {
+      const topic = generateRandomBytes32();
+      await subscriber.subscribe(topic);
+      expect(subscriber.subscriptions.size).to.equal(1);
+      expect(subscriber.topics.length).to.equal(1);
+      subscriber.onDisable();
+      expect(subscriber.cached.length).to.equal(1);
+      expect(subscriber.cached[0].topic).to.equal(topic);
+      subscriber.onDisable();
+      expect(subscriber.cached.length).to.equal(1);
+      subscriber.onDisable();
+      expect(subscriber.cached.length).to.equal(1);
+    });
   });
 
   describe("storageKey", () => {


### PR DESCRIPTION
## Description
this PR fixes a bug where calling `subscriber.onDIsconnect` twice was causing `this.cached` subscription to be overriden by the now empty `this.values` - this bug can happen when the browser kills the ws after a minute or so with no internet

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests, dogfooding

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
