### PR TITLE
chore: `ethereum-provider` changeset

### DIFF
--- a/.changeset/slick-facts-strive.md
+++ b/.changeset/slick-facts-strive.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/core": patch
+"@walletconnect/react-native-compat": patch
+"@walletconnect/sign-client": patch
+"@walletconnect/types": patch
+"@walletconnect/utils": patch
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/signer-connection": patch
+"@walletconnect/universal-provider": patch
+---
+
+updated `@reown/appkit` version to `1.7.8` in `@walletconnect/ethereum-provider`


### PR DESCRIPTION
## Description
Added changeset for https://github.com/WalletConnect/walletconnect-monorepo/pull/6298 to trigger release PR

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
n/a

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
