### PR TITLE
Fix typo in CACAO recap statement

### DIFF
--- a/packages/utils/src/cacao.ts
+++ b/packages/utils/src/cacao.ts
@@ -357,8 +357,8 @@ export function formatStatementFromRecap(statement = "", recap: RecapType) {
     statementForRecap.push(abilities.join(", ").replace(".,", "."));
   });
 
-  const recapStatemet = statementForRecap.join(" ");
-  const recapStatement = `${base}${recapStatemet}`;
+  const recapStatement = statementForRecap.join(" ");
+  const recapStatement = `${base}${recapStatement}`;
   // add a space if there is a statement
   return `${statement ? statement + " " : ""}${recapStatement}`;
 }


### PR DESCRIPTION

- Correct a minor typo in `packages/utils/src/cacao.ts`

