### PR TITLE
fix: single canary publish workflow

### DIFF
--- a/.github/workflows/publish_canary_single.yml
+++ b/.github/workflows/publish_canary_single.yml
@@ -59,6 +59,8 @@ jobs:
         run: npm run build
 
       - name: Publish canary on NPM 🚀
-        run: npm publish --access public --tag canary --workspace ${{ github.event.inputs.dir }}
+        run: |
+          cd ${{ github.event.inputs.dir }}
+          npm publish --access public --tag canary
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_canary_single.yml
+++ b/.github/workflows/publish_canary_single.yml
@@ -37,6 +37,14 @@ jobs:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Validate dir input 📂
+        run: |
+          DIR="${{ github.event.inputs.dir }}"
+          case "$DIR" in
+            packages/*|providers/*) echo "✅ Valid dir: $DIR" ;;
+            *) echo "❌ Invalid dir: $DIR"; exit 1 ;;
+          esac
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/publish_canary_single.yml
+++ b/.github/workflows/publish_canary_single.yml
@@ -40,11 +40,16 @@ jobs:
       - name: Validate dir input 📂
         run: |
           DIR="${{ github.event.inputs.dir }}"
-          case "$DIR" in
-            packages/*|providers/*) echo "✅ Valid dir: $DIR" ;;
-            *) echo "❌ Invalid dir: $DIR"; exit 1 ;;
-          esac
-
+          # Only allow directories like packages/foo or providers/bar (no slashes after the prefix, no .., no special chars)
+          if [[ ! "$DIR" =~ ^(packages|providers)/[a-zA-Z0-9_-]+$ ]]; then
+            echo "❌ Invalid dir: $DIR"
+            exit 1
+          fi
+          if [ ! -d "$DIR" ]; then
+            echo "❌ Directory does not exist: $DIR"
+            exit 1
+          fi
+          echo "✅ Valid dir: $DIR"
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Description

Changing the publish command since `--workspace` doesn't work on new packages

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
