### PR TITLE
[DO NOT MERGE] chore: upgrade appkit to valtio v2 canary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4765,68 +4765,396 @@
       }
     },
     "node_modules/@reown/appkit": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.7.8.tgz",
-      "integrity": "sha512-51kTleozhA618T1UvMghkhKfaPcc9JlKwLJ5uV+riHyvSoWPKPRIa5A6M1Wano5puNyW0s3fwywhyqTHSilkaA==",
+      "version": "1.7.12-valtio-v2.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.7.12-valtio-v2.0.tgz",
+      "integrity": "sha512-hLVtxuMLMLKgmQn/3BvQZZT451A9DR/GyRUebmXKpb6HTT6iCFCL97pknPFn4HOnGey6aIDo1QVPT5mCPB2KPg==",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.8",
-        "@reown/appkit-controllers": "1.7.8",
-        "@reown/appkit-pay": "1.7.8",
-        "@reown/appkit-polyfills": "1.7.8",
-        "@reown/appkit-scaffold-ui": "1.7.8",
-        "@reown/appkit-ui": "1.7.8",
-        "@reown/appkit-utils": "1.7.8",
-        "@reown/appkit-wallet": "1.7.8",
-        "@walletconnect/types": "2.21.0",
-        "@walletconnect/universal-provider": "2.21.0",
+        "@reown/appkit-common": "1.7.12-valtio-v2.0",
+        "@reown/appkit-controllers": "1.7.12-valtio-v2.0",
+        "@reown/appkit-pay": "1.7.12-valtio-v2.0",
+        "@reown/appkit-polyfills": "1.7.12-valtio-v2.0",
+        "@reown/appkit-scaffold-ui": "1.7.12-valtio-v2.0",
+        "@reown/appkit-ui": "1.7.12-valtio-v2.0",
+        "@reown/appkit-utils": "1.7.12-valtio-v2.0",
+        "@reown/appkit-wallet": "1.7.12-valtio-v2.0",
+        "@walletconnect/types": "2.21.3",
+        "@walletconnect/universal-provider": "2.21.3",
         "bs58": "6.0.0",
-        "valtio": "1.13.2",
-        "viem": ">=2.29.0"
+        "semver": "7.7.2",
+        "valtio": "2.1.5",
+        "viem": ">=2.31.3"
       }
     },
     "node_modules/@reown/appkit-common": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.7.8.tgz",
-      "integrity": "sha512-ridIhc/x6JOp7KbDdwGKY4zwf8/iK8EYBl+HtWrruutSLwZyVi5P8WaZa+8iajL6LcDcDF7LoyLwMTym7SRuwQ==",
+      "version": "1.7.12-valtio-v2.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.7.12-valtio-v2.0.tgz",
+      "integrity": "sha512-IugHchIS8/eLKHayxYGq9t4Y2Nw1x8Y+LB3YeMgYBQarE8Wfx/XjcCaRImRUGXFbFc2e2zA/tTT+/6x+E9OQEQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "big.js": "6.2.2",
         "dayjs": "1.11.13",
-        "viem": ">=2.29.0"
+        "viem": ">=2.31.3"
+      }
+    },
+    "node_modules/@reown/appkit-common/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/@reown/appkit-common/node_modules/ox": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.8.1.tgz",
+      "integrity": "sha512-e+z5epnzV+Zuz91YYujecW8cF01mzmrUtWotJ0oEPym/G82uccs7q0WDHTYL3eiONbTUEvcZrptAKLgTBD3u2A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.0.8",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reown/appkit-common/node_modules/viem": {
+      "version": "2.31.6",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.31.6.tgz",
+      "integrity": "sha512-2PPbXL/8bHQxUzaLFDk4R6WHifTcXxAqMC8/j6RBgXl/OexQ1HU8r9OukwfDTqrFoHtWWiYz5fktHATy7+U9nQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.2",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.0.8",
+        "isows": "1.0.7",
+        "ox": "0.8.1",
+        "ws": "8.18.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reown/appkit-common/node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@reown/appkit-controllers": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.7.8.tgz",
-      "integrity": "sha512-IdXlJlivrlj6m63VsGLsjtPHHsTWvKGVzWIP1fXZHVqmK+rZCBDjCi9j267Rb9/nYRGHWBtlFQhO8dK35WfeDA==",
+      "version": "1.7.12-valtio-v2.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.7.12-valtio-v2.0.tgz",
+      "integrity": "sha512-RghpsqnSoqJ0eVH5np6o10s8N/po18Wi0hVTzxK3vz7UO1QDiFO2DUlmvBGfdpbNIfeFACzvDTF0H/KVTKVvnA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.8",
-        "@reown/appkit-wallet": "1.7.8",
-        "@walletconnect/universal-provider": "2.21.0",
-        "valtio": "1.13.2",
-        "viem": ">=2.29.0"
+        "@reown/appkit-common": "1.7.12-valtio-v2.0",
+        "@reown/appkit-wallet": "1.7.12-valtio-v2.0",
+        "@walletconnect/universal-provider": "2.21.3",
+        "valtio": "2.1.5",
+        "viem": ">=2.31.3"
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/core": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.21.3.tgz",
+      "integrity": "sha512-kMjo5bI6VOsFe/DmxgeTMxCdAIfSzUzG8kCDrpxUXrTnMgaU4H2JBW+tGn7KP/YY1x49+lErZsN5JiQsE5n6Rw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "2.1.2",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.21.3",
+        "@walletconnect/utils": "2.21.3",
+        "@walletconnect/window-getters": "1.0.1",
+        "es-toolkit": "1.39.3",
+        "events": "3.3.0",
+        "uint8arrays": "3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/sign-client": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.3.tgz",
+      "integrity": "sha512-Z6sTCBrset7u5CNjPWlqQuWxmLL2WlGLZYKoB7g/Nvg8wLWo0VaaNeTtNsuopLfJeqdV9/4nV/qHE4xXs2nMIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@walletconnect/core": "2.21.3",
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "2.1.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.21.3",
+        "@walletconnect/utils": "2.21.3",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/types": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.3.tgz",
+      "integrity": "sha512-4fDchSb6q/YIuUokaIvp+/tpWtmiL+dOWuKUCq0+w81R0unsQzn4Zc57Xh+TkNAlBGSJmZ44ZQPevN4vaTnjwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "2.1.2",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/universal-provider": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.21.3.tgz",
+      "integrity": "sha512-Tlkfbtp5oNvSb9yEUl3Fxs0A1y8kLbGJOq7F3zyjVu2EvG96cMqqmlYlPRsi55VDn3scmw8zr2zN+BMsMAuDPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/jsonrpc-http-connection": "1.0.8",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "2.1.2",
+        "@walletconnect/sign-client": "2.21.3",
+        "@walletconnect/types": "2.21.3",
+        "@walletconnect/utils": "2.21.3",
+        "es-toolkit": "1.39.3",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/utils": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.3.tgz",
+      "integrity": "sha512-LHxYX69vG7aPCQB9YT1F8ibwAfRNYwqCEBMplrmquAX+l4lMHTpXvsFF/a5NWFT23DKzbWZ4VTfQTDZ//XJKpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@msgpack/msgpack": "3.1.2",
+        "@noble/ciphers": "1.3.0",
+        "@noble/curves": "1.9.2",
+        "@noble/hashes": "1.8.0",
+        "@scure/base": "1.2.6",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.21.3",
+        "@walletconnect/window-getters": "1.0.1",
+        "@walletconnect/window-metadata": "1.0.1",
+        "blakejs": "1.2.1",
+        "bs58": "6.0.0",
+        "detect-browser": "5.3.0",
+        "query-string": "7.1.3",
+        "uint8arrays": "3.1.1",
+        "viem": "2.31.0"
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/utils/node_modules/viem": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.31.0.tgz",
+      "integrity": "sha512-U7OMQ6yqK+bRbEIarf2vqxL7unSEQvNxvML/1zG7suAmKuJmipqdVTVJGKBCJiYsm/EremyO2FS4dHIPpGv+eA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.0.8",
+        "isows": "1.0.7",
+        "ox": "0.7.1",
+        "ws": "8.18.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/utils/node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/viem": {
+      "version": "2.31.6",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.31.6.tgz",
+      "integrity": "sha512-2PPbXL/8bHQxUzaLFDk4R6WHifTcXxAqMC8/j6RBgXl/OexQ1HU8r9OukwfDTqrFoHtWWiYz5fktHATy7+U9nQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.2",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.0.8",
+        "isows": "1.0.7",
+        "ox": "0.8.1",
+        "ws": "8.18.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/viem/node_modules/ox": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.8.1.tgz",
+      "integrity": "sha512-e+z5epnzV+Zuz91YYujecW8cF01mzmrUtWotJ0oEPym/G82uccs7q0WDHTYL3eiONbTUEvcZrptAKLgTBD3u2A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.0.8",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@reown/appkit-pay": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.7.8.tgz",
-      "integrity": "sha512-OSGQ+QJkXx0FEEjlpQqIhT8zGJKOoHzVnyy/0QFrl3WrQTjCzg0L6+i91Ad5Iy1zb6V5JjqtfIFpRVRWN4M3pw==",
+      "version": "1.7.12-valtio-v2.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.7.12-valtio-v2.0.tgz",
+      "integrity": "sha512-dcSC9/K8aIOgM2Ff2Iisa7X3BVFXDU8B0mGsBO8nf8WclCXtb+D0Ces0Oc/vSMN3YQla+jgdpkgoM6azQ0rqUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.8",
-        "@reown/appkit-controllers": "1.7.8",
-        "@reown/appkit-ui": "1.7.8",
-        "@reown/appkit-utils": "1.7.8",
+        "@reown/appkit-common": "1.7.12-valtio-v2.0",
+        "@reown/appkit-controllers": "1.7.12-valtio-v2.0",
+        "@reown/appkit-ui": "1.7.12-valtio-v2.0",
+        "@reown/appkit-utils": "1.7.12-valtio-v2.0",
         "lit": "3.3.0",
-        "valtio": "1.13.2"
+        "valtio": "2.1.5"
       }
     },
     "node_modules/@reown/appkit-polyfills": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.7.8.tgz",
-      "integrity": "sha512-W/kq786dcHHAuJ3IV2prRLEgD/2iOey4ueMHf1sIFjhhCGMynMkhsOhQMUH0tzodPqUgAC494z4bpIDYjwWXaA==",
+      "version": "1.7.12-valtio-v2.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.7.12-valtio-v2.0.tgz",
+      "integrity": "sha512-/PygUjMWNqhuUZYAAxqvLQ7FCeDj9exMsLg2ykiKfB7ycqDrITJ01oozx3MVlnFMg7W4SIKBa8wqviFosU4IAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "buffer": "6.0.3"
@@ -4857,61 +5185,540 @@
       }
     },
     "node_modules/@reown/appkit-scaffold-ui": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.7.8.tgz",
-      "integrity": "sha512-RCeHhAwOrIgcvHwYlNWMcIDibdI91waaoEYBGw71inE0kDB8uZbE7tE6DAXJmDkvl0qPh+DqlC4QbJLF1FVYdQ==",
+      "version": "1.7.12-valtio-v2.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.7.12-valtio-v2.0.tgz",
+      "integrity": "sha512-OyDwU7IvbZY2yOjd3QtFE02LPLBD0CqPa3z8bpAOViSD4f7oJ3dMRj8Fdgu8bVZLff7pVohGFBOIZyPR2r7t1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.8",
-        "@reown/appkit-controllers": "1.7.8",
-        "@reown/appkit-ui": "1.7.8",
-        "@reown/appkit-utils": "1.7.8",
-        "@reown/appkit-wallet": "1.7.8",
+        "@reown/appkit-common": "1.7.12-valtio-v2.0",
+        "@reown/appkit-controllers": "1.7.12-valtio-v2.0",
+        "@reown/appkit-ui": "1.7.12-valtio-v2.0",
+        "@reown/appkit-utils": "1.7.12-valtio-v2.0",
+        "@reown/appkit-wallet": "1.7.12-valtio-v2.0",
         "lit": "3.3.0"
       }
     },
     "node_modules/@reown/appkit-ui": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.7.8.tgz",
-      "integrity": "sha512-1hjCKjf6FLMFzrulhl0Y9Vb9Fu4royE+SXCPSWh4VhZhWqlzUFc7kutnZKx8XZFVQH4pbBvY62SpRC93gqoHow==",
+      "version": "1.7.12-valtio-v2.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.7.12-valtio-v2.0.tgz",
+      "integrity": "sha512-KphxxsTMXZDEm1vya/piUVqT6SgL9tQyctxDzzvUd9TyzpCZVZ3fZcIMrBQvTQjqwzUP64M1SvwXSFFb34msrw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.8",
-        "@reown/appkit-controllers": "1.7.8",
-        "@reown/appkit-wallet": "1.7.8",
+        "@reown/appkit-common": "1.7.12-valtio-v2.0",
+        "@reown/appkit-controllers": "1.7.12-valtio-v2.0",
+        "@reown/appkit-wallet": "1.7.12-valtio-v2.0",
         "lit": "3.3.0",
         "qrcode": "1.5.3"
       }
     },
     "node_modules/@reown/appkit-utils": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.7.8.tgz",
-      "integrity": "sha512-8X7UvmE8GiaoitCwNoB86pttHgQtzy4ryHZM9kQpvjQ0ULpiER44t1qpVLXNM4X35O0v18W0Dk60DnYRMH2WRw==",
+      "version": "1.7.12-valtio-v2.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.7.12-valtio-v2.0.tgz",
+      "integrity": "sha512-soa9+gF0i/z7YblKH2Sw3cPyTfSnmnGYyRDRX+s5yktofnSVU/dBBcTwXZxhLRBhHBGrtIKxvrCIWVxGGw9ukg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.8",
-        "@reown/appkit-controllers": "1.7.8",
-        "@reown/appkit-polyfills": "1.7.8",
-        "@reown/appkit-wallet": "1.7.8",
+        "@reown/appkit-common": "1.7.12-valtio-v2.0",
+        "@reown/appkit-controllers": "1.7.12-valtio-v2.0",
+        "@reown/appkit-polyfills": "1.7.12-valtio-v2.0",
+        "@reown/appkit-wallet": "1.7.12-valtio-v2.0",
+        "@wallet-standard/wallet": "1.1.0",
         "@walletconnect/logger": "2.1.2",
-        "@walletconnect/universal-provider": "2.21.0",
-        "valtio": "1.13.2",
-        "viem": ">=2.29.0"
+        "@walletconnect/universal-provider": "2.21.3",
+        "valtio": "2.1.5",
+        "viem": ">=2.31.3"
       },
       "peerDependencies": {
-        "valtio": "1.13.2"
+        "valtio": "2.1.5"
+      }
+    },
+    "node_modules/@reown/appkit-utils/node_modules/@walletconnect/core": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.21.3.tgz",
+      "integrity": "sha512-kMjo5bI6VOsFe/DmxgeTMxCdAIfSzUzG8kCDrpxUXrTnMgaU4H2JBW+tGn7KP/YY1x49+lErZsN5JiQsE5n6Rw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "2.1.2",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.21.3",
+        "@walletconnect/utils": "2.21.3",
+        "@walletconnect/window-getters": "1.0.1",
+        "es-toolkit": "1.39.3",
+        "events": "3.3.0",
+        "uint8arrays": "3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@reown/appkit-utils/node_modules/@walletconnect/sign-client": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.3.tgz",
+      "integrity": "sha512-Z6sTCBrset7u5CNjPWlqQuWxmLL2WlGLZYKoB7g/Nvg8wLWo0VaaNeTtNsuopLfJeqdV9/4nV/qHE4xXs2nMIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@walletconnect/core": "2.21.3",
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "2.1.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.21.3",
+        "@walletconnect/utils": "2.21.3",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@reown/appkit-utils/node_modules/@walletconnect/types": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.3.tgz",
+      "integrity": "sha512-4fDchSb6q/YIuUokaIvp+/tpWtmiL+dOWuKUCq0+w81R0unsQzn4Zc57Xh+TkNAlBGSJmZ44ZQPevN4vaTnjwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "2.1.2",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@reown/appkit-utils/node_modules/@walletconnect/universal-provider": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.21.3.tgz",
+      "integrity": "sha512-Tlkfbtp5oNvSb9yEUl3Fxs0A1y8kLbGJOq7F3zyjVu2EvG96cMqqmlYlPRsi55VDn3scmw8zr2zN+BMsMAuDPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/jsonrpc-http-connection": "1.0.8",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "2.1.2",
+        "@walletconnect/sign-client": "2.21.3",
+        "@walletconnect/types": "2.21.3",
+        "@walletconnect/utils": "2.21.3",
+        "es-toolkit": "1.39.3",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@reown/appkit-utils/node_modules/@walletconnect/utils": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.3.tgz",
+      "integrity": "sha512-LHxYX69vG7aPCQB9YT1F8ibwAfRNYwqCEBMplrmquAX+l4lMHTpXvsFF/a5NWFT23DKzbWZ4VTfQTDZ//XJKpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@msgpack/msgpack": "3.1.2",
+        "@noble/ciphers": "1.3.0",
+        "@noble/curves": "1.9.2",
+        "@noble/hashes": "1.8.0",
+        "@scure/base": "1.2.6",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.21.3",
+        "@walletconnect/window-getters": "1.0.1",
+        "@walletconnect/window-metadata": "1.0.1",
+        "blakejs": "1.2.1",
+        "bs58": "6.0.0",
+        "detect-browser": "5.3.0",
+        "query-string": "7.1.3",
+        "uint8arrays": "3.1.1",
+        "viem": "2.31.0"
+      }
+    },
+    "node_modules/@reown/appkit-utils/node_modules/@walletconnect/utils/node_modules/viem": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.31.0.tgz",
+      "integrity": "sha512-U7OMQ6yqK+bRbEIarf2vqxL7unSEQvNxvML/1zG7suAmKuJmipqdVTVJGKBCJiYsm/EremyO2FS4dHIPpGv+eA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.0.8",
+        "isows": "1.0.7",
+        "ox": "0.7.1",
+        "ws": "8.18.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reown/appkit-utils/node_modules/@walletconnect/utils/node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@reown/appkit-utils/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/@reown/appkit-utils/node_modules/viem": {
+      "version": "2.31.6",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.31.6.tgz",
+      "integrity": "sha512-2PPbXL/8bHQxUzaLFDk4R6WHifTcXxAqMC8/j6RBgXl/OexQ1HU8r9OukwfDTqrFoHtWWiYz5fktHATy7+U9nQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.2",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.0.8",
+        "isows": "1.0.7",
+        "ox": "0.8.1",
+        "ws": "8.18.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reown/appkit-utils/node_modules/viem/node_modules/ox": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.8.1.tgz",
+      "integrity": "sha512-e+z5epnzV+Zuz91YYujecW8cF01mzmrUtWotJ0oEPym/G82uccs7q0WDHTYL3eiONbTUEvcZrptAKLgTBD3u2A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.0.8",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reown/appkit-utils/node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@reown/appkit-wallet": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.7.8.tgz",
-      "integrity": "sha512-kspz32EwHIOT/eg/ZQbFPxgXq0B/olDOj3YMu7gvLEFz4xyOFd/wgzxxAXkp5LbG4Cp++s/elh79rVNmVFdB9A==",
+      "version": "1.7.12-valtio-v2.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.7.12-valtio-v2.0.tgz",
+      "integrity": "sha512-VupeKyoHiyBavB/VLWb1T3bzfK6wYEylXmsfDSWAbKlAdf3wOw53dsIRrf8JSdGJxqJIWpj2/PDDWZZlDrOr7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.8",
-        "@reown/appkit-polyfills": "1.7.8",
+        "@reown/appkit-common": "1.7.12-valtio-v2.0",
+        "@reown/appkit-polyfills": "1.7.12-valtio-v2.0",
         "@walletconnect/logger": "2.1.2",
         "zod": "3.22.4"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/@walletconnect/core": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.21.3.tgz",
+      "integrity": "sha512-kMjo5bI6VOsFe/DmxgeTMxCdAIfSzUzG8kCDrpxUXrTnMgaU4H2JBW+tGn7KP/YY1x49+lErZsN5JiQsE5n6Rw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "2.1.2",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.21.3",
+        "@walletconnect/utils": "2.21.3",
+        "@walletconnect/window-getters": "1.0.1",
+        "es-toolkit": "1.39.3",
+        "events": "3.3.0",
+        "uint8arrays": "3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/@walletconnect/sign-client": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.3.tgz",
+      "integrity": "sha512-Z6sTCBrset7u5CNjPWlqQuWxmLL2WlGLZYKoB7g/Nvg8wLWo0VaaNeTtNsuopLfJeqdV9/4nV/qHE4xXs2nMIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@walletconnect/core": "2.21.3",
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "2.1.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.21.3",
+        "@walletconnect/utils": "2.21.3",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/@walletconnect/types": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.3.tgz",
+      "integrity": "sha512-4fDchSb6q/YIuUokaIvp+/tpWtmiL+dOWuKUCq0+w81R0unsQzn4Zc57Xh+TkNAlBGSJmZ44ZQPevN4vaTnjwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "2.1.2",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/@walletconnect/universal-provider": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.21.3.tgz",
+      "integrity": "sha512-Tlkfbtp5oNvSb9yEUl3Fxs0A1y8kLbGJOq7F3zyjVu2EvG96cMqqmlYlPRsi55VDn3scmw8zr2zN+BMsMAuDPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/jsonrpc-http-connection": "1.0.8",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "2.1.2",
+        "@walletconnect/sign-client": "2.21.3",
+        "@walletconnect/types": "2.21.3",
+        "@walletconnect/utils": "2.21.3",
+        "es-toolkit": "1.39.3",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/@walletconnect/utils": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.3.tgz",
+      "integrity": "sha512-LHxYX69vG7aPCQB9YT1F8ibwAfRNYwqCEBMplrmquAX+l4lMHTpXvsFF/a5NWFT23DKzbWZ4VTfQTDZ//XJKpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@msgpack/msgpack": "3.1.2",
+        "@noble/ciphers": "1.3.0",
+        "@noble/curves": "1.9.2",
+        "@noble/hashes": "1.8.0",
+        "@scure/base": "1.2.6",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.21.3",
+        "@walletconnect/window-getters": "1.0.1",
+        "@walletconnect/window-metadata": "1.0.1",
+        "blakejs": "1.2.1",
+        "bs58": "6.0.0",
+        "detect-browser": "5.3.0",
+        "query-string": "7.1.3",
+        "uint8arrays": "3.1.1",
+        "viem": "2.31.0"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/@walletconnect/utils/node_modules/viem": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.31.0.tgz",
+      "integrity": "sha512-U7OMQ6yqK+bRbEIarf2vqxL7unSEQvNxvML/1zG7suAmKuJmipqdVTVJGKBCJiYsm/EremyO2FS4dHIPpGv+eA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.0.8",
+        "isows": "1.0.7",
+        "ox": "0.7.1",
+        "ws": "8.18.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/@walletconnect/utils/node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/@reown/appkit/node_modules/viem": {
+      "version": "2.31.6",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.31.6.tgz",
+      "integrity": "sha512-2PPbXL/8bHQxUzaLFDk4R6WHifTcXxAqMC8/j6RBgXl/OexQ1HU8r9OukwfDTqrFoHtWWiYz5fktHATy7+U9nQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.2",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.0.8",
+        "isows": "1.0.7",
+        "ox": "0.8.1",
+        "ws": "8.18.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/viem/node_modules/ox": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.8.1.tgz",
+      "integrity": "sha512-e+z5epnzV+Zuz91YYujecW8cF01mzmrUtWotJ0oEPym/G82uccs7q0WDHTYL3eiONbTUEvcZrptAKLgTBD3u2A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.0.8",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/plugin-alias": {
@@ -6853,6 +7660,27 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@wallet-standard/base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.0.tgz",
+      "integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wallet-standard/wallet": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/wallet/-/wallet-1.1.0.tgz",
+      "integrity": "sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/@walletconnect/core": {
       "resolved": "packages/core",
@@ -10118,15 +10946,6 @@
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/derive-valtio": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/derive-valtio/-/derive-valtio-0.1.0.tgz",
-      "integrity": "sha512-OCg2UsLbXK7GmmpzMXhYkdO64vhJ1ROUUGaTFyHjVwEdMEcTTRj7W1TxLbSBxdY8QLBPCcp66MTyaSy0RpO17A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "valtio": "*"
-      }
     },
     "node_modules/des.js": {
       "version": "1.1.0",
@@ -22360,9 +23179,9 @@
       }
     },
     "node_modules/proxy-compare": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.6.0.tgz",
-      "integrity": "sha512-8xuCeM3l8yqdmbPoYeLbrAXCBWu19XEYc5/F28f5qOaoAIMyfmBUkl5axiK+x9olUvRlcekvnm98AP9RDngOIw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
+      "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {
@@ -23938,9 +24757,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -26736,21 +27555,19 @@
       }
     },
     "node_modules/valtio": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.13.2.tgz",
-      "integrity": "sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-2.1.5.tgz",
+      "integrity": "sha512-vsh1Ixu5mT0pJFZm+Jspvhga5GzHUTYv0/+Th203pLfh3/wbHwxhu/Z2OkZDXIgHfjnjBns7SN9HNcbDvPmaGw==",
       "license": "MIT",
       "dependencies": {
-        "derive-valtio": "0.1.0",
-        "proxy-compare": "2.6.0",
-        "use-sync-external-store": "1.2.0"
+        "proxy-compare": "^3.0.1"
       },
       "engines": {
         "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8",
-        "react": ">=16.8"
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -26759,15 +27576,6 @@
         "react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/valtio/node_modules/use-sync-external-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/varint": {
@@ -28525,7 +29333,7 @@
       "version": "2.21.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit": "1.7.8",
+        "@reown/appkit": "1.7.12-valtio-v2.0",
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
         "@walletconnect/jsonrpc-provider": "1.0.14",
         "@walletconnect/jsonrpc-types": "1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4765,20 +4765,20 @@
       }
     },
     "node_modules/@reown/appkit": {
-      "version": "1.7.12-valtio-v2.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.7.12-valtio-v2.0.tgz",
-      "integrity": "sha512-hLVtxuMLMLKgmQn/3BvQZZT451A9DR/GyRUebmXKpb6HTT6iCFCL97pknPFn4HOnGey6aIDo1QVPT5mCPB2KPg==",
+      "version": "1.7.12-valtio-v2.1.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.7.12-valtio-v2.1.0.tgz",
+      "integrity": "sha512-hogtax2kx4QleSHlgzGBd+Jb9u/+2nScbfN2qEqFhNQ2ZgOyTAWP5bSmBhgX5GSOMHXmfz58nW4DA8ab4n5C8g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.12-valtio-v2.0",
-        "@reown/appkit-controllers": "1.7.12-valtio-v2.0",
-        "@reown/appkit-pay": "1.7.12-valtio-v2.0",
-        "@reown/appkit-polyfills": "1.7.12-valtio-v2.0",
-        "@reown/appkit-scaffold-ui": "1.7.12-valtio-v2.0",
-        "@reown/appkit-ui": "1.7.12-valtio-v2.0",
-        "@reown/appkit-utils": "1.7.12-valtio-v2.0",
-        "@reown/appkit-wallet": "1.7.12-valtio-v2.0",
+        "@reown/appkit-common": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-controllers": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-pay": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-polyfills": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-scaffold-ui": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-ui": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-utils": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-wallet": "1.7.12-valtio-v2.1.0",
         "@walletconnect/types": "2.21.3",
         "@walletconnect/universal-provider": "2.21.3",
         "bs58": "6.0.0",
@@ -4788,9 +4788,9 @@
       }
     },
     "node_modules/@reown/appkit-common": {
-      "version": "1.7.12-valtio-v2.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.7.12-valtio-v2.0.tgz",
-      "integrity": "sha512-IugHchIS8/eLKHayxYGq9t4Y2Nw1x8Y+LB3YeMgYBQarE8Wfx/XjcCaRImRUGXFbFc2e2zA/tTT+/6x+E9OQEQ==",
+      "version": "1.7.12-valtio-v2.1.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.7.12-valtio-v2.1.0.tgz",
+      "integrity": "sha512-eNBT0sHnxyKIOS3vwpiLoE99xe2qj93RVb7mPrbJ7CHUDXDTl0eTw5BTboxTWfD3LlbEkEw4ElzzXnP5RKKXsA==",
       "license": "Apache-2.0",
       "dependencies": {
         "big.js": "6.2.2",
@@ -4886,13 +4886,13 @@
       }
     },
     "node_modules/@reown/appkit-controllers": {
-      "version": "1.7.12-valtio-v2.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.7.12-valtio-v2.0.tgz",
-      "integrity": "sha512-RghpsqnSoqJ0eVH5np6o10s8N/po18Wi0hVTzxK3vz7UO1QDiFO2DUlmvBGfdpbNIfeFACzvDTF0H/KVTKVvnA==",
+      "version": "1.7.12-valtio-v2.1.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.7.12-valtio-v2.1.0.tgz",
+      "integrity": "sha512-GUZ8deOYNVvS+GxHQI7ZIDBdAAPdTnfpMF+S+5EeffhF9UFpfeQqG14uO5FKS8q8GKR56yFKked/2KnBqW7pKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.12-valtio-v2.0",
-        "@reown/appkit-wallet": "1.7.12-valtio-v2.0",
+        "@reown/appkit-common": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-wallet": "1.7.12-valtio-v2.1.0",
         "@walletconnect/universal-provider": "2.21.3",
         "valtio": "2.1.5",
         "viem": ">=2.31.3"
@@ -5138,23 +5138,23 @@
       }
     },
     "node_modules/@reown/appkit-pay": {
-      "version": "1.7.12-valtio-v2.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.7.12-valtio-v2.0.tgz",
-      "integrity": "sha512-dcSC9/K8aIOgM2Ff2Iisa7X3BVFXDU8B0mGsBO8nf8WclCXtb+D0Ces0Oc/vSMN3YQla+jgdpkgoM6azQ0rqUg==",
+      "version": "1.7.12-valtio-v2.1.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.7.12-valtio-v2.1.0.tgz",
+      "integrity": "sha512-7AG++1FKENcSxEu5nYsEauCoGxLwNPiuvaoX/9an6t1o4ud+BDTQMszLImi/+bAbKVmRT5CZrKkwqskJ4Cdhkw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.12-valtio-v2.0",
-        "@reown/appkit-controllers": "1.7.12-valtio-v2.0",
-        "@reown/appkit-ui": "1.7.12-valtio-v2.0",
-        "@reown/appkit-utils": "1.7.12-valtio-v2.0",
+        "@reown/appkit-common": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-controllers": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-ui": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-utils": "1.7.12-valtio-v2.1.0",
         "lit": "3.3.0",
         "valtio": "2.1.5"
       }
     },
     "node_modules/@reown/appkit-polyfills": {
-      "version": "1.7.12-valtio-v2.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.7.12-valtio-v2.0.tgz",
-      "integrity": "sha512-/PygUjMWNqhuUZYAAxqvLQ7FCeDj9exMsLg2ykiKfB7ycqDrITJ01oozx3MVlnFMg7W4SIKBa8wqviFosU4IAQ==",
+      "version": "1.7.12-valtio-v2.1.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.7.12-valtio-v2.1.0.tgz",
+      "integrity": "sha512-fjobmJSptBd6TOCaxu8r1757MHTYYq0/eGAjf3+3439RQeIpi2QvUwRs3OHw8W7c1yAELZcQzTTNar59KMnDwA==",
       "license": "Apache-2.0",
       "dependencies": {
         "buffer": "6.0.3"
@@ -5185,42 +5185,42 @@
       }
     },
     "node_modules/@reown/appkit-scaffold-ui": {
-      "version": "1.7.12-valtio-v2.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.7.12-valtio-v2.0.tgz",
-      "integrity": "sha512-OyDwU7IvbZY2yOjd3QtFE02LPLBD0CqPa3z8bpAOViSD4f7oJ3dMRj8Fdgu8bVZLff7pVohGFBOIZyPR2r7t1A==",
+      "version": "1.7.12-valtio-v2.1.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.7.12-valtio-v2.1.0.tgz",
+      "integrity": "sha512-pxnEjbUPKIJHLUpdpSityj/l0d8Vdgq0w1pnpxsxUEUdYhcqZNIL7zfA0eRnEAHgk2v3sSlrhtebA1hnk9OKSg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.12-valtio-v2.0",
-        "@reown/appkit-controllers": "1.7.12-valtio-v2.0",
-        "@reown/appkit-ui": "1.7.12-valtio-v2.0",
-        "@reown/appkit-utils": "1.7.12-valtio-v2.0",
-        "@reown/appkit-wallet": "1.7.12-valtio-v2.0",
+        "@reown/appkit-common": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-controllers": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-ui": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-utils": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-wallet": "1.7.12-valtio-v2.1.0",
         "lit": "3.3.0"
       }
     },
     "node_modules/@reown/appkit-ui": {
-      "version": "1.7.12-valtio-v2.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.7.12-valtio-v2.0.tgz",
-      "integrity": "sha512-KphxxsTMXZDEm1vya/piUVqT6SgL9tQyctxDzzvUd9TyzpCZVZ3fZcIMrBQvTQjqwzUP64M1SvwXSFFb34msrw==",
+      "version": "1.7.12-valtio-v2.1.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.7.12-valtio-v2.1.0.tgz",
+      "integrity": "sha512-n6E632D9/sDu2vycyK2QfuyDC0fgPV/OqXXDiVCsGLGZm1031Z35TcyezuwKmfl5cfxhMJy6nRb5WNsP05Krog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.12-valtio-v2.0",
-        "@reown/appkit-controllers": "1.7.12-valtio-v2.0",
-        "@reown/appkit-wallet": "1.7.12-valtio-v2.0",
+        "@reown/appkit-common": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-controllers": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-wallet": "1.7.12-valtio-v2.1.0",
         "lit": "3.3.0",
         "qrcode": "1.5.3"
       }
     },
     "node_modules/@reown/appkit-utils": {
-      "version": "1.7.12-valtio-v2.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.7.12-valtio-v2.0.tgz",
-      "integrity": "sha512-soa9+gF0i/z7YblKH2Sw3cPyTfSnmnGYyRDRX+s5yktofnSVU/dBBcTwXZxhLRBhHBGrtIKxvrCIWVxGGw9ukg==",
+      "version": "1.7.12-valtio-v2.1.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.7.12-valtio-v2.1.0.tgz",
+      "integrity": "sha512-ShlCimJirTNYUvm2TBGYyVc8KBd5C0t+zaCqFZLZr0y1yUOrlXWOHphd7Begrd3OmyFKcrMw48/pvom44l5I4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.12-valtio-v2.0",
-        "@reown/appkit-controllers": "1.7.12-valtio-v2.0",
-        "@reown/appkit-polyfills": "1.7.12-valtio-v2.0",
-        "@reown/appkit-wallet": "1.7.12-valtio-v2.0",
+        "@reown/appkit-common": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-controllers": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-polyfills": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-wallet": "1.7.12-valtio-v2.1.0",
         "@wallet-standard/wallet": "1.1.0",
         "@walletconnect/logger": "2.1.2",
         "@walletconnect/universal-provider": "2.21.3",
@@ -5471,13 +5471,13 @@
       }
     },
     "node_modules/@reown/appkit-wallet": {
-      "version": "1.7.12-valtio-v2.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.7.12-valtio-v2.0.tgz",
-      "integrity": "sha512-VupeKyoHiyBavB/VLWb1T3bzfK6wYEylXmsfDSWAbKlAdf3wOw53dsIRrf8JSdGJxqJIWpj2/PDDWZZlDrOr7Q==",
+      "version": "1.7.12-valtio-v2.1.0",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.7.12-valtio-v2.1.0.tgz",
+      "integrity": "sha512-oJdg9KAThBx+2Z6J5uIoD8WVGQT7MnPZ2k4ipHCmqvq1ri4q6p83LdBX6hogm0TAu/rpRNvJT16FNuCcdP5lyA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.12-valtio-v2.0",
-        "@reown/appkit-polyfills": "1.7.12-valtio-v2.0",
+        "@reown/appkit-common": "1.7.12-valtio-v2.1.0",
+        "@reown/appkit-polyfills": "1.7.12-valtio-v2.1.0",
         "@walletconnect/logger": "2.1.2",
         "zod": "3.22.4"
       }
@@ -29333,7 +29333,7 @@
       "version": "2.21.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit": "1.7.12-valtio-v2.0",
+        "@reown/appkit": "1.7.12-valtio-v2.1.0",
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
         "@walletconnect/jsonrpc-provider": "1.0.14",
         "@walletconnect/jsonrpc-types": "1.0.4",

--- a/providers/ethereum-provider/package.json
+++ b/providers/ethereum-provider/package.json
@@ -44,7 +44,7 @@
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },
   "dependencies": {
-    "@reown/appkit": "1.7.8",
+    "@reown/appkit": "1.7.12-valtio-v2.0",
     "@walletconnect/jsonrpc-http-connection": "1.0.8",
     "@walletconnect/jsonrpc-provider": "1.0.14",
     "@walletconnect/jsonrpc-types": "1.0.4",

--- a/providers/ethereum-provider/package.json
+++ b/providers/ethereum-provider/package.json
@@ -44,7 +44,7 @@
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },
   "dependencies": {
-    "@reown/appkit": "1.7.12-valtio-v2.0",
+    "@reown/appkit": "1.7.12-valtio-v2.1.0",
     "@walletconnect/jsonrpc-http-connection": "1.0.8",
     "@walletconnect/jsonrpc-provider": "1.0.14",
     "@walletconnect/jsonrpc-types": "1.0.4",


### PR DESCRIPTION

## Description

This PR upgrades AppKit to the version which is using Valtio v2.

> [!NOTE]
> This PR won't be merged untill we verify this migration flow below works fine.

### Migration guide

- [x] Upgrade Valtio to v2 on AppKit and open PR
- [ ] Get AppKit canary: [1.7.12-valtio-v2.0](https://www.npmjs.com/package/@reown/appkit/v/1.7.12-valtio-v2.0)
- [ ] Update AppKit to Valtio v2 canary on WC packages
- [ ] Get WC packages canary
- [ ] Use this canary in AppKit (so both AppKit and WC packages will be using Valtio v2)
- [ ] Update AppKit Valtio v2 PR with WC canary

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] If all good, merge WC and AppKit PRs.

## How has this been tested?

This will be tested on AppKit PR: https://github.com/reown-com/appkit/pull/4358

## Fixes/Resolves (Optional)

Fixes issue when switching to Valtio v2 on AppKit bc the WC dependencies brings Valtio v1 and both Valtio dependencies are conflicting. AppKit repo requires AppKit version which uses Valtio v2

## Checklist

- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
