### PR TITLE
fix: heartbeat transport restart

### DIFF
--- a/.changeset/puny-lands-say.md
+++ b/.changeset/puny-lands-say.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/utils": patch
+"@walletconnect/core": patch
+"@walletconnect/react-native-compat": patch
+"@walletconnect/sign-client": patch
+"@walletconnect/types": patch
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/signer-connection": patch
+"@walletconnect/universal-provider": patch
+---
+
+Implemented heartbeat connection checker to avoid cases where unreliable browser network state can cause the SDK to stay without active ws connection

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -50,6 +50,8 @@ import {
   isAppVisible,
 } from "@walletconnect/utils";
 
+import { HEARTBEAT_EVENTS } from "@walletconnect/heartbeat";
+
 import {
   RELAYER_SDK_VERSION,
   RELAYER_CONTEXT,
@@ -66,7 +68,6 @@ import {
 import { MessageTracker } from "./messages";
 import { Publisher } from "./publisher";
 import { Subscriber } from "./subscriber";
-import { HEARTBEAT_EVENTS } from "@walletconnect/heartbeat";
 
 export class Relayer extends IRelayer {
   public protocol = "wc";

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -47,6 +47,7 @@ import {
   getInternalError,
   isNode,
   calcExpiry,
+  isAppVisible,
 } from "@walletconnect/utils";
 
 import {
@@ -65,6 +66,7 @@ import {
 import { MessageTracker } from "./messages";
 import { Publisher } from "./publisher";
 import { Subscriber } from "./subscriber";
+import { HEARTBEAT_EVENTS } from "@walletconnect/heartbeat";
 
 export class Relayer extends IRelayer {
   public protocol = "wc";
@@ -616,6 +618,18 @@ export class Relayer extends IRelayer {
         await this.transportOpen().catch((error) =>
           this.logger.error(error, (error as Error)?.message),
         );
+      }
+    });
+
+    this.core.heartbeat.on(HEARTBEAT_EVENTS.pulse, async () => {
+      if (this.transportExplicitlyClosed) return;
+      if (!this.connected && isAppVisible()) {
+        try {
+          await this.confirmOnlineStateOrThrow();
+          await this.transportOpen();
+        } catch (error) {
+          this.logger.warn(error, (error as Error)?.message);
+        }
       }
     });
   }

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -268,168 +268,208 @@ describe("Relayer", () => {
         ).to.be.true;
       });
     });
-    describe("transport", () => {
-      beforeEach(async () => {
-        core = new Core(TEST_CORE_OPTIONS);
-        relayer = core.relayer;
-        await core.start();
-        relayer.subscriber.subscriptions.set(randomTopic, {
-          topic: randomTopic,
-          id: randomTopic,
-          relay: { protocol: "irn" },
-        });
+  });
+  describe("transport", () => {
+    beforeEach(async () => {
+      core = new Core(TEST_CORE_OPTIONS);
+      relayer = core.relayer;
+      await core.start();
+      relayer.subscriber.subscriptions.set(randomTopic, {
+        topic: randomTopic,
+        id: randomTopic,
+        relay: { protocol: "irn" },
       });
-      it("should restart transport after connection drop", async () => {
-        const randomSessionIdentifier = relayer.core.crypto.randomSessionIdentifier;
-        await relayer.transportOpen();
-        const timeout = setTimeout(() => {
-          throw new Error("Connection did not restart after disconnect");
-        }, 5_001);
-        await Promise.all([
-          new Promise<void>((resolve) => {
-            relayer.once(RELAYER_EVENTS.connect, () => {
-              expect(relayer.connected).to.be.true;
-              resolve();
-            });
-          }),
-          new Promise<void>((resolve) => {
-            relayer.once(RELAYER_EVENTS.disconnect, () => {
-              expect(relayer.connected).to.be.false;
-              resolve();
-            });
-          }),
-          relayer.provider.connection.close(),
-        ]);
-        clearTimeout(timeout);
-        // the identifier should be the same
-        expect(relayer.core.crypto.randomSessionIdentifier).to.eq(randomSessionIdentifier);
-      });
-      it("should connect once regardless of the number of disconnect events", async () => {
-        const disconnectsToEmit = 10;
-        let disconnectsReceived = 0;
-        let connectReceived = 0;
-        relayer.on(RELAYER_EVENTS.connect, () => {
-          connectReceived++;
-        });
-        relayer.on(RELAYER_EVENTS.disconnect, () => {
-          disconnectsReceived++;
-        });
-        await Promise.all(
-          Array.from(Array(disconnectsToEmit).keys()).map(() => relayer.onDisconnectHandler()),
-        );
-        await throttle(5_000);
-        expect(connectReceived).to.eq(1);
-        expect(disconnectsReceived).to.eq(disconnectsToEmit);
-      });
-
-      it("should not start wss connection on init without subscriber topics", async () => {
-        relayer = new Relayer({
-          core,
-          relayUrl: TEST_CORE_OPTIONS.relayUrl,
-          projectId: TEST_CORE_OPTIONS.projectId,
-        });
-        await relayer.init();
-        await throttle(1_000); // +1 sec buffer
-        expect(relayer.connected).to.be.false;
-      });
-
-      it("should start transport on subscribe attempt", async () => {
-        relayer = new Relayer({
-          core,
-          relayUrl: TEST_CORE_OPTIONS.relayUrl,
-          projectId: TEST_CORE_OPTIONS.projectId,
-        });
-        await relayer.init();
-        expect(relayer.connected).to.be.false;
-        const topic = generateRandomBytes32();
-        await relayer.subscribe(topic);
-        await throttle(1_000); // +1 sec buffer
-        expect(relayer.connected).to.be.true;
-      });
-      it(`should connect to ${RELAYER_DEFAULT_RELAY_URL} relay url`, async () => {
-        relayer = new Relayer({
-          core,
-          projectId: TEST_CORE_OPTIONS.projectId,
-        });
-        await relayer.init();
-        relayer.subscriber.subscriptions.set(randomTopic, {
-          topic: randomTopic,
-          id: randomTopic,
-          relay: { protocol: "irn" },
-        });
-        await relayer.transportOpen();
-        const wsConnection = relayer.provider.connection as unknown as WebSocket;
-        expect(relayer.connected).to.be.true;
-        expect(wsConnection.url.startsWith(RELAYER_DEFAULT_RELAY_URL)).to.be.true;
-      });
-      it("should not throw an error if terminate() is not available", async () => {
-        const relayer = new Relayer({
-          core,
-          relayUrl: TEST_CORE_OPTIONS.relayUrl,
-          projectId: TEST_CORE_OPTIONS.projectId,
-        });
-        await relayer.init();
-        relayer.subscriber.subscriptions.set(randomTopic, {
-          topic: randomTopic,
-          id: randomTopic,
-          relay: { protocol: "irn" },
-        });
-        await relayer.transportOpen();
-        expect(relayer.connected).to.be.true;
-        //@ts-expect-error - private property
-        relayer.provider.connection.socket.terminate = undefined;
-        //@ts-expect-error - private property
-        relayer.heartBeatTimeout = 1000;
-        //@ts-expect-error - private method
-        relayer.resetPingTimeout();
-        await throttle(2000);
-        await relayer.transportClose();
-        expect(relayer.connected).to.be.false;
-      });
-      it("should not run into a race condition when `toEstablishConnection` is called while connecting is in progress", async () => {
-        const relayer = new Relayer({
-          core,
-          relayUrl: TEST_CORE_OPTIONS.relayUrl,
-          projectId: TEST_CORE_OPTIONS.projectId,
-        });
-        await relayer.init();
-        relayer.subscriber.subscriptions.set(randomTopic, {
-          topic: randomTopic,
-          id: randomTopic,
-          relay: { protocol: "irn" },
-        });
-
-        // artificially slow down the connect method
-        // and call `toEstablishConnection` multiple times while connecting is in progress
-        // to ensure `connect` is called only once
-        const originalConnect = relayer.connect.bind(relayer);
-        let connectCalled = 0;
-        vi.spyOn(relayer, "connect").mockImplementation(() => {
-          return new Promise<void>((resolve) => {
-            connectCalled++;
-            setTimeout(async () => {
-              await originalConnect();
-              resolve();
-            }, 2000);
-          });
-        });
-
-        await Promise.all([
-          relayer.transportOpen(),
-          new Promise<void>(async (resolve) => {
-            await throttle(500);
-            const a = Array.from(Array(10).keys()).map(() => {
-              relayer.toEstablishConnection();
-            });
-            await Promise.all(a);
+    });
+    it("should restart transport after connection drop", async () => {
+      const randomSessionIdentifier = relayer.core.crypto.randomSessionIdentifier;
+      await relayer.transportOpen();
+      const timeout = setTimeout(() => {
+        throw new Error("Connection did not restart after disconnect");
+      }, 5_001);
+      await Promise.all([
+        new Promise<void>((resolve) => {
+          relayer.once(RELAYER_EVENTS.connect, () => {
+            expect(relayer.connected).to.be.true;
             resolve();
-          }),
-        ]);
-
-        await throttle(1000);
-        expect(connectCalled).to.eq(1);
-        await relayer.transportClose();
+          });
+        }),
+        new Promise<void>((resolve) => {
+          relayer.once(RELAYER_EVENTS.disconnect, () => {
+            expect(relayer.connected).to.be.false;
+            resolve();
+          });
+        }),
+        relayer.provider.connection.close(),
+      ]);
+      clearTimeout(timeout);
+      // the identifier should be the same
+      expect(relayer.core.crypto.randomSessionIdentifier).to.eq(randomSessionIdentifier);
+    });
+    it("should connect once regardless of the number of disconnect events", async () => {
+      const disconnectsToEmit = 10;
+      let disconnectsReceived = 0;
+      let connectReceived = 0;
+      relayer.on(RELAYER_EVENTS.connect, () => {
+        connectReceived++;
       });
+      relayer.on(RELAYER_EVENTS.disconnect, () => {
+        disconnectsReceived++;
+      });
+      await Promise.all(
+        Array.from(Array(disconnectsToEmit).keys()).map(() => relayer.onDisconnectHandler()),
+      );
+      await throttle(5_000);
+      expect(connectReceived).to.eq(1);
+      expect(disconnectsReceived).to.eq(disconnectsToEmit);
+    });
+
+    it("should not start wss connection on init without subscriber topics", async () => {
+      relayer = new Relayer({
+        core,
+        relayUrl: TEST_CORE_OPTIONS.relayUrl,
+        projectId: TEST_CORE_OPTIONS.projectId,
+      });
+      await relayer.init();
+      await throttle(1_000); // +1 sec buffer
+      expect(relayer.connected).to.be.false;
+    });
+
+    it("should start transport on subscribe attempt", async () => {
+      relayer = new Relayer({
+        core,
+        relayUrl: TEST_CORE_OPTIONS.relayUrl,
+        projectId: TEST_CORE_OPTIONS.projectId,
+      });
+      await relayer.init();
+      expect(relayer.connected).to.be.false;
+      const topic = generateRandomBytes32();
+      await relayer.subscribe(topic);
+      await throttle(1_000); // +1 sec buffer
+      expect(relayer.connected).to.be.true;
+    });
+    it(`should connect to ${RELAYER_DEFAULT_RELAY_URL} relay url`, async () => {
+      relayer = new Relayer({
+        core,
+        projectId: TEST_CORE_OPTIONS.projectId,
+      });
+      await relayer.init();
+      relayer.subscriber.subscriptions.set(randomTopic, {
+        topic: randomTopic,
+        id: randomTopic,
+        relay: { protocol: "irn" },
+      });
+      await relayer.transportOpen();
+      const wsConnection = relayer.provider.connection as unknown as WebSocket;
+      expect(relayer.connected).to.be.true;
+      expect(wsConnection.url.startsWith(RELAYER_DEFAULT_RELAY_URL)).to.be.true;
+    });
+    it("should not throw an error if terminate() is not available", async () => {
+      const relayer = new Relayer({
+        core,
+        relayUrl: TEST_CORE_OPTIONS.relayUrl,
+        projectId: TEST_CORE_OPTIONS.projectId,
+      });
+      await relayer.init();
+      relayer.subscriber.subscriptions.set(randomTopic, {
+        topic: randomTopic,
+        id: randomTopic,
+        relay: { protocol: "irn" },
+      });
+      await relayer.transportOpen();
+      expect(relayer.connected).to.be.true;
+      //@ts-expect-error - private property
+      relayer.provider.connection.socket.terminate = undefined;
+      //@ts-expect-error - private property
+      relayer.heartBeatTimeout = 1000;
+      //@ts-expect-error - private method
+      relayer.resetPingTimeout();
+      await throttle(2000);
+      await relayer.transportClose();
+      expect(relayer.connected).to.be.false;
+    });
+    it("should not run into a race condition when `toEstablishConnection` is called while connecting is in progress", async () => {
+      const relayer = new Relayer({
+        core,
+        relayUrl: TEST_CORE_OPTIONS.relayUrl,
+        projectId: TEST_CORE_OPTIONS.projectId,
+      });
+      await relayer.init();
+      relayer.subscriber.subscriptions.set(randomTopic, {
+        topic: randomTopic,
+        id: randomTopic,
+        relay: { protocol: "irn" },
+      });
+
+      // artificially slow down the connect method
+      // and call `toEstablishConnection` multiple times while connecting is in progress
+      // to ensure `connect` is called only once
+      const originalConnect = relayer.connect.bind(relayer);
+      let connectCalled = 0;
+      vi.spyOn(relayer, "connect").mockImplementation(() => {
+        return new Promise<void>((resolve) => {
+          connectCalled++;
+          setTimeout(async () => {
+            await originalConnect();
+            resolve();
+          }, 2000);
+        });
+      });
+
+      await Promise.all([
+        relayer.transportOpen(),
+        new Promise<void>(async (resolve) => {
+          await throttle(500);
+          const a = Array.from(Array(10).keys()).map(() => {
+            relayer.toEstablishConnection();
+          });
+          await Promise.all(a);
+          resolve();
+        }),
+      ]);
+
+      await throttle(1000);
+      expect(connectCalled).to.eq(1);
+      await relayer.transportClose();
+    });
+
+    it("should restart transport via heartbeat pulse when app is back in foreground & network is online", async () => {
+      expect(relayer.connected).to.be.false;
+
+      relayer.subscriber.subscriptions.set(randomTopic, {
+        topic: randomTopic,
+        id: randomTopic,
+        relay: { protocol: "irn" },
+      });
+
+      expect(relayer.connected).to.be.false;
+      // heartbeat pulses every ~5s so we need extra to connect + subscribe
+      await throttle(6500);
+      expect(relayer.connected).to.be.true;
+      await relayer.transportClose();
+    });
+    it("should not restart transport via heartbeat pulse when there are no topics", async () => {
+      expect(relayer.connected).to.be.false;
+      relayer.subscriber.subscriptions.clear();
+      expect(relayer.connected).to.be.false;
+      // heartbeat pulses every ~5s so we need extra to connect + subscribe
+      await throttle(6500);
+      expect(relayer.connected).to.be.false;
+      await relayer.transportClose();
+    });
+    it("should not restart transport via heartbeat pulse when transport is explicitly closed", async () => {
+      expect(relayer.connected).to.be.false;
+
+      relayer.subscriber.subscriptions.set(randomTopic, {
+        topic: randomTopic,
+        id: randomTopic,
+        relay: { protocol: "irn" },
+      });
+
+      await relayer.transportClose();
+      expect(relayer.connected).to.be.false;
+      // heartbeat pulses every ~5s so we need extra to connect + subscribe
+      await throttle(6500);
+      expect(relayer.connected).to.be.false;
     });
   });
   describe("packageName and bundleId validations", () => {

--- a/packages/utils/src/network.ts
+++ b/packages/utils/src/network.ts
@@ -77,7 +77,6 @@ export function isAppVisible(): boolean {
     return getDocument()?.visibilityState === "visible";
   }
   // TODO: implement reliable visibility check for react-native
-  // node.js does not have a visibilityState 
+  // node.js does not have a visibilityState
   return true;
 }
-

--- a/packages/utils/src/network.ts
+++ b/packages/utils/src/network.ts
@@ -1,3 +1,4 @@
+import { getDocument } from "@walletconnect/window-getters";
 import { getEnvironment, ENV_MAP, isBrowser, isReactNative } from "./misc";
 
 export function isOnline(): Promise<boolean> {
@@ -70,3 +71,13 @@ export function subscribeToReactNativeNetworkChange(callbackHandler: (connected:
     (global as any)?.NetInfo.addEventListener((state: any) => callbackHandler(state?.isConnected));
   }
 }
+
+export function isAppVisible(): boolean {
+  if (isBrowser() && getDocument()) {
+    return getDocument()?.visibilityState === "visible";
+  }
+  // TODO: implement reliable visibility check for react-native
+  // node.js does not have a visibilityState 
+  return true;
+}
+


### PR DESCRIPTION
## Description
Implemented a fix for unreliable network status detection using navigator.onLine and online/offline event listeners on mobile.

On mobile devices, when airplane mode is enabled while the browser is in the background, the network status often fails to update to offline as expected. As a result, the relayer detects a disconnection and begins its reconnection attempts, eventually reaching the limit of 6 retries. However, because the app is still unaware that it's offline, no new reconnection attempts are triggered. When the app returns to the foreground, it remains disconnected, since the previous retry limit was reached and the incorrect network state prevented any further recovery.

Fixes #6278

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests/dogfooding
canary `2.20.2-canary-hb-1`


## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
