### PR TITLE
chore: auto update lerna.json & relayer version

### DIFF
--- a/.changeset/cyan-fans-shake.md
+++ b/.changeset/cyan-fans-shake.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/core": patch
+"@walletconnect/react-native-compat": patch
+"@walletconnect/sign-client": patch
+"@walletconnect/types": patch
+"@walletconnect/utils": patch
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/signer-connection": patch
+"@walletconnect/universal-provider": patch
+---
+
+fixed auto bumping relayer version on release

--- a/package.json
+++ b/package.json
@@ -36,14 +36,15 @@
     "test:ignoreUnhandled": "npm run test:ignoreUnhandled --workspaces --if-present",
     "check": "npm run lint; npm run build; npm run test",
     "reset": "npm run clean; npm run check",
-    "new-version": "lerna version --no-private --no-git-tag-version --exact && ./scripts/update_relayer_sdk_version.sh",
+    "new-version": "lerna version --no-private --no-git-tag-version --exact && npm run sh-update-versions",
+    "sh-update-versions": "sh ./scripts/update_lerna_json_version.sh && ./scripts/update_relayer_sdk_version.sh",
     "pre-publish": "npm run new-version; npm run reset",
     "npm-publish:rc": "lerna exec --no-private -- npm publish --access public --tag rc",
     "npm-publish:latest": "lerna exec --no-private -- npm publish --access public --tag latest",
     "npm-publish:next": "lerna exec --no-private -- npm publish --access public --tag next",
     "npm-publish:canary": "lerna exec --no-private -- npm publish --access public --tag canary",
     "changeset": "changeset",
-    "changeset:version": "changeset version; npm i",
+    "changeset:version": "changeset version --no-commit; &&  npm i && sh ./scripts/commit.sh",
     "changeset:publish": "changeset publish"
   },
   "repository": {

--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -1,0 +1,9 @@
+# this script is used to commit version updates after changeset version including lerna.json & relayer version
+echo "Staging changes..."
+git add .
+
+# Commit the changes
+echo "Committing the changes..."
+git commit -m "chore: update versions and lerna.json"
+
+echo "✅ Version updates and lerna.json changes committed."

--- a/scripts/update_lerna_json_version.sh
+++ b/scripts/update_lerna_json_version.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+core_file="./packages/core/package.json"
+lerna_file="lerna.json"
+
+# Extract version safely (no trailing comma or period)
+version=$(grep -E '"version"[[:space:]]*:[[:space:]]*"' "$core_file" | \
+         sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
+
+if [ -z "$version" ]; then
+  echo "Error: Could not extract version from $core_file"
+  exit 1
+fi
+
+
+# Use sed to update the value in the file
+if [ "$(uname)" = "Darwin" ]; then
+  # MacOS requires an empty string as the second argument to -i
+  sed -i "" -E "s/(\"version\": \")[^\"]+\"/\1$version\"/" "$lerna_file"
+else
+  sed -i -E "s/(\"version\": \")[^\"]+\"/\1$version\"/" "$lerna_file"
+fi
+
+echo "Updated $lerna_file to version $version"


### PR DESCRIPTION
## Description
Implementing automated flow to update versions in lerna.json and relayer version constant on changeset version update.
It works by
- runs changeset:version without commiting
- reads the updated version from core's package.json
- updates lerna.json
- updates relayer version constant 
- commits everything

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
n/a
## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
