### PR TITLE
Fix typo in events.spec.ts variable name

### DIFF
--- a/packages/core/test/events.spec.ts
+++ b/packages/core/test/events.spec.ts
@@ -119,11 +119,11 @@ describe("Events Client", () => {
     expect(event.setError).to.exist;
 
     const additionalTrace = ["test trace 3", "test trace 4"];
-    const additionlTraceLenght = additionalTrace.length;
+    const additionlTraceLength = additionalTrace.length;
     const defaultTraceLength = trace.length;
     event.addTrace(additionalTrace[0]);
     event.addTrace(additionalTrace[1]);
-    expect(event.props.properties.trace.length).toEqual(defaultTraceLength + additionlTraceLenght);
+    expect(event.props.properties.trace.length).toEqual(defaultTraceLength + additionlTraceLength);
     expect(event.props.properties.trace).toContain(additionalTrace[0]);
     expect(event.props.properties.trace).toContain(additionalTrace[1]);
   });


### PR DESCRIPTION


### Changes
- Fixed typo: `additionlTraceLenght` → `additionlTraceLength` 



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes typo `additionlTraceLenght` → `additionlTraceLength` in `packages/core/test/events.spec.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86117f97a39e69ae26152684fb3bd4a099769a10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->