### PR TITLE
chore: workflow to release single canary package

### DIFF
--- a/.github/workflows/publish_canary_single.yml
+++ b/.github/workflows/publish_canary_single.yml
@@ -1,0 +1,62 @@
+name: Publish Single Package Canary to NPM
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to release from"
+        required: true
+        default: "v2.0"
+      dir:
+        description: "Path to the package (e.g., packages/pos-client)"
+        required: true
+      canaryVersion:
+        description: "Custom version (e.g., 1.2.3-canary.42)"
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Validate canary version format 🔍
+        run: |
+          VERSION="${{ github.event.inputs.canaryVersion }}"
+          if [[ ! "$VERSION" =~ -canary\. ]]; then
+            echo "❌ Invalid version: '$VERSION'. It must include '-canary.'."
+            exit 1
+          fi
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies and build 🔧
+        run: npm ci && npm run build
+
+      - name: Update package.json in target dir 📦
+        run: |
+          DIR="${{ github.event.inputs.dir }}"
+          VERSION="${{ github.event.inputs.canaryVersion }}"
+
+          if [ ! -f "$DIR/package.json" ]; then
+            echo "❌ No package.json found in $DIR"
+            exit 1
+          fi
+
+          echo "📦 Updating version of $DIR to $VERSION"
+          npm version "$VERSION" --no-git-tag-version --prefix "$DIR"
+
+      - name: Rebuild after version change 🔁
+        run: npm run build
+
+      - name: Publish canary on NPM 🚀
+        run: npm publish --access public --tag canary --workspace ${{ github.event.inputs.dir }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_canary_single.yml
+++ b/.github/workflows/publish_canary_single.yml
@@ -37,9 +37,11 @@ jobs:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Install dependencies and build 🔧
-        run: npm ci && npm run build
+      - name: Install dependencies
+        run: npm ci
 
+      - name: Build project
+        run: npm run build
       - name: Update package.json in target dir 📦
         run: |
           DIR="${{ github.event.inputs.dir }}"


### PR DESCRIPTION
## Description

This PR adds a new GitHub Actions workflow for publishing canary releases of individual packages within a monorepo structure. The workflow allows manual triggering with customizable branch, package directory, and version parameters.

- Adds manual workflow dispatch capability for single package canary releases
- Implements version validation to ensure proper canary format
- Includes package-specific build and publish steps with NPM workspace support

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
n/a

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
