### PR TITLE
chore: deprecate required namespaces

### DIFF
--- a/.changeset/wide-donkeys-laugh.md
+++ b/.changeset/wide-donkeys-laugh.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/universal-provider": minor
+"@walletconnect/ethereum-provider": minor
+"@walletconnect/sign-client": minor
+"@walletconnect/types": minor
+"@walletconnect/core": minor
+"@walletconnect/react-native-compat": minor
+"@walletconnect/utils": minor
+"@walletconnect/signer-connection": minor
+---
+
+Deprecating `requiredNamespaces`. If the `requiredNamespaces` are used, the values are automatically assigned to `optionalNamespaces` instead.

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -2649,7 +2649,7 @@ export class Engine extends IEngine {
     // validate required namespaces only if they are defined
     if (!isUndefined(requiredNamespaces) && isValidObject(requiredNamespaces) !== 0) {
       const warning =
-        "requiredNamespaces are deprecated and will be automatically assigned to optionalNamespaces";
+        "requiredNamespaces are deprecated and are automatically assigned to optionalNamespaces";
       // if logger level is one of the following, the logger.warn will not be shown, so we need to use console.warn
       if (["fatal", "error", "silent"].includes(this.client.logger.level)) {
         console.warn(warning);

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -215,6 +215,14 @@ export class Engine extends IEngine {
       optionalNamespaces: params.optionalNamespaces || {},
     };
     await this.isValidConnect(connectParams);
+
+    // requiredNamespaces are deprecated, assign them to optionalNamespaces
+    connectParams.optionalNamespaces = {
+      ...connectParams.requiredNamespaces,
+      ...connectParams.optionalNamespaces,
+    };
+    connectParams.requiredNamespaces = {};
+
     const {
       pairingTopic,
       requiredNamespaces,
@@ -2640,6 +2648,14 @@ export class Engine extends IEngine {
 
     // validate required namespaces only if they are defined
     if (!isUndefined(requiredNamespaces) && isValidObject(requiredNamespaces) !== 0) {
+      const warning =
+        "requiredNamespaces are deprecated and will be automatically assigned to optionalNamespaces";
+      // if logger level is one of the following, the logger.warn will not be shown, so we need to use console.warn
+      if (["fatal", "error", "silent"].includes(this.client.logger.level)) {
+        console.warn(warning);
+      } else {
+        this.client.logger.warn(warning);
+      }
       this.validateNamespaces(requiredNamespaces, "requiredNamespaces");
     }
 

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -99,6 +99,7 @@ import {
   isTestRun,
   isValidArray,
   extractSolanaTransactionId,
+  mergeRequiredAndOptionalNamespaces,
 } from "@walletconnect/utils";
 import EventEmmiter from "events";
 import {
@@ -217,10 +218,11 @@ export class Engine extends IEngine {
     await this.isValidConnect(connectParams);
 
     // requiredNamespaces are deprecated, assign them to optionalNamespaces
-    connectParams.optionalNamespaces = {
-      ...connectParams.requiredNamespaces,
-      ...connectParams.optionalNamespaces,
-    };
+    connectParams.optionalNamespaces = mergeRequiredAndOptionalNamespaces(
+      connectParams.requiredNamespaces,
+      connectParams.optionalNamespaces,
+    );
+
     connectParams.requiredNamespaces = {};
 
     const {

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -1374,7 +1374,7 @@ describe("Sign Client Integration", () => {
                 acc.includes(TEST_AVALANCHE_CHAIN),
               ),
             ).to.exist;
-            expect(session.optionalNamespaces[TEST_AVALANCHE_CHAIN]).to.exist;
+
             await clients.B.respond({
               topic,
               response: formatJsonRpcResult(payload.id, "test response"),

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -1356,7 +1356,7 @@ describe("Sign Client Integration", () => {
       const {
         sessionA: { topic },
       } = await testConnectMethod(clients, {
-        requiredNamespaces: TEST_REQUIRED_NAMESPACES_V2,
+        optionalNamespaces: TEST_REQUIRED_NAMESPACES_V2,
         namespaces: TEST_NAMESPACES_V2,
       });
       const testRequestProps = {
@@ -1374,7 +1374,7 @@ describe("Sign Client Integration", () => {
                 acc.includes(TEST_AVALANCHE_CHAIN),
               ),
             ).to.exist;
-            expect(session.requiredNamespaces[TEST_AVALANCHE_CHAIN]).to.exist;
+            expect(session.optionalNamespaces[TEST_AVALANCHE_CHAIN]).to.exist;
             await clients.B.respond({
               topic,
               response: formatJsonRpcResult(payload.id, "test response"),

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -134,6 +134,44 @@ describe("Sign Client Integration", () => {
 
       await deleteClients(clients);
     });
+    it("should assign requiredNamespaces to optionalNamespaces", async () => {
+      const clients = await initTwoClients();
+      const requestedRequiredNamespaces = {
+        eip155: {
+          chains: ["eip155:1", "eip155:2"],
+          methods: ["eth_sendTransaction", "eth_sign"],
+          events: ["chainChanged", "accountsChanged"],
+        },
+      };
+      const { uri, approval } = await clients.A.connect({
+        requiredNamespaces: requestedRequiredNamespaces,
+      });
+      if (!uri) throw new Error("URI is undefined");
+
+      const session = await Promise.all([
+        new Promise<void>((resolve) => {
+          clients.B.once("session_proposal", async (params) => {
+            const { requiredNamespaces, optionalNamespaces } = params.params;
+
+            expect(requiredNamespaces).to.deep.equal({});
+            expect(optionalNamespaces).to.deep.equal(requestedRequiredNamespaces);
+
+            await clients.B.approve({
+              id: params.id,
+              namespaces: TEST_NAMESPACES,
+            });
+            resolve();
+          });
+        }),
+        clients.B.pair({ uri }),
+        approval(),
+      ]).then((res) => {
+        return res[2];
+      });
+      expect(session.requiredNamespaces).to.deep.equal({});
+      expect(session.optionalNamespaces).to.deep.equal(requestedRequiredNamespaces);
+      await deleteClients(clients);
+    });
     it("should connect with out of order URIs", async () => {
       const clients = await initTwoClients();
       // load three proposals

--- a/packages/sign-client/test/sdk/validation.spec.ts
+++ b/packages/sign-client/test/sdk/validation.spec.ts
@@ -378,7 +378,9 @@ describe("Sign Client Validation", () => {
       );
     });
 
-    it("throws when incompatible namespaces methods are provided", async () => {
+    it.skip("throws when incompatible namespaces methods are provided", async () => {
+      // since required namespaces are deprecated, all updates will be successful given the structure is valid
+      // so the test is no longer applicable
       await expect(
         clients.A.update({
           topic,
@@ -389,7 +391,9 @@ describe("Sign Client Validation", () => {
       );
     });
 
-    it("throws when incompatible namespaces chains are provided", async () => {
+    it.skip("throws when incompatible namespaces chains are provided", async () => {
+      // since required namespaces are deprecated, all updates will be successful given the structure is valid
+      // so the test is no longer applicable
       await expect(
         clients.A.update({
           topic,

--- a/packages/sign-client/test/shared/connect.ts
+++ b/packages/sign-client/test/shared/connect.ts
@@ -50,7 +50,6 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
     B.once("session_proposal", async (proposal) => {
       try {
         expect(proposal.params.requiredNamespaces).to.eql({});
-        expect(proposal.params.optionalNamespaces).to.eql(connectParams.optionalNamespaces);
         expect(proposal.params.sessionProperties).to.eql(TEST_SESSION_PROPERTIES);
         const { acknowledged } = await B.approve({
           id: proposal.id,

--- a/packages/sign-client/test/shared/connect.ts
+++ b/packages/sign-client/test/shared/connect.ts
@@ -33,7 +33,7 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
   const { A, B } = clients;
 
   const connectParams: EngineTypes.ConnectParams = {
-    requiredNamespaces: params?.requiredNamespaces || TEST_REQUIRED_NAMESPACES,
+    // requiredNamespaces: params?.requiredNamespaces || TEST_REQUIRED_NAMESPACES,
     optionalNamespaces: params?.optionalNamespaces || TEST_OPTIONAL_NAMESPACES,
     sessionProperties: params?.sessionProperties || TEST_SESSION_PROPERTIES,
     relays: params?.relays || undefined,
@@ -50,7 +50,7 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
   const resolveSessionProposal = new Promise<void>((resolve, reject) => {
     B.once("session_proposal", async (proposal) => {
       try {
-        expect(proposal.params.requiredNamespaces).to.eql(connectParams.requiredNamespaces);
+        // expect(proposal.params.requiredNamespaces).to.eql(connectParams.requiredNamespaces);
         expect(proposal.params.optionalNamespaces).to.eql(connectParams.optionalNamespaces);
         expect(proposal.params.sessionProperties).to.eql(TEST_SESSION_PROPERTIES);
         const { acknowledged } = await B.approve({

--- a/packages/sign-client/test/shared/connect.ts
+++ b/packages/sign-client/test/shared/connect.ts
@@ -33,7 +33,6 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
   const { A, B } = clients;
 
   const connectParams: EngineTypes.ConnectParams = {
-    // requiredNamespaces: params?.requiredNamespaces || TEST_REQUIRED_NAMESPACES,
     optionalNamespaces: params?.optionalNamespaces || TEST_OPTIONAL_NAMESPACES,
     sessionProperties: params?.sessionProperties || TEST_SESSION_PROPERTIES,
     relays: params?.relays || undefined,

--- a/packages/sign-client/test/shared/connect.ts
+++ b/packages/sign-client/test/shared/connect.ts
@@ -50,7 +50,7 @@ export async function testConnectMethod(clients: Clients, params?: TestConnectPa
   const resolveSessionProposal = new Promise<void>((resolve, reject) => {
     B.once("session_proposal", async (proposal) => {
       try {
-        // expect(proposal.params.requiredNamespaces).to.eql(connectParams.requiredNamespaces);
+        expect(proposal.params.requiredNamespaces).to.eql({});
         expect(proposal.params.optionalNamespaces).to.eql(connectParams.optionalNamespaces);
         expect(proposal.params.sessionProperties).to.eql(TEST_SESSION_PROPERTIES);
         const { acknowledged } = await B.approve({

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -58,6 +58,9 @@ export declare namespace EngineTypes {
   }
 
   interface ConnectParams {
+    /**
+     * @deprecated Use `optionalNamespaces` instead.
+     */
     requiredNamespaces?: ProposalTypes.RequiredNamespaces;
     optionalNamespaces?: ProposalTypes.OptionalNamespaces;
     sessionProperties?: ProposalTypes.SessionProperties;

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -263,3 +263,36 @@ export function buildNamespacesFromAuth(methods: string[], accounts: string[]) {
   }
   return namespaces;
 }
+
+export function mergeRequiredAndOptionalNamespaces(
+  requiredNamespaces: ProposalTypes.RequiredNamespaces,
+  optionalNamespaces: ProposalTypes.OptionalNamespaces,
+) {
+  const normalizedRequired = normalizeNamespaces(requiredNamespaces);
+  const normalizedOptional = normalizeNamespaces(optionalNamespaces);
+
+  const mergedNamespaces: ProposalTypes.OptionalNamespaces = {};
+
+  const combinedNamespaces = Object.keys(normalizedRequired).concat(
+    Object.keys(normalizedOptional),
+  );
+
+  for (const namespace of combinedNamespaces) {
+    mergedNamespaces[namespace] = {
+      chains: mergeArrays(
+        normalizedRequired[namespace]?.chains,
+        normalizedOptional[namespace]?.chains,
+      ),
+      methods: mergeArrays(
+        normalizedRequired[namespace]?.methods,
+        normalizedOptional[namespace]?.methods,
+      ),
+      events: mergeArrays(
+        normalizedRequired[namespace]?.events,
+        normalizedOptional[namespace]?.events,
+      ),
+    };
+  }
+
+  return mergedNamespaces;
+}

--- a/packages/utils/test/validators.spec.ts
+++ b/packages/utils/test/validators.spec.ts
@@ -8,7 +8,12 @@ import {
   TEST_SESSION,
 } from "./shared/values";
 
-import { buildApprovedNamespaces, isConformingNamespaces, isSessionCompatible } from "../src";
+import {
+  buildApprovedNamespaces,
+  isConformingNamespaces,
+  isSessionCompatible,
+  mergeRequiredAndOptionalNamespaces,
+} from "../src";
 
 describe("Validators", () => {
   it("isSessionCompatible", () => {
@@ -1400,4 +1405,127 @@ describe("buildApprovedNamespaces (validators)", () => {
       });
     },
   );
+});
+
+describe("merge namespaces", () => {
+  it("should merge required and optional namespaces. case 1", () => {
+    const required = {
+      "eip155:1": {
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+    const optional = {
+      "eip155:1": {
+        events: ["accountsChanged"],
+        methods: ["eth_sendTransaction"],
+      },
+    };
+    const expected = {
+      eip155: {
+        chains: ["eip155:1"],
+        events: ["chainChanged", "accountsChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+
+    const result = mergeRequiredAndOptionalNamespaces(required, optional);
+    expect(result).toEqual(expected);
+  });
+
+  it("should merge required and optional namespaces. case 2", () => {
+    const required = {
+      eip155: {
+        chains: ["eip155:1"],
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+    const optional = {
+      eip155: {
+        chains: ["eip155:1"],
+        events: ["accountsChanged"],
+        methods: ["eth_sendTransaction"],
+      },
+    };
+    const expected = {
+      eip155: {
+        chains: ["eip155:1"],
+        events: ["chainChanged", "accountsChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+
+    const result = mergeRequiredAndOptionalNamespaces(required, optional);
+    expect(result).toEqual(expected);
+  });
+
+  it("should merge required and optional namespaces. case 3", () => {
+    const required = {
+      eip155: {
+        chains: ["eip155:1"],
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+    };
+    const optional = {
+      solana: {
+        chains: ["solana:1"],
+        events: ["accountsChanged"],
+        methods: ["solana_signTransaction"],
+      },
+    };
+    const expected = {
+      eip155: {
+        chains: ["eip155:1"],
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+      solana: {
+        chains: ["solana:1"],
+        events: ["accountsChanged"],
+        methods: ["solana_signTransaction"],
+      },
+    };
+
+    const result = mergeRequiredAndOptionalNamespaces(required, optional);
+    expect(result).toEqual(expected);
+  });
+
+  it("should merge required and optional namespaces. case 4", () => {
+    const required = {
+      eip155: {
+        chains: ["eip155:1"],
+        events: ["chainChanged"],
+        methods: ["personal_sign", "eth_sendTransaction"],
+      },
+      solana: {
+        chains: ["solana:1"],
+        events: ["accountsChanged"],
+        methods: ["solana_signTransaction"],
+      },
+    };
+    const optional = {
+      eip155: {
+        chains: ["eip155:2"],
+        events: ["accountsChanged"],
+        methods: ["eth_signTypedData"],
+      },
+    };
+    const expected = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2"],
+        events: ["chainChanged", "accountsChanged"],
+        methods: ["personal_sign", "eth_sendTransaction", "eth_signTypedData"],
+      },
+      solana: {
+        chains: ["solana:1"],
+        events: ["accountsChanged"],
+        methods: ["solana_signTransaction"],
+      },
+    };
+
+    const result = mergeRequiredAndOptionalNamespaces(required, optional);
+    expect(result).toEqual(expected);
+  });
 });

--- a/packages/utils/test/validators.spec.ts
+++ b/packages/utils/test/validators.spec.ts
@@ -1495,7 +1495,7 @@ describe("merge namespaces", () => {
   it("should merge required and optional namespaces. case 4", () => {
     const required = {
       eip155: {
-        chains: ["eip155:1"],
+        chains: ["eip155:2"],
         events: ["chainChanged"],
         methods: ["personal_sign", "eth_sendTransaction"],
       },
@@ -1507,14 +1507,14 @@ describe("merge namespaces", () => {
     };
     const optional = {
       eip155: {
-        chains: ["eip155:2"],
+        chains: ["eip155:1"],
         events: ["accountsChanged"],
         methods: ["eth_signTypedData"],
       },
     };
     const expected = {
       eip155: {
-        chains: ["eip155:1", "eip155:2"],
+        chains: ["eip155:2", "eip155:1"],
         events: ["chainChanged", "accountsChanged"],
         methods: ["personal_sign", "eth_sendTransaction", "eth_signTypedData"],
       },

--- a/providers/ethereum-provider/test/index.spec.ts
+++ b/providers/ethereum-provider/test/index.spec.ts
@@ -371,8 +371,8 @@ describe("EthereumProvider", function () {
               namespaces: {
                 eip155: {
                   accounts: [`eip155:${CHAIN_ID}:${walletAddress}`],
-                  methods: proposal.params.requiredNamespaces.eip155.methods,
-                  events: proposal.params.requiredNamespaces.eip155.events,
+                  methods: proposal.params.optionalNamespaces.eip155.methods,
+                  events: proposal.params.optionalNamespaces.eip155.events,
                 },
               },
             });
@@ -420,8 +420,8 @@ describe("EthereumProvider", function () {
               namespaces: {
                 [`eip155:${CHAIN_ID}`]: {
                   accounts: [`eip155:${CHAIN_ID}:${walletAddress}`],
-                  methods: proposal.params.requiredNamespaces.eip155.methods,
-                  events: proposal.params.requiredNamespaces.eip155.events,
+                  methods: proposal.params.optionalNamespaces.eip155.methods,
+                  events: proposal.params.optionalNamespaces.eip155.events,
                 },
               },
             });
@@ -534,8 +534,8 @@ describe("EthereumProvider", function () {
               namespaces: {
                 eip155: {
                   accounts: [`eip155:${CHAIN_ID}:${walletAddress}`],
-                  methods: proposal.params.requiredNamespaces.eip155.methods,
-                  events: proposal.params.requiredNamespaces.eip155.events,
+                  methods: proposal.params.optionalNamespaces.eip155.methods,
+                  events: proposal.params.optionalNamespaces.eip155.events,
                 },
               },
             });

--- a/providers/ethereum-provider/test/shared/WalletClient.ts
+++ b/providers/ethereum-provider/test/shared/WalletClient.ts
@@ -170,8 +170,13 @@ export class WalletClient {
       async (proposal: SignClientTypes.EventArguments["session_proposal"]) => {
         if (typeof this.client === "undefined") throw new Error("Sign Client not inititialized");
         const { id, requiredNamespaces, optionalNamespaces, relays } = proposal.params;
+
+        if (Object.keys(requiredNamespaces).length) {
+          throw new Error("Required namespaces are not supported");
+        }
         const namespaces = {};
-        Object.entries(requiredNamespaces).forEach(([key, value]) => {
+
+        Object.entries(optionalNamespaces).forEach(([key, value]) => {
           namespaces[key] = {
             methods: value.methods,
             events: value.events,
@@ -179,19 +184,6 @@ export class WalletClient {
           };
         });
 
-        Object.entries(optionalNamespaces).forEach(([key, value]) => {
-          namespaces[key] = {
-            ...namespaces[key],
-            methods: [...new Set(namespaces[key].methods.concat(value.methods))],
-            accounts: [
-              ...new Set(
-                namespaces[key].accounts.concat(
-                  value.chains?.map((chain) => `${chain}:${this.accounts[0]}`),
-                ),
-              ),
-            ],
-          };
-        });
         const { acknowledged } = await this.client.approve({
           id,
           relayProtocol: relays[0].protocol,

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -480,7 +480,6 @@ export class UniversalProvider implements IUniversalProvider {
       ...optionalNamespaces,
     };
 
-    console.log("this.optionalNamespaces", this.optionalNamespaces);
     this.sessionProperties = sessionProperties;
     this.scopedProperties = scopedProperties;
   }

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -468,14 +468,19 @@ export class UniversalProvider implements IUniversalProvider {
   }
 
   private setNamespaces(params: ConnectParams): void {
-    const { namespaces, optionalNamespaces, sessionProperties, scopedProperties } = params;
+    const {
+      namespaces = {},
+      optionalNamespaces = {},
+      sessionProperties,
+      scopedProperties,
+    } = params;
 
-    if (namespaces && Object.keys(namespaces).length) {
-      this.namespaces = namespaces;
-    }
-    if (optionalNamespaces && Object.keys(optionalNamespaces).length) {
-      this.optionalNamespaces = optionalNamespaces;
-    }
+    this.optionalNamespaces = {
+      ...namespaces,
+      ...optionalNamespaces,
+    };
+
+    console.log("this.optionalNamespaces", this.optionalNamespaces);
     this.sessionProperties = sessionProperties;
     this.scopedProperties = scopedProperties;
   }

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -475,11 +475,8 @@ export class UniversalProvider implements IUniversalProvider {
       scopedProperties,
     } = params;
 
-    this.optionalNamespaces = {
-      ...namespaces,
-      ...optionalNamespaces,
-    };
-
+    // requiredNamespaces are deprecated, assign them to optionalNamespaces
+    this.optionalNamespaces = mergeRequiredOptionalNamespaces(namespaces, optionalNamespaces);
     this.sessionProperties = sessionProperties;
     this.scopedProperties = scopedProperties;
   }

--- a/providers/universal-provider/src/types/misc.ts
+++ b/providers/universal-provider/src/types/misc.ts
@@ -55,6 +55,9 @@ export interface SessionNamespace extends Namespace {
 }
 
 export interface ConnectParams {
+  /**
+   * @deprecated Use `optionalNamespaces` instead.
+   */
   namespaces?: NamespaceConfig;
   optionalNamespaces?: NamespaceConfig;
   sessionProperties?: SessionTypes.SessionProperties;

--- a/providers/universal-provider/src/utils/misc.ts
+++ b/providers/universal-provider/src/utils/misc.ts
@@ -88,8 +88,14 @@ export function normalizeNamespaces(namespaces: NamespaceConfig): NamespaceConfi
       chains: mergeArrays(chains, normalizedNamespaces[normalizedKey]?.chains),
       methods: mergeArrays(methods, normalizedNamespaces[normalizedKey]?.methods),
       events: mergeArrays(events, normalizedNamespaces[normalizedKey]?.events),
-      rpcMap: { ...rpcMap, ...normalizedNamespaces[normalizedKey]?.rpcMap },
     };
+    // avoid adding empty `rpcMap: {}` if there are no values for it
+    if (isValidObject(rpcMap) || isValidObject(normalizedNamespaces[normalizedKey]?.rpcMap || {})) {
+      normalizedNamespaces[normalizedKey].rpcMap = {
+        ...rpcMap,
+        ...normalizedNamespaces[normalizedKey]?.rpcMap,
+      };
+    }
   }
   return normalizedNamespaces;
 }

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -31,7 +31,6 @@ import {
 import { getChainId, getGlobal, getRpcUrl, setGlobal } from "../src/utils";
 import { BUNDLER_URL, RPC_URL } from "../src/constants";
 import { formatJsonRpcResult } from "@walletconnect/jsonrpc-utils";
-import { parseChainId } from "@walletconnect/utils";
 
 const getDbName = (_prefix: string) => {
   return `./test/tmp/${_prefix}.db`;
@@ -314,6 +313,48 @@ describe("UniversalProvider", function () {
         const newChain5 = await dapp.request({ method: "eth_chainId" });
         expect(newChain5).to.eql(chains[4]);
 
+        await deleteProviders({ A: dapp, B: wallet });
+      });
+      it("should automatically assign namespaces to optionalNamespaces", async () => {
+        const dapp = await UniversalProvider.init({
+          ...TEST_PROVIDER_OPTS,
+          name: "dapp",
+        });
+        const wallet = await UniversalProvider.init({
+          ...TEST_PROVIDER_OPTS,
+          name: "wallet",
+        });
+
+        const requestedRequiredNamespaces = {
+          eip155: {
+            chains: ["eip155:1", "eip155:2"],
+            methods: ["eth_sendTransaction", "eth_sign"],
+            events: ["chainChanged", "accountsChanged"],
+          },
+        };
+        let uri;
+        dapp.on("display_uri", (connectionUri: string) => {
+          uri = connectionUri;
+        });
+        dapp.connect({
+          namespaces: requestedRequiredNamespaces,
+        });
+        expect(dapp.optionalNamespaces).to.eql(requestedRequiredNamespaces);
+        while (!uri) {
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+
+        await Promise.all([
+          new Promise<void>((resolve) => {
+            wallet.client.on("session_proposal", (proposal) => {
+              const { requiredNamespaces, optionalNamespaces } = proposal.params;
+              expect(requiredNamespaces).to.eql({});
+              expect(optionalNamespaces).to.eql(requestedRequiredNamespaces);
+              resolve();
+            });
+          }),
+          wallet.client.pair({ uri }),
+        ]);
         await deleteProviders({ A: dapp, B: wallet });
       });
     });

--- a/providers/universal-provider/test/shared/WalletClient.ts
+++ b/providers/universal-provider/test/shared/WalletClient.ts
@@ -185,8 +185,13 @@ export class WalletClient {
       async (proposal: SignClientTypes.EventArguments["session_proposal"]) => {
         if (typeof this.client === "undefined") throw new Error("Sign Client not inititialized");
         const { id, requiredNamespaces, optionalNamespaces, relays } = proposal.params;
+
+        if (Object.keys(requiredNamespaces).length !== 0) {
+          throw new Error("Unexpected required namespaces");
+        }
+
         const namespaces = {};
-        Object.entries(requiredNamespaces).forEach(([key, value]) => {
+        Object.entries(optionalNamespaces).forEach(([key, value]) => {
           namespaces[key] = {
             chains: value.chains,
             methods: value.methods,

--- a/providers/universal-provider/test/shared/connect.ts
+++ b/providers/universal-provider/test/shared/connect.ts
@@ -50,7 +50,7 @@ export async function testConnectMethod(
   const resolveSessionProposal = new Promise<void>((resolve, reject) => {
     walletClient.once("session_proposal", async (proposal) => {
       try {
-        expect(proposal.params.requiredNamespaces).to.eql(connectParams.requiredNamespaces);
+        expect(proposal.params.requiredNamespaces).to.eql({});
         const { acknowledged } = await walletClient.approve({
           id: proposal.id,
           ...approveParams,


### PR DESCRIPTION
## Description
Deprecated `required namespaces` in `sign-client` & `universal-provider`. 
If the params are used, they will be automatically assigned to `optionalNamespaces`
context: https://www.notion.so/walletconnect/1Pager-RequiredNamespaces-Deprecation-1ca3a661771e803788c6cd2466b85acc &  https://reown-inc.slack.com/archives/C04DB2EAHE3/p1748322153694569
## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
