### PR TITLE
fix: 1271 multi sig

### DIFF
--- a/.changeset/small-clouds-behave.md
+++ b/.changeset/small-clouds-behave.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/utils": patch
+"@walletconnect/core": patch
+"@walletconnect/react-native-compat": patch
+"@walletconnect/sign-client": patch
+"@walletconnect/types": patch
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/signer-connection": patch
+"@walletconnect/universal-provider": patch
+---
+
+Fixed a bug in the 1271 signature validator that was causing multi sig to fail due to hardcoded signature length

--- a/packages/utils/src/signatures.ts
+++ b/packages/utils/src/signatures.ts
@@ -75,10 +75,13 @@ export async function isValidEip1271Signature(
   try {
     const eip1271MagicValue = "0x1626ba7e";
     const dynamicTypeOffset = "0000000000000000000000000000000000000000000000000000000000000040";
-    const dynamicTypeLength = "0000000000000000000000000000000000000000000000000000000000000041";
     const nonPrefixedSignature = signature.substring(2);
-    const nonPrefixedHashedMessage = hashEthereumMessage(reconstructedMessage).substring(2);
-
+    const dynamicTypeLength = (nonPrefixedSignature.length / 2).toString(16).padStart(64, "0");
+    const nonPrefixedHashedMessage = (
+      reconstructedMessage.startsWith("0x")
+        ? reconstructedMessage
+        : hashEthereumMessage(reconstructedMessage)
+    ).substring(2);
     const data =
       eip1271MagicValue +
       nonPrefixedHashedMessage +
@@ -88,6 +91,9 @@ export async function isValidEip1271Signature(
     const response = await fetch(
       `${baseRpcUrl || DEFAULT_RPC_URL}/?chainId=${chainId}&projectId=${projectId}`,
       {
+        headers: {
+          "Content-Type": "application/json",
+        },
         method: "POST",
         body: JSON.stringify({
           id: generateJsonRpcId(),

--- a/packages/utils/test/signatures.spec.ts
+++ b/packages/utils/test/signatures.spec.ts
@@ -8,6 +8,7 @@ import {
   getNearTransactionIdFromSignedTransaction,
   getSignDirectHash,
   getSuiDigest,
+  isValidEip1271Signature,
   isValidEip191Signature,
   verifySignature,
 } from "../src";
@@ -98,6 +99,21 @@ Expiration Time: 2022-10-11T23:03:35.700Z`;
       ).rejects.toThrow(
         `isValidEip1271Signature failed: chainId must be in CAIP-2 format, received: ${invalidChainIdThree}`,
       );
+    });
+    it("should verify 1271 multi-sig", async () => {
+      const signature =
+        "0x6037120d3995a626caa8dac775220ef5c91ece120a8ffa599bf28dbd1c40f1e1398cb941dd9fc4e880b988f279c603cedf7fe0609aa2b9cad829861d9798803b1be2a4308f50367f32a84baa7965102c87ab22db69a70ba3d3717f951e07007fea5901c524425171f8ff9143b64fe3223155a26ee0aab54b03058ab99187bc5ad71c";
+      const message = "0xb48c43838346726a55fe0023cd2fc14b26144b6a9d36284a436b62e934bf382d";
+      const address = "0x9a1148b5D6a2D34CA46111379d0FD1352a0ade4a";
+      const chainId = "eip155:11155111";
+      const isValid = await isValidEip1271Signature(
+        address,
+        message,
+        signature,
+        chainId,
+        projectId,
+      );
+      expect(isValid).toBe(true);
     });
   });
   describe("EIP-191 signatures", () => {


### PR DESCRIPTION
## Description

Fixed a bug in the 1271 signature validator that was causing multi sig to fail due to hardcoded signature length

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests
## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
