### PR TITLE
refactor: omit awaiting `cleanupPendingPairings`

### DIFF
--- a/.changeset/tidy-walls-notice.md
+++ b/.changeset/tidy-walls-notice.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/universal-provider": patch
+"@walletconnect/core": patch
+"@walletconnect/react-native-compat": patch
+"@walletconnect/sign-client": patch
+"@walletconnect/types": patch
+"@walletconnect/utils": patch
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/signer-connection": patch
+---
+
+No longer awaits `cleanupPendingPairings` when initiating a connection in `universal-provider` to avoid delaying/blocking the pairing flow

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -136,7 +136,8 @@ export class UniversalProvider implements IUniversalProvider {
       throw new Error("Sign Client not initialized");
     }
     this.setNamespaces(opts);
-    await this.cleanupPendingPairings();
+    // omit `await` to avoid delaying the pairing flow
+    this.cleanupPendingPairings();
     if (opts.skipPairing) return;
 
     return await this.pair(opts.pairingTopic);
@@ -231,20 +232,24 @@ export class UniversalProvider implements IUniversalProvider {
   }
 
   public async cleanupPendingPairings(opts: PairingsCleanupOpts = {}): Promise<void> {
-    this.logger.info("Cleaning up inactive pairings...");
-    const inactivePairings = this.client.pairing.getAll();
+    try {
+      this.logger.info("Cleaning up inactive pairings...");
+      const inactivePairings = this.client.pairing.getAll();
 
-    if (!isValidArray(inactivePairings)) return;
+      if (!isValidArray(inactivePairings)) return;
 
-    for (const pairing of inactivePairings) {
-      if (opts.deletePairings) {
-        this.client.core.expirer.set(pairing.topic, 0);
-      } else {
-        await this.client.core.relayer.subscriber.unsubscribe(pairing.topic);
+      for (const pairing of inactivePairings) {
+        if (opts.deletePairings) {
+          this.client.core.expirer.set(pairing.topic, 0);
+        } else {
+          await this.client.core.relayer.subscriber.unsubscribe(pairing.topic);
+        }
       }
-    }
 
-    this.logger.info(`Inactive pairings cleared: ${inactivePairings.length}`);
+      this.logger.info(`Inactive pairings cleared: ${inactivePairings.length}`);
+    } catch (error) {
+      this.logger.warn("Failed to cleanup pending pairings", error);
+    }
   }
 
   public abortPairingAttempt() {
@@ -596,7 +601,7 @@ export class UniversalProvider implements IUniversalProvider {
     await this.deleteFromStore("sessionProperties");
     // reset the session after removing from store as the topic is used there
     this.session = undefined;
-    await this.cleanupPendingPairings({ deletePairings: true });
+    this.cleanupPendingPairings({ deletePairings: true });
     await this.cleanupStorage();
   }
 


### PR DESCRIPTION
## Description
Removed the awaiting of `cleanupPendingPairings` in `universal-provider` to avoid blocking the pairing flow. 
Awaiting the cleanup util was needlessly increasing the time to produce a connection URI

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
n/a 

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
