### PR TITLE
fix: missing verify context

### DIFF
--- a/.changeset/eleven-ants-enjoy.md
+++ b/.changeset/eleven-ants-enjoy.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/sign-client": patch
+"@walletconnect/types": patch
+"@walletconnect/core": patch
+"@walletconnect/react-native-compat": patch
+"@walletconnect/utils": patch
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/signer-connection": patch
+"@walletconnect/universal-provider": patch
+---
+
+Fixed a bug where reuseing pairing URI second time was not providing correct verify context in session_proposal

--- a/.changeset/eleven-ants-enjoy.md
+++ b/.changeset/eleven-ants-enjoy.md
@@ -9,4 +9,4 @@
 "@walletconnect/universal-provider": patch
 ---
 
-Fixed a bug where reuseing pairing URI second time was not providing correct verify context in session_proposal
+Fixed a bug where reusing pairing URI second time was not providing correct verify context in session_proposal

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -1886,7 +1886,14 @@ export class Engine extends IEngine {
       this.isValidConnect({ ...payload.params });
       const expiryTimestamp =
         params.expiryTimestamp || calcExpiry(ENGINE_RPC_OPTS.wc_sessionPropose.req.ttl);
-      const proposal = { id, pairingTopic: topic, expiryTimestamp, ...params };
+      const proposal = {
+        id,
+        pairingTopic: topic,
+        expiryTimestamp,
+        attestation,
+        encryptedId,
+        ...params,
+      };
       await this.setProposal(id, proposal);
 
       const verifyContext = await this.getVerifyContext({
@@ -2526,6 +2533,8 @@ export class Engine extends IEngine {
         },
         proposal.id,
       ),
+      attestation: proposal.attestation,
+      encryptedId: proposal.encryptedId,
     });
   };
 

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -177,6 +177,62 @@ describe("Sign Client Integration", () => {
       expect(session.optionalNamespaces).to.deep.equal(requestedRequiredNamespaces);
       await deleteClients(clients);
     });
+
+    it("should save attestation and encryptedId in pending proposal", async () => {
+      const clients = await initTwoClients();
+      const requestedRequiredNamespaces = {
+        eip155: {
+          chains: ["eip155:1", "eip155:2"],
+          methods: ["eth_sendTransaction", "eth_sign"],
+          events: ["chainChanged", "accountsChanged"],
+        },
+      };
+      const { uri } = await clients.A.connect({
+        requiredNamespaces: requestedRequiredNamespaces,
+      });
+      if (!uri) throw new Error("URI is undefined");
+
+      const attestation = "attestation";
+      const encryptedId = "encryptedId";
+
+      await Promise.all([
+        new Promise<void>((resolve) => {
+          clients.B.once("session_proposal", (params) => {
+            const { id } = params.params;
+
+            const proposal = clients.A.proposal.get(id);
+            expect(proposal).to.exist;
+            expect(proposal.attestation).to.be.undefined;
+            expect(proposal.encryptedId).to.be.undefined;
+            clients.A.proposal.set(id, {
+              ...proposal,
+              attestation,
+              encryptedId,
+            });
+
+            resolve();
+          });
+        }),
+        clients.B.pair({ uri }),
+      ]);
+
+      await Promise.all([
+        new Promise<void>((resolve) => {
+          clients.B.once("session_proposal", (params) => {
+            const { id } = params.params;
+            const proposal = clients.A.proposal.get(id);
+            expect(proposal).to.exist;
+            console.log("proposal", proposal);
+            expect(proposal.attestation).to.equal(attestation);
+            expect(proposal.encryptedId).to.equal(encryptedId);
+            resolve();
+          });
+        }),
+        clients.B.pair({ uri }),
+      ]);
+
+      await deleteClients(clients);
+    });
     it("should connect with out of order URIs", async () => {
       const clients = await initTwoClients();
       // load three proposals

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -222,7 +222,6 @@ describe("Sign Client Integration", () => {
             const { id } = params.params;
             const proposal = clients.A.proposal.get(id);
             expect(proposal).to.exist;
-            console.log("proposal", proposal);
             expect(proposal.attestation).to.equal(attestation);
             expect(proposal.encryptedId).to.equal(encryptedId);
             resolve();

--- a/packages/types/src/sign-client/proposal.ts
+++ b/packages/types/src/sign-client/proposal.ts
@@ -33,6 +33,9 @@ export declare namespace ProposalTypes {
     sessionProperties?: SessionProperties;
     scopedProperties?: ScopedProperties;
     pairingTopic: string;
+    // these two fields are for verifyContext
+    attestation?: string;
+    encryptedId?: string;
   }
 }
 


### PR DESCRIPTION
## Description
Fixed a bug where reusing pairing URI a second time was not providing the correct `verify context`. This was happening because the attestation wasn't stored with the proposal

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests, dogfooding

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
