### PR TITLE
fix: importing react-native-compat files with correct extension

### DIFF
--- a/.changeset/nice-kiwis-tie.md
+++ b/.changeset/nice-kiwis-tie.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/react-native-compat": patch
+"@walletconnect/core": patch
+"@walletconnect/sign-client": patch
+"@walletconnect/types": patch
+"@walletconnect/utils": patch
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/signer-connection": patch
+"@walletconnect/universal-provider": patch
+---
+
+fix: solved react-native-compat file imports

--- a/packages/react-native-compat/index.js
+++ b/packages/react-native-compat/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
-import { getApplicationModule } from "./module/index.js";
+import { getApplicationModule } from "./module/index.ts";
 
 // Polyfill TextEncode / TextDecode
 import "fast-text-encoding";

--- a/packages/react-native-compat/module/index.ts
+++ b/packages/react-native-compat/module/index.ts
@@ -9,7 +9,7 @@ const LINKING_ERROR =
 const isTurboModuleEnabled = global.__turboModuleProxy != null;
 
 const RNWalletConnectModule = isTurboModuleEnabled
-  ? require("../module/NativeRNWalletConnectModule.js").default
+  ? require("../module/NativeRNWalletConnectModule.ts").default
   : NativeModules.RNWalletConnectModule;
 
 function getExpoModule(): any | undefined {


### PR DESCRIPTION
## Description

FIxed file imports on react-native-compat, using TS extension

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your configuration.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Noticed the error while using the latest version of compat lib

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects TypeScript import paths in react-native-compat and adds patch releases across related packages.
> 
> - **React Native Compat**:
>   - Update imports to TypeScript files for proper resolution:
>     - `packages/react-native-compat/index.js`: `./module/index.ts`
>     - `packages/react-native-compat/module/index.ts`: `../module/NativeRNWalletConnectModule.ts`
> - **Release**:
>   - Add changeset with patch bumps for `@walletconnect/react-native-compat`, `@walletconnect/core`, `@walletconnect/sign-client`, `@walletconnect/types`, `@walletconnect/utils`, `@walletconnect/ethereum-provider`, `@walletconnect/signer-connection`, `@walletconnect/universal-provider`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c879ea935ed2f99c5a01ff3476c7d697677672b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->