### PR TITLE
fix:  `buildApprovedNamespaces`

### DIFF
--- a/.changeset/yellow-mugs-poke.md
+++ b/.changeset/yellow-mugs-poke.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/utils": patch
+"@walletconnect/core": patch
+"@walletconnect/react-native-compat": patch
+"@walletconnect/sign-client": patch
+"@walletconnect/types": patch
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/signer-connection": patch
+"@walletconnect/universal-provider": patch
+---
+
+fixed a bug within `buildApprovedNamespaces` that didn't discard namespace when there were no matching chains or accounts

--- a/packages/utils/src/namespaces.ts
+++ b/packages/utils/src/namespaces.ts
@@ -180,6 +180,13 @@ export function buildApprovedNamespaces(
     };
   });
 
+  // remove namespaces with no chains or accounts
+  for (const [namespace, values] of Object.entries(approvedNamespaces)) {
+    if (values.accounts.length === 0 || values?.chains?.length === 0) {
+      delete approvedNamespaces[namespace];
+    }
+  }
+
   return approvedNamespaces;
 }
 

--- a/packages/utils/test/validators.spec.ts
+++ b/packages/utils/test/validators.spec.ts
@@ -1405,6 +1405,64 @@ describe("buildApprovedNamespaces (validators)", () => {
       });
     },
   );
+  it("should build approved namespaces - matching namespace but no supported chains", () => {
+    const required = {};
+    const optional = {
+      eip155: {
+        chains: ["eip155:1", "eip155:2"],
+        events: ["chainChanged", "accountsChanged"],
+        methods: [
+          "personal_sign",
+          "eth_sendTransaction",
+          "eth_signTransaction",
+          "eth_signTypedData",
+        ],
+      },
+      bip122: {
+        chains: ["bip122:000000000019d6689c085ae165831e93"],
+        events: ["chainChanged"],
+        methods: ["bip122_signTransaction"],
+      },
+    };
+
+    const chainsEip = ["eip155:1"];
+    const methods = ["personal_sign", "eth_sendTransaction"];
+    const events = ["chainChanged"];
+    const accountsEip = ["eip155:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"];
+
+    const result = buildApprovedNamespaces({
+      proposal: {
+        ...TEST_PROPOSAL,
+        requiredNamespaces: required,
+        optionalNamespaces: optional,
+      },
+      supportedNamespaces: {
+        eip155: {
+          chains: chainsEip,
+          methods,
+          events,
+          accounts: accountsEip,
+        },
+        bip122: {
+          chains: ["bip122:000000000019d6689c085ae165831e92"],
+          events: ["chainChanged"],
+          methods: ["bip122_signTransaction"],
+          accounts: [
+            "bip122:000000000019d6689c085ae165831e92:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+          ],
+        },
+      },
+    });
+    // it should not inclide bip122 namespace since the supported chains do not match with the proposal
+    expect(result).toEqual({
+      eip155: {
+        chains: chainsEip,
+        events,
+        methods,
+        accounts: accountsEip,
+      },
+    });
+  });
 });
 
 describe("merge namespaces", () => {


### PR DESCRIPTION
## Description
Fixed a bug within `buildApprovedNamespaces` that didn't discard namespace when there were no matching chains or accounts
context: https://reown-inc.slack.com/archives/C04DB2EAHE3/p1752737346819389?thread_ts=1752689877.524959&cid=C04DB2EAHE3
## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
