### PR TITLE
fix: duplicate `chainChanged` & `accountChanged` events emit from UP

### DIFF
--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -519,14 +519,17 @@ export class UniversalProvider implements IUniversalProvider {
 
     this.updateNamespaceChain(namespace, chainId);
 
-    this.events.emit("chainChanged", chainId);
-
     const previousChainId = this.getProvider(namespace).getDefaultChain();
     if (!internal) {
       this.getProvider(namespace).setDefaultChain(chainId);
+    } else {
+      // emit the events during the `internal` cycle of chain change
+      // otherwise events are emitted twice
+      // once on the chainChanged event and once triggered by `this.getProvider(namespace).setDefaultChain(chainId);`
+      this.events.emit("chainChanged", chainId);
+      this.emitAccountsChangedOnChainChange({ namespace, previousChainId, newChainId: caip2Chain });
     }
 
-    this.emitAccountsChangedOnChainChange({ namespace, previousChainId, newChainId: caip2Chain });
     await this.persist("namespaces", this.namespaces);
   }
 

--- a/providers/universal-provider/test/index.spec.ts
+++ b/providers/universal-provider/test/index.spec.ts
@@ -1876,6 +1876,77 @@ describe("UniversalProvider", function () {
       await deleteProviders({ A: dapp, B: wallet });
     });
 
+    it("should switch btc account on bip122 chainChanged event", async () => {
+      const dapp = await UniversalProvider.init({
+        ...TEST_PROVIDER_OPTS,
+        name: "dapp",
+      });
+      const wallet = await UniversalProvider.init({
+        ...TEST_PROVIDER_OPTS,
+        name: "wallet",
+      });
+      const optionalNamespaces = {
+        bip122: {
+          chains: [
+            "bip122:000000000019d6689c085ae165831e91",
+            "bip122:000000000019d6689c085ae165831e92",
+          ],
+          events: ["chainChanged"],
+          methods: ["bip122_signTransaction"],
+        },
+      };
+      const { sessionA } = await testConnectMethod(
+        {
+          dapp,
+          wallet,
+        },
+        {
+          requiredNamespaces: {},
+          optionalNamespaces,
+          namespaces: {
+            bip122: {
+              accounts: [
+                "bip122:000000000019d6689c085ae165831e91:0x1",
+                "bip122:000000000019d6689c085ae165831e92:0x2",
+              ],
+              chains: [
+                "bip122:000000000019d6689c085ae165831e91",
+                "bip122:000000000019d6689c085ae165831e92",
+              ],
+              methods: ["bip122_signTransaction"],
+              events: ["chainChanged"],
+            },
+          },
+        },
+      );
+      let chainChangedCount = 0;
+      let accountsChangedCount = 0;
+      dapp.on("chainChanged", (chainId) => {
+        expect(chainId).to.eql("000000000019d6689c085ae165831e92");
+        chainChangedCount++;
+      });
+      dapp.on("accountsChanged", (accounts) => {
+        expect(accounts).to.eql(["0x2"]);
+        accountsChangedCount++;
+      });
+
+      await wallet.client.emit({
+        event: {
+          name: "chainChanged",
+          data: "000000000019d6689c085ae165831e92",
+        },
+        chainId: "bip122:000000000019d6689c085ae165831e92",
+        topic: sessionA.topic,
+      });
+
+      await throttle(2_000);
+
+      expect(chainChangedCount).to.eql(1);
+      expect(accountsChangedCount).to.eql(1);
+
+      await deleteProviders({ A: dapp, B: wallet });
+    });
+
     it("should set default chain on generic providers", async () => {
       const dapp = await UniversalProvider.init({
         ...TEST_PROVIDER_OPTS,


### PR DESCRIPTION
## Description
Fixed a bug where duplicate `chainChanged` & `accountChanged` were emitted from `universal-provider` when chain was switched from the wallet side via `session_event`


## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
