### PR TITLE
fix: UP to gracefully handle namespace without accounts

### DIFF
--- a/.changeset/public-hats-sip.md
+++ b/.changeset/public-hats-sip.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/universal-provider": patch
+"@walletconnect/core": patch
+"@walletconnect/react-native-compat": patch
+"@walletconnect/sign-client": patch
+"@walletconnect/types": patch
+"@walletconnect/utils": patch
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/signer-connection": patch
+---
+
+fixed a bug that caused `universal-provider` to throw unhandled when it tried to create sub provider for a namespace without accounts

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -320,6 +320,9 @@ export class UniversalProvider implements IUniversalProvider {
     providersToCreate.forEach((namespace) => {
       if (!this.session) return;
       const accounts = getAccountsFromSession(namespace, this.session);
+      if (accounts?.length === 0) {
+        return;
+      }
       const approvedChains = getChainsFromApprovedSession(accounts);
       const mergedNamespaces = mergeRequiredOptionalNamespaces(
         this.namespaces,

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -1806,6 +1806,65 @@ describe("UniversalProvider", function () {
 
       await deleteProviders({ A: dapp, B: wallet });
     });
+
+    it("should gracefully handle invalid namespaces without chains/accounts", async () => {
+      const dapp = await UniversalProvider.init({
+        ...TEST_PROVIDER_OPTS,
+        name: "dapp",
+      });
+      const wallet = await UniversalProvider.init({
+        ...TEST_PROVIDER_OPTS,
+        name: "wallet",
+      });
+      const optionalNamespaces = {
+        eip155: {
+          chains: ["eip155:1"],
+          events: ["chainChanged"],
+          methods: ["personal_sign", "eth_sendTransaction"],
+        },
+        bip122: {
+          chains: ["bip122:000000000019d6689c085ae165831e93"],
+          events: ["chainChanged"],
+          methods: ["bip122_signTransaction"],
+        },
+      };
+      await testConnectMethod(
+        {
+          dapp,
+          wallet,
+        },
+        {
+          requiredNamespaces: {},
+          optionalNamespaces,
+          namespaces: {
+            bip122: {
+              accounts: [],
+              chains: [],
+              methods: ["bip122_signTransaction"],
+              events: ["chainChanged"],
+            },
+            eip155: {
+              accounts: ["eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"],
+              chains: ["eip155:1"],
+              methods: ["personal_sign", "eth_sendTransaction"],
+              events: ["chainChanged"],
+            },
+          },
+        },
+      );
+      await throttle(1_000);
+      expect(dapp.rpcProviders).to.be.an("object");
+      expect(dapp.rpcProviders.eip155).to.exist;
+      expect(dapp.rpcProviders.eip155).to.be.an("object");
+      // verify bip122(generic) provider is not created
+      expect(dapp.rpcProviders.generic).to.not.exist;
+
+      const httpProviders = dapp.rpcProviders.eip155.httpProviders;
+
+      expect(Object.keys(httpProviders).length).is.greaterThan(0);
+
+      await deleteProviders({ A: dapp, B: wallet });
+    });
   });
 });
 


### PR DESCRIPTION
## Description
fixed a bug that caused `universal-provider` to throw unhandled when it tried to create sub provider for a namespace without accounts. Its addition to https://github.com/WalletConnect/walletconnect-monorepo/pull/6805

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
