### PR TITLE
fix: 5792 tests validation

### DIFF
--- a/providers/universal-provider/test/5792.spec.ts
+++ b/providers/universal-provider/test/5792.spec.ts
@@ -170,6 +170,7 @@ describe("UniversalProvider 5792 utils", function () {
               ],
               data: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
               blockNumber: "0x15ec918",
+              blockTimestamp: "0x68822a17",
               transactionHash: "0xa52498b3b9a951859235ebaedfc92bcdb4f4b895b6467d71cbd7d65abf64ec41",
               transactionIndex: "0xcd",
               blockHash: "0x2ae77979eecb4655a3adc36e465c0b6aad2bb468426d7f76a0b415e20fcda685",


### PR DESCRIPTION
## Description
Added `blockTimestamp` prop to 5792 tests as nodes started to return it causing the `expect` to fail

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
