### PR TITLE
fix: the wallet_getCapabilities to use address + chainIds as cache key

### DIFF
--- a/.changeset/twenty-poems-accept.md
+++ b/.changeset/twenty-poems-accept.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/universal-provider": patch
+"@walletconnect/core": patch
+"@walletconnect/react-native-compat": patch
+"@walletconnect/sign-client": patch
+"@walletconnect/types": patch
+"@walletconnect/utils": patch
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/signer-connection": patch
+---
+
+the wallet_getCapabilities cache in universal-provider now takes the chainIds as well as the address to decide if the request should be sent to the wallet

--- a/providers/universal-provider/src/providers/eip155.ts
+++ b/providers/universal-provider/src/providers/eip155.ts
@@ -177,12 +177,18 @@ class Eip155Provider implements IProvider {
   private async getCapabilities(args: RequestParams) {
     // if capabilities are stored in the session, return them, else send the request to the wallet
     const address = args.request?.params?.[0];
+    const chainIds: string[] = args.request?.params?.[1] || [];
+
+    // cache key is address + chainIds to allow requests to be made to different chains
+    const capabilitiesKey = `${address}${chainIds.join(",")}`;
     if (!address) throw new Error("Missing address parameter in `wallet_getCapabilities` request");
     const session = this.client.session.get(args.topic);
     const sessionCapabilities = session?.sessionProperties?.capabilities || {};
-    if (sessionCapabilities?.[address]) {
-      return sessionCapabilities?.[address];
+
+    if (sessionCapabilities?.[capabilitiesKey]) {
+      return sessionCapabilities?.[capabilitiesKey];
     }
+
     // intentionally omit catching errors/rejection during `request` to allow the error to bubble up
     const capabilities = await this.client.request(args as EngineTypes.RequestParams);
     try {
@@ -192,7 +198,7 @@ class Eip155Provider implements IProvider {
           ...(session.sessionProperties || {}),
           capabilities: {
             ...(sessionCapabilities || {}),
-            [address]: capabilities,
+            [capabilitiesKey]: capabilities,
           } as any, // by spec sessionProperties should be <string, string> but here are used as objects?
         },
       });

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -1455,7 +1455,7 @@ describe("UniversalProvider", function () {
           }),
         ]);
       });
-      it("should cache `wallet_getCapabilities` request", async () => {
+      it("should cache `wallet_getCapabilities` request with different chainIds", async () => {
         const dapp = await UniversalProvider.init({
           ...TEST_PROVIDER_OPTS,
           name: "dapp",
@@ -1498,7 +1498,7 @@ describe("UniversalProvider", function () {
         };
         await Promise.all([
           new Promise<void>((resolve) => {
-            wallet.client.on("session_request", async (event) => {
+            wallet.client.once("session_request", async (event) => {
               await wallet.client.respond({
                 topic: event.topic,
                 response: formatJsonRpcResult(event.id, sessionPropertiesResponse),
@@ -1525,6 +1525,44 @@ describe("UniversalProvider", function () {
           params: [walletAddress],
         });
         expect(cachedResult).to.eql(sessionPropertiesResponse);
+
+        const secondCapabilitiesResult = {
+          "0x1": {
+            atomicBatch: {
+              supported: true,
+            },
+          },
+        };
+
+        await Promise.all([
+          new Promise<void>((resolve) => {
+            wallet.client.once("session_request", async (event) => {
+              await wallet.client.respond({
+                topic: event.topic,
+                response: formatJsonRpcResult(event.id, secondCapabilitiesResult),
+              });
+              resolve();
+            });
+          }),
+          new Promise<void>(async (resolve) => {
+            const result = await dapp.request({
+              method: "wallet_getCapabilities",
+              // this req has additional chainId param so it should not use cached result but make a new request to the wallet
+              params: [walletAddress, ["0x1"]],
+            });
+            expect(result).to.eql(secondCapabilitiesResult);
+            resolve();
+          }),
+        ]);
+
+        const updatedSession2 = dapp.client.session.get(sessionA.topic);
+        expect(updatedSession2.sessionProperties).to.exist;
+        expect(updatedSession2.sessionProperties?.capabilities).to.exist;
+        expect(Object.keys(updatedSession2.sessionProperties?.capabilities || {}).length).to.eql(2);
+        expect(updatedSession2.sessionProperties?.capabilities[`${walletAddress}0x1`]).to.eql(
+          secondCapabilitiesResult,
+        );
+
         await deleteProviders({ A: dapp, B: wallet });
       });
     });


### PR DESCRIPTION
## Description
The `wallet_getCapabilities` cache in `universal-provider` now takes the chainIds as well as the address to decide if the request should be sent to the wallet. This allows requests for the same address but different chains to reach the wallet

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
