### PR TITLE
refactor: relayer init

### DIFF
--- a/.changeset/beige-rice-stand.md
+++ b/.changeset/beige-rice-stand.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/universal-provider": patch
+"@walletconnect/sign-client": patch
+"@walletconnect/core": patch
+"@walletconnect/react-native-compat": patch
+"@walletconnect/types": patch
+"@walletconnect/utils": patch
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/signer-connection": patch
+---
+
+Relayer init no longer awaits transportOpen

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -131,13 +131,8 @@ export class Relayer extends IRelayer {
     this.registerEventListeners();
     await Promise.all([this.messages.init(), this.subscriber.init()]);
     this.initialized = true;
-    if (this.subscriber.hasAnyTopics) {
-      try {
-        await this.transportOpen();
-      } catch (e) {
-        this.logger.warn(e, (e as Error)?.message);
-      }
-    }
+    // don't block init with transportOpen
+    this.transportOpen().catch((e) => this.logger.warn(e, (e as Error)?.message));
   }
 
   get context() {
@@ -377,7 +372,7 @@ export class Relayer extends IRelayer {
 
         await new Promise<void>(async (resolve, reject) => {
           const onDisconnect = () => {
-            reject(new Error(`Connection interrupted while trying to subscribe`));
+            reject(new Error(`Connection interrupted while trying to connect`));
           };
           this.provider.once(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
 
@@ -395,15 +390,15 @@ export class Relayer extends IRelayer {
               this.provider.off(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
               clearTimeout(this.reconnectTimeout);
             });
-          await new Promise(async (resolve, reject) => {
+          await new Promise(async (_resolve, _reject) => {
             const onDisconnect = () => {
               reject(new Error(`Connection interrupted while trying to subscribe`));
             };
             this.provider.once(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
             await this.subscriber
               .start()
-              .then(resolve)
-              .catch(reject)
+              .then(_resolve)
+              .catch(_reject)
               .finally(() => {
                 this.provider.off(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
               });

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -46,6 +46,26 @@ describe("Relayer", () => {
       await disconnectSocket(relayer);
     });
 
+    it("should not block init with transportOpen", async () => {
+      const core = new Core({ ...TEST_CORE_OPTIONS, projectId: "non-existent" });
+      core.relayer.subscriber.topicMap.set(randomTopic, randomTopic);
+      let initFinished = false;
+
+      await Promise.all([
+        new Promise<void>((resolve) => {
+          core.relayer.on(RELAYER_EVENTS.error, () => {
+            if (initFinished === false) {
+              throw new Error("Error received before init finished");
+            }
+            resolve();
+          });
+        }),
+        core.start().then(() => {
+          initFinished = true;
+        }),
+      ]);
+    });
+
     it("should not throw unhandled on network disconnect when there is no provider instance", async () => {
       relayer.messages.init = initSpy;
       relayer.subscriber.topicMap.clear();

--- a/packages/sign-client/test/sdk/persistence.spec.ts
+++ b/packages/sign-client/test/sdk/persistence.spec.ts
@@ -78,6 +78,15 @@ describe("Sign Client Persistence", () => {
             },
           );
 
+          await new Promise<void>((resolve) => {
+            clients.A.core.relayer.on(RELAYER_EVENTS.connect, () => {
+              resolve();
+            });
+            clients.B.core.relayer.on(RELAYER_EVENTS.connect, () => {
+              resolve();
+            });
+          });
+
           expect(clients.A.core.relayer.connected).toBe(true);
           expect(clients.B.core.relayer.connected).toBe(true);
 
@@ -395,7 +404,8 @@ describe("Sign Client Persistence", () => {
      * before the implementing client (sign-client) is ready to process it
      * the message should be queued and processed after the client is ready
      */
-    it("should process pending messages after restart", async () => {
+    // NOTE: this test is no longer applicable as we no longer await the relayer to connect during init
+    it.skip("should process pending messages after restart", async () => {
       const db_a = generateClientDbName("client_a");
       const clients = await initTwoClients(
         {

--- a/packages/sign-client/test/sdk/persistence.spec.ts
+++ b/packages/sign-client/test/sdk/persistence.spec.ts
@@ -78,14 +78,18 @@ describe("Sign Client Persistence", () => {
             },
           );
 
-          await new Promise<void>((resolve) => {
-            clients.A.core.relayer.on(RELAYER_EVENTS.connect, () => {
-              resolve();
-            });
-            clients.B.core.relayer.on(RELAYER_EVENTS.connect, () => {
-              resolve();
-            });
-          });
+          await Promise.all([
+            new Promise<void>((resolve) => {
+              clients.A.core.relayer.on(RELAYER_EVENTS.connect, () => {
+                resolve();
+              });
+            }),
+            new Promise<void>((resolve) => {
+              clients.B.core.relayer.on(RELAYER_EVENTS.connect, () => {
+                resolve();
+              });
+            }),
+          ]);
 
           expect(clients.A.core.relayer.connected).toBe(true);
           expect(clients.B.core.relayer.connected).toBe(true);

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -31,6 +31,7 @@ import {
 import { getChainId, getGlobal, getRpcUrl, setGlobal } from "../src/utils";
 import { BUNDLER_URL, RPC_URL } from "../src/constants";
 import { formatJsonRpcResult } from "@walletconnect/jsonrpc-utils";
+import { RELAYER_EVENTS } from "../../../packages/core/src/constants";
 
 const getDbName = (_prefix: string) => {
   return `./test/tmp/${_prefix}.db`;
@@ -1756,6 +1757,14 @@ type ValidateProviderParams = {
 };
 const validateProvider = async (params: ValidateProviderParams) => {
   const { provider, defaultNamespace = "eip155", addresses, chains, expectedChainId } = params;
+  if (!provider.client.core.relayer.connected) {
+    await new Promise<void>((resolve) => {
+      provider.client.core.relayer.once(RELAYER_EVENTS.connect, () => {
+        resolve();
+      });
+    });
+  }
+
   expect(provider.client.core.relayer.connected).to.be.true;
   const accounts = (await provider.request({ method: "eth_accounts" })) as string[];
   expect(accounts).to.be.an("array");


### PR DESCRIPTION
## Description
Relayer init no longer awaits `transportOpen`.  This change will speed up the SDK initialization as well as not block the client from intializing when the projectId and/or JWT is invalid which prevent ws successfully connecting  
https://linear.app/reown/issue/APKT-3063/universalproviderinit-takes-forever-to-load
## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests
## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
