### PR TITLE
chore: change connection skip log level to info

### DIFF
--- a/.changeset/tough-sloths-report.md
+++ b/.changeset/tough-sloths-report.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/core": patch
+"@walletconnect/react-native-compat": patch
+"@walletconnect/sign-client": patch
+"@walletconnect/types": patch
+"@walletconnect/utils": patch
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/signer-connection": patch
+"@walletconnect/universal-provider": patch
+---
+
+Updated the `skipped transport open due to no topics` relayer log message level to `info`

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -275,7 +275,7 @@ export class Relayer extends IRelayer {
 
   async transportOpen(relayUrl?: string) {
     if (!this.subscriber.hasAnyTopics) {
-      this.logger.warn(
+      this.logger.info(
         "Starting WS connection skipped because the client has no topics to work with.",
       );
       return;


### PR DESCRIPTION
> Creating a release? Please use the [Release PR Template](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/.github/pr_template_release.md) instead.

## Description

A customer who invokes the SDK via `Web3Wallet.init({...})` complains "millions" of log noise for the log statement in question.

While this PR doesn't resolve this issue fully it adjust the log level.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Not tested.

Use this table template to show examples of your changes:

| Before       | After        |
| ------------ | ------------ |
| Content Cell | Content Cell |
| Content Cell | Content Cell |

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
