### PR TITLE
fix: metadata mismatch warning

### DIFF
--- a/.changeset/tender-actors-film.md
+++ b/.changeset/tender-actors-film.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/utils": patch
+---
+
+Fixes issue where a warning would be emitted on mismatched metadata URLs

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -117,7 +117,7 @@ export function populateAppMetadata(metadata?: SignClientTypes.Metadata): SignCl
   const appMetadata = getAppMetadata();
   try {
     if (metadata?.url && appMetadata.url) {
-      if (metadata.url !== appMetadata.url) {
+      if (new URL(metadata.url).host !== new URL(appMetadata.url).host) {
         console.warn(
           `The configured WalletConnect 'metadata.url':${metadata.url} differs from the actual page url:${appMetadata.url}. This is probably unintended and can lead to issues.`,
         );

--- a/packages/utils/test/metadata.spec.ts
+++ b/packages/utils/test/metadata.spec.ts
@@ -71,7 +71,7 @@ describe("metadata", () => {
     expect(populated.icons).to.eql(mockedMetadata.icons);
   });
 
-  it("should warn if metadata.url differs from the actual page url", () => {
+  it("should replace url if metadata.url differs from the actual page url", () => {
     const metadata: SignClientTypes.Metadata = {
       name: "Mocked App Name",
       description: "Mocked App Description",
@@ -82,7 +82,7 @@ describe("metadata", () => {
     expect(populated.url).to.eql(mockedMetadata.url);
   });
 
-  it("should not warn if metadata.url is the same as the actual page url", () => {
+  it("should not replace url if metadata.url is the same as the actual page url", () => {
     const metadata: SignClientTypes.Metadata = {
       name: "Mocked App Name",
       description: "Mocked App Description",

--- a/packages/utils/test/metadata.spec.ts
+++ b/packages/utils/test/metadata.spec.ts
@@ -82,7 +82,18 @@ describe("metadata", () => {
     expect(populated.url).to.eql(mockedMetadata.url);
   });
 
-  it("should not replace url if metadata.url is the same as the actual page url", () => {
+  it("should not replace url if metadata.url hostname is the same as the actual page url", () => {
+    const metadata: SignClientTypes.Metadata = {
+      name: "Mocked App Name",
+      description: "Mocked App Description",
+      url: "https://mocked-app.com/",
+      icons: ["https://mocked-app.com/icon.png"],
+    };
+    const populated = populateAppMetadata(metadata);
+    expect(populated.url).to.eql(metadata.url);
+  });
+
+  it("should not replace url if metadata.url hostname is the same as the actual page url", () => {
     const metadata: SignClientTypes.Metadata = {
       name: "Mocked App Name",
       description: "Mocked App Description",

--- a/packages/utils/test/metadata.spec.ts
+++ b/packages/utils/test/metadata.spec.ts
@@ -82,7 +82,7 @@ describe("metadata", () => {
     expect(populated.url).to.eql(mockedMetadata.url);
   });
 
-  it("should not replace url if metadata.url hostname is the same as the actual page url", () => {
+  it("should not replace url if metadata.url hostname is the same as the actual page url with a trailing slash", () => {
     const metadata: SignClientTypes.Metadata = {
       name: "Mocked App Name",
       description: "Mocked App Description",
@@ -97,8 +97,8 @@ describe("metadata", () => {
     const metadata: SignClientTypes.Metadata = {
       name: "Mocked App Name",
       description: "Mocked App Description",
-      url: "https://mocked-app.com/",
-      icons: ["https://mocked-app.com/icon.png"],
+      url: mockedMetadata.url,
+      icons: mockedMetadata.icons,
     };
     const populated = populateAppMetadata(metadata);
     expect(populated.url).to.eql(metadata.url);

--- a/packages/utils/test/metadata.spec.ts
+++ b/packages/utils/test/metadata.spec.ts
@@ -86,10 +86,10 @@ describe("metadata", () => {
     const metadata: SignClientTypes.Metadata = {
       name: "Mocked App Name",
       description: "Mocked App Description",
-      url: "https://mocked-app.com",
+      url: "https://mocked-app.com/",
       icons: ["https://mocked-app.com/icon.png"],
     };
     const populated = populateAppMetadata(metadata);
-    expect(populated.url).to.eql(mockedMetadata.url);
+    expect(populated.url).to.eql(metadata.url);
   });
 });

--- a/packages/utils/test/metadata.spec.ts
+++ b/packages/utils/test/metadata.spec.ts
@@ -70,4 +70,26 @@ describe("metadata", () => {
     expect(populated.url).to.eql(mockedMetadata.url);
     expect(populated.icons).to.eql(mockedMetadata.icons);
   });
+
+  it("should warn if metadata.url differs from the actual page url", () => {
+    const metadata: SignClientTypes.Metadata = {
+      name: "Mocked App Name",
+      description: "Mocked App Description",
+      url: "https://something.com",
+      icons: ["https://something.com/icon.png"],
+    };
+    const populated = populateAppMetadata(metadata);
+    expect(populated.url).to.eql(mockedMetadata.url);
+  });
+
+  it("should not warn if metadata.url is the same as the actual page url", () => {
+    const metadata: SignClientTypes.Metadata = {
+      name: "Mocked App Name",
+      description: "Mocked App Description",
+      url: "https://mocked-app.com",
+      icons: ["https://mocked-app.com/icon.png"],
+    };
+    const populated = populateAppMetadata(metadata);
+    expect(populated.url).to.eql(mockedMetadata.url);
+  });
 });


### PR DESCRIPTION
## Description

- Fixes issue where a trailing `/` mismatch in metadata urls would trigger a warning message

- Closes https://linear.app/reown/issue/APKT-2813/bug-metadata-warning-is-showing-the-wrong-url

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
- Unit tests

## Fixes/Resolves (Optional)
- Metadata mismatches because of trailing backlashes

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
