### PR TITLE
fix: set default chain unhandled exception

### DIFF
--- a/.changeset/cuddly-insects-send.md
+++ b/.changeset/cuddly-insects-send.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/universal-provider": patch
+"@walletconnect/core": patch
+"@walletconnect/react-native-compat": patch
+"@walletconnect/sign-client": patch
+"@walletconnect/types": patch
+"@walletconnect/utils": patch
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/signer-connection": patch
+---
+
+Fixed an unhandled exception when setting default chain of a generic subProvider in `universal-provider`

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -218,12 +218,7 @@ export class UniversalProvider implements IUniversalProvider {
       if (!this.session) return;
       const [namespace, chainId] = this.validateChain(chain);
       const provider = this.getProvider(namespace);
-      // @ts-expect-error
-      if (provider.name === GENERIC_SUBPROVIDER_NAME) {
-        provider.setDefaultChain(`${namespace}:${chainId}`, rpcUrl);
-      } else {
-        provider.setDefaultChain(chainId, rpcUrl);
-      }
+      provider.setDefaultChain(chainId, rpcUrl);
     } catch (error) {
       // ignore the error if the fx is used prematurely before namespaces are set
       if (!/Please call connect/.test((error as Error).message)) throw error;
@@ -385,13 +380,9 @@ export class UniversalProvider implements IUniversalProvider {
           });
           break;
         default:
-          if (!this.rpcProviders[GENERIC_SUBPROVIDER_NAME]) {
-            this.rpcProviders[GENERIC_SUBPROVIDER_NAME] = new GenericProvider({
-              namespace: combinedNamespace,
-            });
-          } else {
-            this.rpcProviders[GENERIC_SUBPROVIDER_NAME].updateNamespace(combinedNamespace);
-          }
+          this.rpcProviders[namespace] = new GenericProvider({
+            namespace: combinedNamespace,
+          });
       }
     });
   }

--- a/providers/universal-provider/src/providers/generic.ts
+++ b/providers/universal-provider/src/providers/generic.ts
@@ -27,6 +27,7 @@ class GenericProvider implements IProvider {
     this.events = getGlobal("events");
     this.client = getGlobal("client");
     this.chainId = this.getDefaultChain();
+    this.name = this.getNamespaceName();
     this.httpProviders = this.createHttpProviders();
   }
 
@@ -76,6 +77,13 @@ class GenericProvider implements IProvider {
     return chainId.split(":")[1];
   }
 
+  public getNamespaceName(): string {
+    const chainId = this.namespace.chains[0];
+    if (!chainId) throw new Error(`ChainId not found`);
+
+    return parseChainId(chainId).namespace;
+  }
+
   // --------- PRIVATE --------- //
 
   private getAccounts(): string[] {
@@ -99,7 +107,7 @@ class GenericProvider implements IProvider {
     const http = {};
     this.namespace?.accounts?.forEach((account) => {
       const chain = parseChainId(account);
-      http[`${chain.namespace}:${chain.reference}`] = this.createHttpProvider(account);
+      http[chain.reference] = this.createHttpProvider(account);
     });
     return http;
   }

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -1788,20 +1788,30 @@ describe("UniversalProvider", function () {
       );
       await throttle(1_000);
       expect(dapp.rpcProviders).to.be.an("object");
-      expect(dapp.rpcProviders.generic).to.exist;
-      expect(dapp.rpcProviders.generic).to.be.an("object");
+      expect(dapp.rpcProviders.zora).to.exist;
+      expect(dapp.rpcProviders.zora).to.be.an("object");
 
-      const httpProviders = dapp.rpcProviders.generic.httpProviders;
+      const zoraHttpProviders = dapp.rpcProviders.zora.httpProviders;
 
-      expect(Object.keys(httpProviders).length).is.greaterThan(0);
-      expect(Object.keys(httpProviders).length).to.eql(tronChains.length + zoraChains.length);
+      expect(Object.keys(zoraHttpProviders).length).is.greaterThan(0);
+      expect(Object.keys(zoraHttpProviders).length).to.eql(zoraChains.length);
 
-      const allChains = [...tronChains, ...zoraChains];
-      Object.values(httpProviders).forEach((provider, i) => {
+      Object.values(zoraHttpProviders).forEach((provider, i) => {
         const url = provider.connection.url as string;
         expect(url).to.include("https://");
         expect(url).to.include(RPC_URL);
-        expect(url).to.eql(getRpcUrl(allChains[i], {} as Namespace, TEST_PROVIDER_OPTS.projectId));
+        expect(url).to.eql(getRpcUrl(zoraChains[i], {} as Namespace, TEST_PROVIDER_OPTS.projectId));
+      });
+
+      const tronHttpProviders = dapp.rpcProviders.tron.httpProviders;
+      expect(Object.keys(tronHttpProviders).length).is.greaterThan(0);
+      expect(Object.keys(tronHttpProviders).length).to.eql(tronChains.length);
+
+      Object.values(tronHttpProviders).forEach((provider, i) => {
+        const url = provider.connection.url as string;
+        expect(url).to.include("https://");
+        expect(url).to.include(RPC_URL);
+        expect(url).to.eql(getRpcUrl(tronChains[i], {} as Namespace, TEST_PROVIDER_OPTS.projectId));
       });
 
       await deleteProviders({ A: dapp, B: wallet });
@@ -1856,13 +1866,72 @@ describe("UniversalProvider", function () {
       expect(dapp.rpcProviders).to.be.an("object");
       expect(dapp.rpcProviders.eip155).to.exist;
       expect(dapp.rpcProviders.eip155).to.be.an("object");
-      // verify bip122(generic) provider is not created
-      expect(dapp.rpcProviders.generic).to.not.exist;
+      // verify bip122 provider is not created
+      expect(dapp.rpcProviders.bip122).to.not.exist;
 
       const httpProviders = dapp.rpcProviders.eip155.httpProviders;
 
       expect(Object.keys(httpProviders).length).is.greaterThan(0);
 
+      await deleteProviders({ A: dapp, B: wallet });
+    });
+
+    it("should set default chain on generic providers", async () => {
+      const dapp = await UniversalProvider.init({
+        ...TEST_PROVIDER_OPTS,
+        name: "dapp",
+      });
+      const wallet = await UniversalProvider.init({
+        ...TEST_PROVIDER_OPTS,
+        name: "wallet",
+      });
+      const optionalNamespaces = {
+        bip122: {
+          chains: ["bip122:000000000019d6689c085ae165831e93"],
+          events: ["chainChanged"],
+          methods: ["bip122_signTransaction"],
+        },
+        zora: {
+          chains: ["zora:1"],
+          events: ["chainChanged"],
+          methods: ["zora_signTransaction"],
+        },
+      };
+      await testConnectMethod(
+        {
+          dapp,
+          wallet,
+        },
+        {
+          requiredNamespaces: {},
+          optionalNamespaces,
+          namespaces: {
+            bip122: {
+              accounts: [
+                "bip122:000000000019d6689c085ae165831e93:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092",
+              ],
+              chains: ["bip122:000000000019d6689c085ae165831e93"],
+              methods: ["bip122_signTransaction"],
+              events: ["chainChanged"],
+            },
+            zora: {
+              accounts: ["zora:1:0x57f48fAFeC1d76B27e3f29b8d277b6218CDE6092"],
+              chains: ["zora:1"],
+              methods: ["zora_signTransaction"],
+              events: ["chainChanged"],
+            },
+          },
+        },
+      );
+      await throttle(1_000);
+      dapp.setDefaultChain("bip122:000000000019d6689c085ae165831e93");
+      expect(dapp.rpcProviders.bip122.getDefaultChain()).to.eql("000000000019d6689c085ae165831e93");
+      expect(Object.keys(dapp.rpcProviders.bip122.httpProviders)).to.eql([
+        "000000000019d6689c085ae165831e93",
+      ]);
+      dapp.setDefaultChain("zora:1");
+      expect(dapp.rpcProviders.zora.getDefaultChain()).to.eql("1");
+      expect(Object.keys(dapp.rpcProviders.zora.httpProviders)).to.eql(["1"]);
       await deleteProviders({ A: dapp, B: wallet });
     });
   });


### PR DESCRIPTION
## Description
Fixe unhandled exception when setting default chain of a generic sub provider. It was caused due to incorrect usage of the `this.name` variable that holds correct namespace name in other subproviders but not in the `generic` one.
context: https://reown-inc.slack.com/archives/C04DB2EAHE3/p1753257987706779

Also reworked the general generic provider usage such that new instance is created for each namespace rather than reusing a single instance for all namespaces missing a dedicated subprovider - it simplifies usage and maintainability 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests
## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
