### PR TITLE
fix: duplicate `session_request` after client restart

### DIFF
--- a/.changeset/eighty-ways-wonder.md
+++ b/.changeset/eighty-ways-wonder.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/sign-client": patch
+"@walletconnect/types": patch
+"@walletconnect/utils": patch
+"@walletconnect/core": patch
+"@walletconnect/react-native-compat": patch
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/signer-connection": patch
+"@walletconnect/universal-provider": patch
+---
+
+Fixed a bug where duplicate session_request was emitted after client restart affecting sign-client instances with disabled session request queue.

--- a/packages/sign-client/src/client.ts
+++ b/packages/sign-client/src/client.ts
@@ -6,7 +6,6 @@ import {
   pino,
 } from "@walletconnect/logger";
 import { SignClientTypes, ISignClient, ISignClientEvents, EngineTypes } from "@walletconnect/types";
-import { ONE_SECOND, toMiliseconds } from "@walletconnect/time";
 import { populateAppMetadata } from "@walletconnect/utils";
 import { EventEmitter } from "events";
 import { SIGN_CLIENT_DEFAULT, SIGN_CLIENT_PROTOCOL, SIGN_CLIENT_VERSION } from "./constants";
@@ -253,9 +252,6 @@ export class SignClient extends ISignClient {
       await this.auth.init();
       await this.engine.init();
       this.logger.info(`SignClient Initialization Success`);
-      setTimeout(() => {
-        this.engine.processRelayMessageCache();
-      }, toMiliseconds(ONE_SECOND));
     } catch (error: any) {
       this.logger.info(`SignClient Initialization Failure`);
       this.logger.error(error.message);

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -2476,7 +2476,6 @@ export class Engine extends IEngine {
 
   private emitSessionRequest = (request: PendingRequestTypes.Struct) => {
     if (this.emittedSessionRequests.has(request.id)) {
-      console.log("skipping session_request", request.id);
       return;
     }
     this.emittedSessionRequests.add(request.id);

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -105,6 +105,7 @@ import {
   getAlgorandTransactionId,
   buildSignedExtrinsicHash,
   getSignDirectHash,
+  LimitedSet,
 } from "@walletconnect/utils";
 import EventEmmiter from "events";
 import {
@@ -143,6 +144,10 @@ export class Engine extends IEngine {
     state: ENGINE_QUEUE_STATES.idle,
     queue: [],
   };
+
+  // a set to track session requests that have been emitted via `session_request` event
+  // this is to make sure we don't emit the same request multiple times
+  private emittedSessionRequests = new LimitedSet(500);
 
   private requestQueueDelay = ONE_SECOND;
   private expectedPairingMethodMap: Map<string, string[]> = new Map();
@@ -1336,6 +1341,10 @@ export class Engine extends IEngine {
     return formatMessage(request, iss);
   };
 
+  /**
+   * no longer used as the client initializes instantly without waiting to connect+subscribe
+   * @deprecated
+   */
   public processRelayMessageCache: IEngine["processRelayMessageCache"] = () => {
     // process the relay messages cache in the next tick to allow event listeners to be registered by the implementing app
     setTimeout(async () => {
@@ -2466,6 +2475,11 @@ export class Engine extends IEngine {
   };
 
   private emitSessionRequest = (request: PendingRequestTypes.Struct) => {
+    if (this.emittedSessionRequests.has(request.id)) {
+      console.log("skipping session_request", request.id);
+      return;
+    }
+    this.emittedSessionRequests.add(request.id);
     this.client.events.emit("session_request", request);
   };
 

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -147,7 +147,7 @@ export class Engine extends IEngine {
 
   // a set to track session requests that have been emitted via `session_request` event
   // this is to make sure we don't emit the same request multiple times
-  private emittedSessionRequests = new LimitedSet(500);
+  private emittedSessionRequests = new LimitedSet({ limit: 500 });
 
   private requestQueueDelay = ONE_SECOND;
   private expectedPairingMethodMap: Map<string, string[]> = new Map();

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -2467,7 +2467,6 @@ export class Engine extends IEngine {
     }
 
     try {
-      this.sessionRequestQueue.state = ENGINE_QUEUE_STATES.active;
       this.emitSessionRequest(request);
     } catch (error) {
       this.client.logger.error(error);
@@ -2476,8 +2475,15 @@ export class Engine extends IEngine {
 
   private emitSessionRequest = (request: PendingRequestTypes.Struct) => {
     if (this.emittedSessionRequests.has(request.id)) {
+      this.client.logger.warn(
+        {
+          id: request.id,
+        },
+        `Skipping emitting \`session_request\` event for duplicate request. id: ${request.id}`,
+      );
       return;
     }
+    this.sessionRequestQueue.state = ENGINE_QUEUE_STATES.active;
     this.emittedSessionRequests.add(request.id);
     this.client.events.emit("session_request", request);
   };

--- a/packages/sign-client/test/sdk/persistence.spec.ts
+++ b/packages/sign-client/test/sdk/persistence.spec.ts
@@ -178,21 +178,25 @@ describe("Sign Client Persistence", () => {
             sessionA: { topic },
           } = await testConnectMethod(clients);
 
+          // delete client B so it can be reinstated
+          await deleteClients({ A: undefined, B: clients.B });
           let rejection: JsonRpcError;
-
+          let requestsReceived = 0;
           await Promise.all([
-            new Promise<void>((resolve) => {
+            new Promise<void>(async (resolve) => {
+              await throttle(3_000);
+              // restart
+              clients.B = await SignClient.init({
+                ...TEST_SIGN_CLIENT_OPTIONS_B,
+                storageOptions: { database: db_b },
+                signConfig: {
+                  disableRequestQueue: true,
+                },
+              });
+
               clients.B.on("session_request", async (args) => {
-                // delete client B so it can be reinstated
-                await deleteClients({ A: undefined, B: clients.B });
-
-                await throttle(1_000);
-
-                // restart
-                clients.B = await SignClient.init({
-                  ...TEST_SIGN_CLIENT_OPTIONS_B,
-                  storageOptions: { database: db_b },
-                });
+                requestsReceived++;
+                await throttle(3_000);
                 const pendingRequests = clients.B.getPendingSessionRequests();
                 const { id, topic, params } = pendingRequests[0];
                 expect(params).toEqual(args.params);
@@ -220,7 +224,8 @@ describe("Sign Client Persistence", () => {
               }
             }),
           ]);
-
+          // validate that the pending request was received only once
+          expect(requestsReceived).toBe(1);
           // delete
           await deleteClients(clients);
         });

--- a/packages/sign-client/test/sdk/validation.spec.ts
+++ b/packages/sign-client/test/sdk/validation.spec.ts
@@ -440,6 +440,17 @@ describe("Sign Client Validation", () => {
   });
 
   describe("request", () => {
+    it("should emit session_request event once", async () => {
+      const request = { id: 1, topic, params: TEST_REQUEST_PARAMS };
+      let requestsReceived = 0;
+      clients.A.on("session_request", (args) => {
+        requestsReceived++;
+      });
+      for (let i = 0; i < 100; i++) {
+        await clients.A.engine.emitSessionRequest(request);
+      }
+      expect(requestsReceived).toBe(1);
+    });
     it("throws when no params are passed", async () => {
       await expect(clients.A.request()).rejects.toThrowError(
         "Missing or invalid. request() params: undefined",

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -426,5 +426,9 @@ export abstract class IEngine {
 
   public abstract rejectSessionAuthenticate(params: EngineTypes.RejectParams): Promise<void>;
 
+  /**
+   * no longer used as the client initializes instantly without waiting to connect+subscribe
+   * @deprecated
+   */
   public abstract processRelayMessageCache(): void;
 }

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -560,3 +560,29 @@ export function fromBase64(encodedString: string): string {
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+export class LimitedSet {
+  private limit: number;
+  private set: Set<any>;
+
+  constructor(limit: number) {
+    this.limit = limit;
+    this.set = new Set();
+  }
+
+  add(item: any) {
+    if (this.set.has(item)) return;
+
+    if (this.set.size >= this.limit) {
+      // Remove the oldest entry (FIFO)
+      const firstKey = this.set.values().next().value;
+      this.set.delete(firstKey);
+    }
+
+    this.set.add(item);
+  }
+
+  has(item: any) {
+    return this.set.has(item);
+  }
+}

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -561,28 +561,30 @@ export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export class LimitedSet {
+export class LimitedSet<T> {
   private limit: number;
-  private set: Set<any>;
+  private set: Set<T>;
 
-  constructor(limit: number) {
+  constructor({ limit }: { limit: number }) {
     this.limit = limit;
-    this.set = new Set();
+    this.set = new Set<T>();
   }
 
-  add(item: any) {
+  add(item: T) {
     if (this.set.has(item)) return;
 
     if (this.set.size >= this.limit) {
       // Remove the oldest entry (FIFO)
       const firstKey = this.set.values().next().value;
-      this.set.delete(firstKey);
+      if (firstKey) {
+        this.set.delete(firstKey);
+      }
     }
 
     this.set.add(item);
   }
 
-  has(item: any) {
+  has(item: T) {
     return this.set.has(item);
   }
 }


### PR DESCRIPTION
## Description
Fixed a bug where duplicate `session_request` was emitted after client restart affecting `sign-client` instances with disabled session request queue. 

Also implemented additional safe guards against emitting the same request multiple times 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
