### PR TITLE
chore: set workdir in dockerfile

### DIFF
--- a/.github/workflows/ci_sign_client.yml
+++ b/.github/workflows/ci_sign_client.yml
@@ -41,9 +41,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.run_id }}
-          #restore-keys: |
-          # ${{ runner.os }}-buildx-
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Build, tag, and push image to Amazon ECR
         uses: docker/build-push-action@v6
         env:

--- a/.github/workflows/ci_sign_client.yml
+++ b/.github/workflows/ci_sign_client.yml
@@ -42,8 +42,8 @@ jobs:
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+          #restore-keys: |
+          # ${{ runner.os }}-buildx-
       - name: Build, tag, and push image to Amazon ECR
         uses: docker/build-push-action@v6
         env:

--- a/.github/workflows/ci_sign_client.yml
+++ b/.github/workflows/ci_sign_client.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Build, tag, and push image to Amazon ECR

--- a/packages/sign-client/Dockerfile
+++ b/packages/sign-client/Dockerfile
@@ -7,10 +7,11 @@ RUN apk --update --no-cache \
 
 FROM base AS build
 
-WORKDIR /
+# setting the workdir resolves npm Error: Tracker "idealTree" already exists
+WORKDIR /sdk
 
 COPY ../ ./
-RUN npm cache clean --force && npm ci
+RUN npm ci
 RUN npm run build
 
 WORKDIR /packages/sign-client/

--- a/packages/sign-client/Dockerfile
+++ b/packages/sign-client/Dockerfile
@@ -10,7 +10,7 @@ FROM base AS build
 WORKDIR /
 
 COPY ../ ./
-RUN npm ci
+RUN npm cache clean --force && npm ci
 RUN npm run build
 
 WORKDIR /packages/sign-client/

--- a/packages/sign-client/Dockerfile
+++ b/packages/sign-client/Dockerfile
@@ -14,6 +14,6 @@ COPY ../ ./
 RUN npm ci
 RUN npm run build
 
-WORKDIR /packages/sign-client/
+WORKDIR /sdk/packages/sign-client/
 
 CMD ["node", "-v"]


### PR DESCRIPTION
## Description
The ci-sign-client job is failing with `npm ERR! Tracker "idealTree" already exists`
https://github.com/WalletConnect/walletconnect-monorepo/actions/runs/15870829407/job/44746765681#step:7:287


## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
docker image is built successfully


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
