### PR TITLE
ci: use actions/checkout@v5

### DIFF
--- a/.github/workflows/ci_sign_client.yml
+++ b/.github/workflows/ci_sign_client.yml
@@ -32,7 +32,7 @@ jobs:
           mask-password: 'true'
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.event.action == 'opened' || github.event.action == 'synchronize'
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: setup-node
         uses: actions/setup-node@v4
         with:
@@ -44,7 +44,7 @@ jobs:
           - prettier
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: setup-node
         uses: actions/setup-node@v4
         with:
@@ -74,7 +74,7 @@ jobs:
       TEST_MOBILE_APP_ID: ${{ vars.TEST_MOBILE_APP_ID }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: setup-node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0

--- a/.github/workflows/publish_canary.yml
+++ b/.github/workflows/publish_canary.yml
@@ -19,7 +19,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/publish_canary_single.yml
+++ b/.github/workflows/publish_canary_single.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/validate_swift.yml
+++ b/.github/workflows/validate_swift.yml
@@ -17,7 +17,7 @@ jobs:
       group: apple-silicon
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: WalletConnect/WalletConnectSwiftV2
 


### PR DESCRIPTION
Upgrade to actions/checkout@v5 for improved performance and stability.