### PR TITLE
chore: updates Appkit to `1.8.11`

### DIFF
--- a/.changeset/stale-buckets-cheer.md
+++ b/.changeset/stale-buckets-cheer.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/core": patch
+"@walletconnect/react-native-compat": patch
+"@walletconnect/sign-client": patch
+"@walletconnect/types": patch
+"@walletconnect/utils": patch
+"@walletconnect/signer-connection": patch
+"@walletconnect/universal-provider": patch
+---
+
+Updated `Appkit` to `1.8.11` in `ethereum-provider`

--- a/package-lock.json
+++ b/package-lock.json
@@ -5310,21 +5310,21 @@
       }
     },
     "node_modules/@reown/appkit": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.8.9.tgz",
-      "integrity": "sha512-e3N2DAzf3Xv3jnoD8IsUo0/Yfwuhk7npwJBe1+9rDJIRwgPsyYcCLD4gKPDFC5IUIfOLqK7YtGOh9oPEUnIWpw==",
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.8.11.tgz",
+      "integrity": "sha512-G96zt1P3ASrivV7HRrFQuzkCEzSmy3ca7cSQxaLeIS+P2VVhjE5YAyINArGVbooY0heHCPvQuTNM+YgK4oBmfg==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.9",
-        "@reown/appkit-controllers": "1.8.9",
-        "@reown/appkit-pay": "1.8.9",
-        "@reown/appkit-polyfills": "1.8.9",
-        "@reown/appkit-scaffold-ui": "1.8.9",
-        "@reown/appkit-ui": "1.8.9",
-        "@reown/appkit-utils": "1.8.9",
-        "@reown/appkit-wallet": "1.8.9",
-        "@walletconnect/universal-provider": "2.21.9",
+        "@reown/appkit-common": "1.8.11",
+        "@reown/appkit-controllers": "1.8.11",
+        "@reown/appkit-pay": "1.8.11",
+        "@reown/appkit-polyfills": "1.8.11",
+        "@reown/appkit-scaffold-ui": "1.8.11",
+        "@reown/appkit-ui": "1.8.11",
+        "@reown/appkit-utils": "1.8.11",
+        "@reown/appkit-wallet": "1.8.11",
+        "@walletconnect/universal-provider": "2.22.4",
         "bs58": "6.0.0",
         "semver": "7.7.2",
         "valtio": "2.1.7",
@@ -5335,9 +5335,9 @@
       }
     },
     "node_modules/@reown/appkit-common": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.9.tgz",
-      "integrity": "sha512-drseYLBDqcQR2WvhfAwrKRiDJdTmsmwZsRBg72sxQDvAwxfKNSmiqsqURq5c/Q9SeeTwclge58Dyq7Ijo6TeeQ==",
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.11.tgz",
+      "integrity": "sha512-rRcxrah6uouqEo/VbniVH11Y3H27BsP+Psv2+Usic+3Rt4kiSImIyeDG1YBV0gZNmME9N3sXHK8Bt7iqkxdOWw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "big.js": "6.2.2",
@@ -5346,265 +5346,36 @@
       }
     },
     "node_modules/@reown/appkit-controllers": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.9.tgz",
-      "integrity": "sha512-/8hgFAgiYCTDG3gSxJr8hXy6GnO28UxN8JOXFUEi5gOODy7d3+3Jwm+7OEghf7hGKrShDedibsXdXKdX1PUT+g==",
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.11.tgz",
+      "integrity": "sha512-V3hPB6NE7kM+7pS8n4ygZWbMh/XoHYxdPWxH3qtDlvYlH9Rgc3yvU8+IFWdB79Ta0lyJIbGqVlQeH5sQe4QOsw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.9",
-        "@reown/appkit-wallet": "1.8.9",
-        "@walletconnect/universal-provider": "2.21.9",
+        "@reown/appkit-common": "1.8.11",
+        "@reown/appkit-wallet": "1.8.11",
+        "@walletconnect/universal-provider": "2.22.4",
         "valtio": "2.1.7",
         "viem": ">=2.37.9"
       }
     },
-    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/core": {
-      "version": "2.21.9",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.21.9.tgz",
-      "integrity": "sha512-SlSknLvbO4i9Y4y8zU0zeCuJv1klQIUX3HRSBs1BaYvQKVVkrdiWPgRj4jcrL2wEOINa9NXw6HXp6x5XCXOolA==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@walletconnect/heartbeat": "1.2.2",
-        "@walletconnect/jsonrpc-provider": "1.0.14",
-        "@walletconnect/jsonrpc-types": "1.0.4",
-        "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "2.1.2",
-        "@walletconnect/relay-api": "1.0.11",
-        "@walletconnect/relay-auth": "1.1.0",
-        "@walletconnect/safe-json": "1.0.2",
-        "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.21.9",
-        "@walletconnect/utils": "2.21.9",
-        "@walletconnect/window-getters": "1.0.1",
-        "es-toolkit": "1.39.3",
-        "events": "3.3.0",
-        "uint8arrays": "3.1.1"
-      },
-      "engines": {
-        "node": ">=18.20.8"
-      }
-    },
-    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/sign-client": {
-      "version": "2.21.9",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.9.tgz",
-      "integrity": "sha512-EKLDS97o1rk/0XilD0nQdSR9SNgRsVoIK5M5HpS9sDTvHPv2EF5pIqu6Xr2vLsKcQ0KnCx+D5bnpav8Yh4NVZg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@walletconnect/core": "2.21.9",
-        "@walletconnect/events": "1.0.1",
-        "@walletconnect/heartbeat": "1.2.2",
-        "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/logger": "2.1.2",
-        "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.21.9",
-        "@walletconnect/utils": "2.21.9",
-        "events": "3.3.0"
-      }
-    },
-    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/types": {
-      "version": "2.21.9",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.9.tgz",
-      "integrity": "sha512-+82TRNX3lGRO96WyLISaBs/FkLts7y4hVgmOI4we84I7XdBu1xsjgiJj0JwYXnurz+X94lTqzOkzPps+wadWKw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@walletconnect/events": "1.0.1",
-        "@walletconnect/heartbeat": "1.2.2",
-        "@walletconnect/jsonrpc-types": "1.0.4",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "2.1.2",
-        "events": "3.3.0"
-      }
-    },
-    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/universal-provider": {
-      "version": "2.21.9",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.21.9.tgz",
-      "integrity": "sha512-dVA9DWSz9jYe37FW5GSRV5zlY9E7rX1kktcDGI7i1/9oG/z9Pk5UKp5r/DFys4Zjml9wZc46R/jlEgeBXTT06A==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@walletconnect/events": "1.0.1",
-        "@walletconnect/jsonrpc-http-connection": "1.0.8",
-        "@walletconnect/jsonrpc-provider": "1.0.14",
-        "@walletconnect/jsonrpc-types": "1.0.4",
-        "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.21.9",
-        "@walletconnect/types": "2.21.9",
-        "@walletconnect/utils": "2.21.9",
-        "es-toolkit": "1.39.3",
-        "events": "3.3.0"
-      }
-    },
-    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/utils": {
-      "version": "2.21.9",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.9.tgz",
-      "integrity": "sha512-FHagysDvp7yQl+74veIeuqwZZnMiTyTW3Lw0NXsbIKnlmlSQu5pma+4EnRD/CnSzbN6PV39k2t1KBaaZ4PjDgg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@msgpack/msgpack": "3.1.2",
-        "@noble/ciphers": "1.3.0",
-        "@noble/curves": "1.9.7",
-        "@noble/hashes": "1.8.0",
-        "@scure/base": "1.2.6",
-        "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/relay-api": "1.0.11",
-        "@walletconnect/relay-auth": "1.1.0",
-        "@walletconnect/safe-json": "1.0.2",
-        "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.21.9",
-        "@walletconnect/window-getters": "1.0.1",
-        "@walletconnect/window-metadata": "1.0.1",
-        "blakejs": "1.2.1",
-        "bs58": "6.0.0",
-        "detect-browser": "5.3.0",
-        "uint8arrays": "3.1.1",
-        "viem": "2.36.0"
-      }
-    },
-    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/utils/node_modules/viem": {
-      "version": "2.36.0",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.36.0.tgz",
-      "integrity": "sha512-Xz7AkGtR43K+NY74X2lBevwfRrsXuifGUzt8QiULO47NXIcT7g3jcA4nIvl5m2OTE5v8SlzishwXmg64xOIVmQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "1.9.6",
-        "@noble/hashes": "1.8.0",
-        "@scure/bip32": "1.7.0",
-        "@scure/bip39": "1.6.0",
-        "abitype": "1.0.8",
-        "isows": "1.0.7",
-        "ox": "0.9.1",
-        "ws": "8.18.3"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/utils/node_modules/viem/node_modules/@noble/curves": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.6.tgz",
-      "integrity": "sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@reown/appkit-controllers/node_modules/abitype": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
-      "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/wevm"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4",
-        "zod": "^3 >=3.22.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@reown/appkit-controllers/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
-    },
-    "node_modules/@reown/appkit-controllers/node_modules/ox": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.1.tgz",
-      "integrity": "sha512-NVI0cajROntJWtFnxZQ1aXDVy+c6DLEXJ3wwON48CgbPhmMJrpRTfVbuppR+47RmXm3lZ/uMaKiFSkLdAO1now==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.11.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "^1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "abitype": "^1.0.8",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@reown/appkit-controllers/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@reown/appkit-pay": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.8.9.tgz",
-      "integrity": "sha512-AEmaPqxnzjawSRFenyiTtq0vjKM5IPb2CTD9wa+OMXFpe6FissO+1Eg1H47sfdrycZCvUizSRmQmYqkJaI8BCw==",
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.8.11.tgz",
+      "integrity": "sha512-68IB3sKfxlCwLz44jvWWpULnmyIGHwnItojrr/PRXUof3z9t/nV8G7FiRY4ZDIo75EkabcIguhtYNSQ7R3vZbA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.9",
-        "@reown/appkit-controllers": "1.8.9",
-        "@reown/appkit-ui": "1.8.9",
-        "@reown/appkit-utils": "1.8.9",
+        "@reown/appkit-common": "1.8.11",
+        "@reown/appkit-controllers": "1.8.11",
+        "@reown/appkit-ui": "1.8.11",
+        "@reown/appkit-utils": "1.8.11",
         "lit": "3.3.0",
         "valtio": "2.1.7"
       }
     },
     "node_modules/@reown/appkit-polyfills": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.9.tgz",
-      "integrity": "sha512-33YCU8dxe4UkpNf9qCAaHx5crSoEu6tbmZxE/0eEPCYRDRXoiH9VGiN7xwTDOVduacg/U8H6/32ibmYZKnRk5Q==",
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.11.tgz",
+      "integrity": "sha512-pP9k5dvtWil88Zv3UgGurtbUmTx47z/5eriClGf8JI0VjBu/IExbAHg2gIZNEFdvkFD5/fIqIg8zno46SKbCKQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "buffer": "6.0.3"
@@ -5635,46 +5406,46 @@
       }
     },
     "node_modules/@reown/appkit-scaffold-ui": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.8.9.tgz",
-      "integrity": "sha512-F7PSM1nxvlvj2eu8iL355GzvCNiL8RKiCqT1zag8aB4QpxjU24l+vAF6debtkg4HY8nJOyDifZ7Z1jkKrHlIDQ==",
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.8.11.tgz",
+      "integrity": "sha512-oCEhNdUh2d59UHp/rLwfzv5odWg0pw000fg4Z53orjnKzcZfBpBDM00I9hu2pijnaYitJVqwsqCQ1F1q6hju/Q==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.9",
-        "@reown/appkit-controllers": "1.8.9",
-        "@reown/appkit-ui": "1.8.9",
-        "@reown/appkit-utils": "1.8.9",
-        "@reown/appkit-wallet": "1.8.9",
+        "@reown/appkit-common": "1.8.11",
+        "@reown/appkit-controllers": "1.8.11",
+        "@reown/appkit-ui": "1.8.11",
+        "@reown/appkit-utils": "1.8.11",
+        "@reown/appkit-wallet": "1.8.11",
         "lit": "3.3.0"
       }
     },
     "node_modules/@reown/appkit-ui": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.9.tgz",
-      "integrity": "sha512-WR17ql77KOMKfyDh7RW4oSfmj+p5gIl0u8Wmopzbx5Hd0HcPVZ5HmTDpwOM9WCSxYcin0fsSAoI+nVdvrhWNtw==",
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.11.tgz",
+      "integrity": "sha512-kBWZCiGaB/M2exIiDglsaTWYsWR0L89WXi7IFA6RgW0B0piYv5eiS3l/KPNj9/zxK8UnKsGsMefxl/UK/QqMng==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@phosphor-icons/webcomponents": "2.1.5",
-        "@reown/appkit-common": "1.8.9",
-        "@reown/appkit-controllers": "1.8.9",
-        "@reown/appkit-wallet": "1.8.9",
+        "@reown/appkit-common": "1.8.11",
+        "@reown/appkit-controllers": "1.8.11",
+        "@reown/appkit-wallet": "1.8.11",
         "lit": "3.3.0",
         "qrcode": "1.5.3"
       }
     },
     "node_modules/@reown/appkit-utils": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.9.tgz",
-      "integrity": "sha512-U9hx4h7tIE7ha/QWKjZpZc/imaLumdwe0QNdku9epjp/npXVjGuwUrW5mj8yWNSkjtQpY/BEItNdDAUKZ7rrjw==",
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.11.tgz",
+      "integrity": "sha512-6Wplz7LNe2HoxHmGGYT6FIp8saa0DzVP/427jlNuWpkL65/azPyYjA8tKptxbFWViQ4VYBsqLoQxivXC/xNMBg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.9",
-        "@reown/appkit-controllers": "1.8.9",
-        "@reown/appkit-polyfills": "1.8.9",
-        "@reown/appkit-wallet": "1.8.9",
+        "@reown/appkit-common": "1.8.11",
+        "@reown/appkit-controllers": "1.8.11",
+        "@reown/appkit-polyfills": "1.8.11",
+        "@reown/appkit-wallet": "1.8.11",
         "@wallet-standard/wallet": "1.1.0",
-        "@walletconnect/logger": "2.1.2",
-        "@walletconnect/universal-provider": "2.21.9",
+        "@walletconnect/logger": "^3.0.0",
+        "@walletconnect/universal-provider": "2.22.4",
         "valtio": "2.1.7",
         "viem": ">=2.37.9"
       },
@@ -5682,474 +5453,16 @@
         "valtio": "2.1.7"
       }
     },
-    "node_modules/@reown/appkit-utils/node_modules/@walletconnect/core": {
-      "version": "2.21.9",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.21.9.tgz",
-      "integrity": "sha512-SlSknLvbO4i9Y4y8zU0zeCuJv1klQIUX3HRSBs1BaYvQKVVkrdiWPgRj4jcrL2wEOINa9NXw6HXp6x5XCXOolA==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@walletconnect/heartbeat": "1.2.2",
-        "@walletconnect/jsonrpc-provider": "1.0.14",
-        "@walletconnect/jsonrpc-types": "1.0.4",
-        "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "2.1.2",
-        "@walletconnect/relay-api": "1.0.11",
-        "@walletconnect/relay-auth": "1.1.0",
-        "@walletconnect/safe-json": "1.0.2",
-        "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.21.9",
-        "@walletconnect/utils": "2.21.9",
-        "@walletconnect/window-getters": "1.0.1",
-        "es-toolkit": "1.39.3",
-        "events": "3.3.0",
-        "uint8arrays": "3.1.1"
-      },
-      "engines": {
-        "node": ">=18.20.8"
-      }
-    },
-    "node_modules/@reown/appkit-utils/node_modules/@walletconnect/sign-client": {
-      "version": "2.21.9",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.9.tgz",
-      "integrity": "sha512-EKLDS97o1rk/0XilD0nQdSR9SNgRsVoIK5M5HpS9sDTvHPv2EF5pIqu6Xr2vLsKcQ0KnCx+D5bnpav8Yh4NVZg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@walletconnect/core": "2.21.9",
-        "@walletconnect/events": "1.0.1",
-        "@walletconnect/heartbeat": "1.2.2",
-        "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/logger": "2.1.2",
-        "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.21.9",
-        "@walletconnect/utils": "2.21.9",
-        "events": "3.3.0"
-      }
-    },
-    "node_modules/@reown/appkit-utils/node_modules/@walletconnect/types": {
-      "version": "2.21.9",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.9.tgz",
-      "integrity": "sha512-+82TRNX3lGRO96WyLISaBs/FkLts7y4hVgmOI4we84I7XdBu1xsjgiJj0JwYXnurz+X94lTqzOkzPps+wadWKw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@walletconnect/events": "1.0.1",
-        "@walletconnect/heartbeat": "1.2.2",
-        "@walletconnect/jsonrpc-types": "1.0.4",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "2.1.2",
-        "events": "3.3.0"
-      }
-    },
-    "node_modules/@reown/appkit-utils/node_modules/@walletconnect/universal-provider": {
-      "version": "2.21.9",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.21.9.tgz",
-      "integrity": "sha512-dVA9DWSz9jYe37FW5GSRV5zlY9E7rX1kktcDGI7i1/9oG/z9Pk5UKp5r/DFys4Zjml9wZc46R/jlEgeBXTT06A==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@walletconnect/events": "1.0.1",
-        "@walletconnect/jsonrpc-http-connection": "1.0.8",
-        "@walletconnect/jsonrpc-provider": "1.0.14",
-        "@walletconnect/jsonrpc-types": "1.0.4",
-        "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.21.9",
-        "@walletconnect/types": "2.21.9",
-        "@walletconnect/utils": "2.21.9",
-        "es-toolkit": "1.39.3",
-        "events": "3.3.0"
-      }
-    },
-    "node_modules/@reown/appkit-utils/node_modules/@walletconnect/utils": {
-      "version": "2.21.9",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.9.tgz",
-      "integrity": "sha512-FHagysDvp7yQl+74veIeuqwZZnMiTyTW3Lw0NXsbIKnlmlSQu5pma+4EnRD/CnSzbN6PV39k2t1KBaaZ4PjDgg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@msgpack/msgpack": "3.1.2",
-        "@noble/ciphers": "1.3.0",
-        "@noble/curves": "1.9.7",
-        "@noble/hashes": "1.8.0",
-        "@scure/base": "1.2.6",
-        "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/relay-api": "1.0.11",
-        "@walletconnect/relay-auth": "1.1.0",
-        "@walletconnect/safe-json": "1.0.2",
-        "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.21.9",
-        "@walletconnect/window-getters": "1.0.1",
-        "@walletconnect/window-metadata": "1.0.1",
-        "blakejs": "1.2.1",
-        "bs58": "6.0.0",
-        "detect-browser": "5.3.0",
-        "uint8arrays": "3.1.1",
-        "viem": "2.36.0"
-      }
-    },
-    "node_modules/@reown/appkit-utils/node_modules/@walletconnect/utils/node_modules/viem": {
-      "version": "2.36.0",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.36.0.tgz",
-      "integrity": "sha512-Xz7AkGtR43K+NY74X2lBevwfRrsXuifGUzt8QiULO47NXIcT7g3jcA4nIvl5m2OTE5v8SlzishwXmg64xOIVmQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "1.9.6",
-        "@noble/hashes": "1.8.0",
-        "@scure/bip32": "1.7.0",
-        "@scure/bip39": "1.6.0",
-        "abitype": "1.0.8",
-        "isows": "1.0.7",
-        "ox": "0.9.1",
-        "ws": "8.18.3"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@reown/appkit-utils/node_modules/@walletconnect/utils/node_modules/viem/node_modules/@noble/curves": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.6.tgz",
-      "integrity": "sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@reown/appkit-utils/node_modules/abitype": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
-      "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/wevm"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4",
-        "zod": "^3 >=3.22.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@reown/appkit-utils/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
-    },
-    "node_modules/@reown/appkit-utils/node_modules/ox": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.1.tgz",
-      "integrity": "sha512-NVI0cajROntJWtFnxZQ1aXDVy+c6DLEXJ3wwON48CgbPhmMJrpRTfVbuppR+47RmXm3lZ/uMaKiFSkLdAO1now==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.11.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "^1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "abitype": "^1.0.8",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@reown/appkit-utils/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@reown/appkit-wallet": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.9.tgz",
-      "integrity": "sha512-rcAXvkzOVG4941eZVCGtr2dSJAMOclzZGSe+8hnOUnhK4zxa5svxiP6K9O5SMBp3MrAS3WNsRj5hqx6+JHb7iA==",
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.11.tgz",
+      "integrity": "sha512-tCzrieMuOD4tDcNQjMe83T38tJUfRdv4LG+cYGyGK1RpPGaszbq06TQVbCPkRrGiTELwkrKwXjSg1XAuHktS2w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.9",
-        "@reown/appkit-polyfills": "1.8.9",
-        "@walletconnect/logger": "2.1.2",
+        "@reown/appkit-common": "1.8.11",
+        "@reown/appkit-polyfills": "1.8.11",
+        "@walletconnect/logger": "^3.0.0",
         "zod": "3.22.4"
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/@walletconnect/core": {
-      "version": "2.21.9",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.21.9.tgz",
-      "integrity": "sha512-SlSknLvbO4i9Y4y8zU0zeCuJv1klQIUX3HRSBs1BaYvQKVVkrdiWPgRj4jcrL2wEOINa9NXw6HXp6x5XCXOolA==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@walletconnect/heartbeat": "1.2.2",
-        "@walletconnect/jsonrpc-provider": "1.0.14",
-        "@walletconnect/jsonrpc-types": "1.0.4",
-        "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "2.1.2",
-        "@walletconnect/relay-api": "1.0.11",
-        "@walletconnect/relay-auth": "1.1.0",
-        "@walletconnect/safe-json": "1.0.2",
-        "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.21.9",
-        "@walletconnect/utils": "2.21.9",
-        "@walletconnect/window-getters": "1.0.1",
-        "es-toolkit": "1.39.3",
-        "events": "3.3.0",
-        "uint8arrays": "3.1.1"
-      },
-      "engines": {
-        "node": ">=18.20.8"
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/@walletconnect/sign-client": {
-      "version": "2.21.9",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.9.tgz",
-      "integrity": "sha512-EKLDS97o1rk/0XilD0nQdSR9SNgRsVoIK5M5HpS9sDTvHPv2EF5pIqu6Xr2vLsKcQ0KnCx+D5bnpav8Yh4NVZg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@walletconnect/core": "2.21.9",
-        "@walletconnect/events": "1.0.1",
-        "@walletconnect/heartbeat": "1.2.2",
-        "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/logger": "2.1.2",
-        "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.21.9",
-        "@walletconnect/utils": "2.21.9",
-        "events": "3.3.0"
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/@walletconnect/types": {
-      "version": "2.21.9",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.9.tgz",
-      "integrity": "sha512-+82TRNX3lGRO96WyLISaBs/FkLts7y4hVgmOI4we84I7XdBu1xsjgiJj0JwYXnurz+X94lTqzOkzPps+wadWKw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@walletconnect/events": "1.0.1",
-        "@walletconnect/heartbeat": "1.2.2",
-        "@walletconnect/jsonrpc-types": "1.0.4",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "2.1.2",
-        "events": "3.3.0"
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/@walletconnect/universal-provider": {
-      "version": "2.21.9",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.21.9.tgz",
-      "integrity": "sha512-dVA9DWSz9jYe37FW5GSRV5zlY9E7rX1kktcDGI7i1/9oG/z9Pk5UKp5r/DFys4Zjml9wZc46R/jlEgeBXTT06A==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@walletconnect/events": "1.0.1",
-        "@walletconnect/jsonrpc-http-connection": "1.0.8",
-        "@walletconnect/jsonrpc-provider": "1.0.14",
-        "@walletconnect/jsonrpc-types": "1.0.4",
-        "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.21.9",
-        "@walletconnect/types": "2.21.9",
-        "@walletconnect/utils": "2.21.9",
-        "es-toolkit": "1.39.3",
-        "events": "3.3.0"
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/@walletconnect/utils": {
-      "version": "2.21.9",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.9.tgz",
-      "integrity": "sha512-FHagysDvp7yQl+74veIeuqwZZnMiTyTW3Lw0NXsbIKnlmlSQu5pma+4EnRD/CnSzbN6PV39k2t1KBaaZ4PjDgg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@msgpack/msgpack": "3.1.2",
-        "@noble/ciphers": "1.3.0",
-        "@noble/curves": "1.9.7",
-        "@noble/hashes": "1.8.0",
-        "@scure/base": "1.2.6",
-        "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/relay-api": "1.0.11",
-        "@walletconnect/relay-auth": "1.1.0",
-        "@walletconnect/safe-json": "1.0.2",
-        "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.21.9",
-        "@walletconnect/window-getters": "1.0.1",
-        "@walletconnect/window-metadata": "1.0.1",
-        "blakejs": "1.2.1",
-        "bs58": "6.0.0",
-        "detect-browser": "5.3.0",
-        "uint8arrays": "3.1.1",
-        "viem": "2.36.0"
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/@walletconnect/utils/node_modules/viem": {
-      "version": "2.36.0",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.36.0.tgz",
-      "integrity": "sha512-Xz7AkGtR43K+NY74X2lBevwfRrsXuifGUzt8QiULO47NXIcT7g3jcA4nIvl5m2OTE5v8SlzishwXmg64xOIVmQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "1.9.6",
-        "@noble/hashes": "1.8.0",
-        "@scure/bip32": "1.7.0",
-        "@scure/bip39": "1.6.0",
-        "abitype": "1.0.8",
-        "isows": "1.0.7",
-        "ox": "0.9.1",
-        "ws": "8.18.3"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/@walletconnect/utils/node_modules/viem/node_modules/@noble/curves": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.6.tgz",
-      "integrity": "sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/abitype": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
-      "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/wevm"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4",
-        "zod": "^3 >=3.22.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
-    },
-    "node_modules/@reown/appkit/node_modules/ox": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.1.tgz",
-      "integrity": "sha512-NVI0cajROntJWtFnxZQ1aXDVy+c6DLEXJ3wwON48CgbPhmMJrpRTfVbuppR+47RmXm3lZ/uMaKiFSkLdAO1now==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.11.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "^1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "abitype": "^1.0.8",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/@rollup/plugin-alias": {
@@ -8268,13 +7581,13 @@
       }
     },
     "node_modules/@walletconnect/logger": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.2.tgz",
-      "integrity": "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
       "license": "MIT",
       "dependencies": {
         "@walletconnect/safe-json": "^1.0.2",
-        "pino": "7.11.0"
+        "pino": "10.0.0"
       }
     },
     "node_modules/@walletconnect/react-native-compat": {
@@ -10660,18 +9973,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/duplexify": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
-      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.4.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1",
-        "stream-shift": "^1.0.2"
-      }
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -10758,6 +10059,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -12127,15 +11429,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-redact": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/fast-text-encoding": {
       "version": "1.0.6",
@@ -17559,10 +16852,13 @@
       }
     },
     "node_modules/on-exit-leak-free": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
-      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==",
-      "license": "MIT"
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/on-finished": {
       "version": "2.3.0",
@@ -18478,34 +17774,33 @@
       }
     },
     "node_modules/pino": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
-      "integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.0.0",
-        "on-exit-leak-free": "^0.2.0",
-        "pino-abstract-transport": "v0.5.0",
-        "pino-std-serializers": "^4.0.0",
-        "process-warning": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
         "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.1.0",
-        "safe-stable-stringify": "^2.1.0",
-        "sonic-boom": "^2.2.1",
-        "thread-stream": "^0.15.1"
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
       },
       "bin": {
         "pino": "bin.js"
       }
     },
     "node_modules/pino-abstract-transport": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
-      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
       "license": "MIT",
       "dependencies": {
-        "duplexify": "^4.1.2",
         "split2": "^4.0.0"
       }
     },
@@ -18519,9 +17814,9 @@
       }
     },
     "node_modules/pino-std-serializers": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
-      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
       "license": "MIT"
     },
     "node_modules/pirates": {
@@ -18694,9 +17989,19 @@
       "license": "MIT"
     },
     "node_modules/process-warning": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
-      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/proggy": {
@@ -19414,6 +18719,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -19425,9 +18731,9 @@
       }
     },
     "node_modules/real-require": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
-      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
@@ -19848,6 +19154,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -20267,9 +19574,9 @@
       }
     },
     "node_modules/slow-redact": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.1.tgz",
-      "integrity": "sha512-NvFvl1GuLZNW4U046Tfi8b26zXo8aBzgCAS2f7yVJR/fArN93mOqSA99cB9uITm92ajSz01bsu1K7SCVVjIMpQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
+      "integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==",
       "license": "MIT"
     },
     "node_modules/smart-buffer": {
@@ -20324,9 +19631,9 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
-      "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -20562,16 +19869,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/stream-shift": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
-      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-      "license": "MIT"
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -21032,12 +20334,12 @@
       "license": "MIT"
     },
     "node_modules/thread-stream": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
-      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
       "license": "MIT",
       "dependencies": {
-        "real-require": "^0.1.0"
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/throat": {
@@ -21878,6 +21180,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -21950,9 +21253,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.38.0",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.38.0.tgz",
-      "integrity": "sha512-YU5TG8dgBNeYPrCMww0u9/JVeq2ZCk9fzk6QybrPkBooFysamHXL1zC3ua10aLPt9iWoA/gSVf1D9w7nc5B1aA==",
+      "version": "2.38.3",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.38.3.tgz",
+      "integrity": "sha512-By2TutLv07iNHHtWqHHzjGipevYsfGqT7KQbGEmqLco1qTJxKnvBbSviqiu6/v/9REV6Q/FpmIxf2Z7/l5AbcQ==",
       "funding": [
         {
           "type": "github",
@@ -23563,114 +22866,6 @@
         "node": ">=18.20.8"
       }
     },
-    "packages/core/node_modules/@walletconnect/logger": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
-      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
-      "license": "MIT",
-      "dependencies": {
-        "@walletconnect/safe-json": "^1.0.2",
-        "pino": "10.0.0"
-      }
-    },
-    "packages/core/node_modules/on-exit-leak-free": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
-      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "packages/core/node_modules/pino": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
-      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^2.0.0",
-        "pino-std-serializers": "^7.0.0",
-        "process-warning": "^5.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.2.0",
-        "safe-stable-stringify": "^2.3.1",
-        "slow-redact": "^0.3.0",
-        "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "packages/core/node_modules/pino-abstract-transport": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
-      "license": "MIT",
-      "dependencies": {
-        "split2": "^4.0.0"
-      }
-    },
-    "packages/core/node_modules/pino-std-serializers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
-      "license": "MIT"
-    },
-    "packages/core/node_modules/process-warning": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
-    "packages/core/node_modules/real-require": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
-      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.13.0"
-      }
-    },
-    "packages/core/node_modules/sonic-boom": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
-      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
-    "packages/core/node_modules/split2": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "packages/core/node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-      "license": "MIT",
-      "dependencies": {
-        "real-require": "^0.2.0"
-      }
-    },
     "packages/react-native-compat": {
       "name": "@walletconnect/react-native-compat",
       "version": "2.22.4",
@@ -23756,16 +22951,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "packages/sign-client/node_modules/@walletconnect/logger": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
-      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
-      "license": "MIT",
-      "dependencies": {
-        "@walletconnect/safe-json": "^1.0.2",
-        "pino": "10.0.0"
-      }
-    },
     "packages/sign-client/node_modules/ethers": {
       "version": "6.13.5",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.5.tgz",
@@ -23793,104 +22978,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "packages/sign-client/node_modules/on-exit-leak-free": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
-      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "packages/sign-client/node_modules/pino": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
-      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^2.0.0",
-        "pino-std-serializers": "^7.0.0",
-        "process-warning": "^5.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.2.0",
-        "safe-stable-stringify": "^2.3.1",
-        "slow-redact": "^0.3.0",
-        "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "packages/sign-client/node_modules/pino-abstract-transport": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
-      "license": "MIT",
-      "dependencies": {
-        "split2": "^4.0.0"
-      }
-    },
-    "packages/sign-client/node_modules/pino-std-serializers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
-      "license": "MIT"
-    },
-    "packages/sign-client/node_modules/process-warning": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
-    "packages/sign-client/node_modules/real-require": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
-      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.13.0"
-      }
-    },
-    "packages/sign-client/node_modules/sonic-boom": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
-      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
-    "packages/sign-client/node_modules/split2": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "packages/sign-client/node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-      "license": "MIT",
-      "dependencies": {
-        "real-require": "^0.2.0"
       }
     },
     "packages/sign-client/node_modules/tslib": {
@@ -23942,114 +23029,6 @@
         "events": "3.3.0"
       }
     },
-    "packages/types/node_modules/@walletconnect/logger": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
-      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
-      "license": "MIT",
-      "dependencies": {
-        "@walletconnect/safe-json": "^1.0.2",
-        "pino": "10.0.0"
-      }
-    },
-    "packages/types/node_modules/on-exit-leak-free": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
-      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "packages/types/node_modules/pino": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
-      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^2.0.0",
-        "pino-std-serializers": "^7.0.0",
-        "process-warning": "^5.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.2.0",
-        "safe-stable-stringify": "^2.3.1",
-        "slow-redact": "^0.3.0",
-        "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "packages/types/node_modules/pino-abstract-transport": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
-      "license": "MIT",
-      "dependencies": {
-        "split2": "^4.0.0"
-      }
-    },
-    "packages/types/node_modules/pino-std-serializers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
-      "license": "MIT"
-    },
-    "packages/types/node_modules/process-warning": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
-    "packages/types/node_modules/real-require": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
-      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.13.0"
-      }
-    },
-    "packages/types/node_modules/sonic-boom": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
-      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
-    "packages/types/node_modules/split2": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "packages/types/node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-      "license": "MIT",
-      "dependencies": {
-        "real-require": "^0.2.0"
-      }
-    },
     "packages/utils": {
       "name": "@walletconnect/utils",
       "version": "2.22.4",
@@ -24081,16 +23060,6 @@
         "@walletconnect/jsonrpc-types": "1.0.4"
       }
     },
-    "packages/utils/node_modules/@walletconnect/logger": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
-      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
-      "license": "MIT",
-      "dependencies": {
-        "@walletconnect/safe-json": "^1.0.2",
-        "pino": "10.0.0"
-      }
-    },
     "packages/utils/node_modules/abitype": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.1.1.tgz",
@@ -24117,15 +23086,6 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
-    },
-    "packages/utils/node_modules/on-exit-leak-free": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
-      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "packages/utils/node_modules/ox": {
       "version": "0.9.3",
@@ -24172,101 +23132,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "packages/utils/node_modules/pino": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
-      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^2.0.0",
-        "pino-std-serializers": "^7.0.0",
-        "process-warning": "^5.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.2.0",
-        "safe-stable-stringify": "^2.3.1",
-        "slow-redact": "^0.3.0",
-        "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "packages/utils/node_modules/pino-abstract-transport": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
-      "license": "MIT",
-      "dependencies": {
-        "split2": "^4.0.0"
-      }
-    },
-    "packages/utils/node_modules/pino-std-serializers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
-      "license": "MIT"
-    },
-    "packages/utils/node_modules/process-warning": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
-    "packages/utils/node_modules/real-require": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
-      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.13.0"
-      }
-    },
-    "packages/utils/node_modules/sonic-boom": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
-      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
-    "packages/utils/node_modules/split2": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "packages/utils/node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-      "license": "MIT",
-      "dependencies": {
-        "real-require": "^0.2.0"
-      }
-    },
     "providers/ethereum-provider": {
       "name": "@walletconnect/ethereum-provider",
       "version": "2.22.4",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit": "1.8.9",
+        "@reown/appkit": "1.8.11",
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
         "@walletconnect/jsonrpc-provider": "1.0.14",
         "@walletconnect/jsonrpc-types": "1.0.4",
@@ -24309,16 +23180,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "providers/ethereum-provider/node_modules/@walletconnect/logger": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
-      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
-      "license": "MIT",
-      "dependencies": {
-        "@walletconnect/safe-json": "^1.0.2",
-        "pino": "10.0.0"
       }
     },
     "providers/ethereum-provider/node_modules/chalk": {
@@ -24364,15 +23225,6 @@
         "hardhat": "dist/src/cli.js"
       }
     },
-    "providers/ethereum-provider/node_modules/on-exit-leak-free": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
-      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "providers/ethereum-provider/node_modules/p-map": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
@@ -24384,95 +23236,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "providers/ethereum-provider/node_modules/pino": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
-      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^2.0.0",
-        "pino-std-serializers": "^7.0.0",
-        "process-warning": "^5.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.2.0",
-        "safe-stable-stringify": "^2.3.1",
-        "slow-redact": "^0.3.0",
-        "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "providers/ethereum-provider/node_modules/pino-abstract-transport": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
-      "license": "MIT",
-      "dependencies": {
-        "split2": "^4.0.0"
-      }
-    },
-    "providers/ethereum-provider/node_modules/pino-std-serializers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
-      "license": "MIT"
-    },
-    "providers/ethereum-provider/node_modules/process-warning": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
-    "providers/ethereum-provider/node_modules/real-require": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
-      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.13.0"
-      }
-    },
-    "providers/ethereum-provider/node_modules/sonic-boom": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
-      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
-    "providers/ethereum-provider/node_modules/split2": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "providers/ethereum-provider/node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-      "license": "MIT",
-      "dependencies": {
-        "real-require": "^0.2.0"
       }
     },
     "providers/ethereum-provider/node_modules/uint8arrays": {
@@ -24581,16 +23344,6 @@
         "node": ">=18"
       }
     },
-    "providers/universal-provider/node_modules/@walletconnect/logger": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
-      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
-      "license": "MIT",
-      "dependencies": {
-        "@walletconnect/safe-json": "^1.0.2",
-        "pino": "10.0.0"
-      }
-    },
     "providers/universal-provider/node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -24634,15 +23387,6 @@
         "hardhat": "dist/src/cli.js"
       }
     },
-    "providers/universal-provider/node_modules/on-exit-leak-free": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
-      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "providers/universal-provider/node_modules/p-map": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
@@ -24654,95 +23398,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "providers/universal-provider/node_modules/pino": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
-      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^2.0.0",
-        "pino-std-serializers": "^7.0.0",
-        "process-warning": "^5.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.2.0",
-        "safe-stable-stringify": "^2.3.1",
-        "slow-redact": "^0.3.0",
-        "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "providers/universal-provider/node_modules/pino-abstract-transport": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
-      "license": "MIT",
-      "dependencies": {
-        "split2": "^4.0.0"
-      }
-    },
-    "providers/universal-provider/node_modules/pino-std-serializers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
-      "license": "MIT"
-    },
-    "providers/universal-provider/node_modules/process-warning": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
-    "providers/universal-provider/node_modules/real-require": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
-      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.13.0"
-      }
-    },
-    "providers/universal-provider/node_modules/sonic-boom": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
-      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
-    "providers/universal-provider/node_modules/split2": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "providers/universal-provider/node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-      "license": "MIT",
-      "dependencies": {
-        "real-require": "^0.2.0"
       }
     },
     "providers/universal-provider/node_modules/uint8arrays": {

--- a/providers/ethereum-provider/package.json
+++ b/providers/ethereum-provider/package.json
@@ -45,7 +45,7 @@
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },
   "dependencies": {
-    "@reown/appkit": "1.8.9",
+    "@reown/appkit": "1.8.11",
     "@walletconnect/jsonrpc-http-connection": "1.0.8",
     "@walletconnect/jsonrpc-provider": "1.0.14",
     "@walletconnect/jsonrpc-types": "1.0.4",


### PR DESCRIPTION
## Description
This PR updates the @reown/appkit dependency from version 1.8.9 to 1.8.11 in the ethereum-provider package.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
n/a

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps @reown/appkit to 1.8.11 in ethereum-provider and refreshes lockfile with related dependency updates.
> 
> - **ethereum-provider**:
>   - Update `@reown/appkit` from `1.8.9` to `1.8.11` in `providers/ethereum-provider/package.json`.
> - **Dependencies/Lockfile**:
>   - Cascade updates to AppKit subpackages (`1.8.11`) and `@walletconnect/universal-provider` (`2.22.4`).
>   - Upgrade logging stack: `@walletconnect/logger` `3.0.0` → `pino` `10.x` (and related transitive deps).
>   - Misc transitive bumps (e.g., `viem` `2.38.3`, `ox` `0.9.3`, `slow-redact`, `sonic-boom`, etc.).
> - **Changeset**:
>   - Add patch changeset noting Appkit update for multiple packages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 793bfe86780e08bd58848077e47786befbf93184. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->