### PR TITLE
refactor: changed logs error level to warn

### DIFF
--- a/packages/core/src/controllers/crypto.ts
+++ b/packages/core/src/controllers/crypto.ts
@@ -154,10 +154,10 @@ export class Crypto implements ICrypto {
       const payload = safeJsonParse(message);
       return payload;
     } catch (error) {
-      this.logger.error(
+      this.logger.warn(
         `Failed to decode message from topic: '${topic}', clientId: '${await this.getClientId()}'`,
       );
-      this.logger.error(error);
+      this.logger.warn(error);
     }
   };
 

--- a/packages/core/src/controllers/expirer.ts
+++ b/packages/core/src/controllers/expirer.ts
@@ -153,7 +153,7 @@ export class Expirer extends IExpirer {
       if (!persisted.length) return;
       if (this.expirations.size) {
         const { message } = getInternalError("RESTORE_WILL_OVERRIDE", this.name);
-        this.logger.error(message);
+        this.logger.warn(message);
         throw new Error(message);
       }
       this.cached = persisted;
@@ -161,7 +161,7 @@ export class Expirer extends IExpirer {
       this.logger.trace({ type: "method", method: "restore", expirations: this.values });
     } catch (e) {
       this.logger.debug(`Failed to Restore expirations for ${this.name}`);
-      this.logger.error(e as any);
+      this.logger.warn(e as any);
     }
   }
 

--- a/packages/core/src/controllers/history.ts
+++ b/packages/core/src/controllers/history.ts
@@ -185,7 +185,7 @@ export class JsonRpcHistory extends IJsonRpcHistory {
       if (!persisted.length) return;
       if (this.records.size) {
         const { message } = getInternalError("RESTORE_WILL_OVERRIDE", this.name);
-        this.logger.error(message);
+        this.logger.warn(message);
         throw new Error(message);
       }
       this.cached = persisted;
@@ -193,7 +193,7 @@ export class JsonRpcHistory extends IJsonRpcHistory {
       this.logger.trace({ type: "method", method: "restore", records: this.values });
     } catch (e) {
       this.logger.debug(`Failed to Restore records for ${this.name}`);
-      this.logger.error(e as any);
+      this.logger.warn(e as any);
     }
   }
 

--- a/packages/core/src/controllers/messages.ts
+++ b/packages/core/src/controllers/messages.ts
@@ -47,7 +47,7 @@ export class MessageTracker extends IMessageTracker {
         this.logger.trace({ type: "method", method: "restore", size: this.messages.size });
       } catch (e) {
         this.logger.debug(`Failed to Restore records for ${this.name}`);
-        this.logger.error(e as any);
+        this.logger.warn(e as any);
       } finally {
         this.initialized = true;
       }

--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -342,7 +342,7 @@ export class Pairing implements IPairing {
         }
         await this.core.relayer.messages.ack(topic, message);
       } catch (error) {
-        this.logger.error(error);
+        this.logger.warn(error);
       }
     });
   }
@@ -385,7 +385,7 @@ export class Pairing implements IPairing {
       this.events.emit(PAIRING_EVENTS.ping, { id, topic });
     } catch (err: any) {
       await this.sendError(id, topic, err);
-      this.logger.error(err);
+      this.logger.warn(err);
     }
   };
 
@@ -413,7 +413,7 @@ export class Pairing implements IPairing {
       this.events.emit(PAIRING_EVENTS.delete, { id, topic });
     } catch (err: any) {
       await this.sendError(id, topic, err);
-      this.logger.error(err);
+      this.logger.warn(err);
     }
   };
 
@@ -428,17 +428,17 @@ export class Pairing implements IPairing {
       if (this.registeredMethods.includes(method)) return;
       const error = getSdkError("WC_METHOD_UNSUPPORTED", method);
       await this.sendError(id, topic, error);
-      this.logger.error(error);
+      this.logger.warn(error);
     } catch (err: any) {
       await this.sendError(id, topic, err);
-      this.logger.error(err);
+      this.logger.warn(err);
     }
   };
 
   private onUnknownRpcMethodResponse: IPairingPrivate["onUnknownRpcMethodResponse"] = (method) => {
     // Ignore if the implementing client has registered this method as known.
     if (this.registeredMethods.includes(method)) return;
-    this.logger.error(getSdkError("WC_METHOD_UNSUPPORTED", method));
+    this.logger.warn(getSdkError("WC_METHOD_UNSUPPORTED", method));
   };
 
   // ---------- Expirer Events ---------------------------------------- //

--- a/packages/core/src/controllers/publisher.ts
+++ b/packages/core/src/controllers/publisher.ts
@@ -118,7 +118,7 @@ export class Publisher extends IPublisher {
       await createExpiringPromise(publishPromise, this.publishTimeout, failedPublishMessage);
     } catch (e) {
       this.logger.debug(`Failed to Publish Payload`);
-      this.logger.error(e as any);
+      this.logger.warn(e as any);
       if (opts?.internal?.throwOnFailedPublish) {
         throw e;
       }
@@ -197,7 +197,7 @@ export class Publisher extends IPublisher {
       await createExpiringPromise(publishPromise, this.publishTimeout, failedPublishMessage);
     } catch (e) {
       this.logger.debug(`Failed to Publish Payload`);
-      this.logger.error(e as any);
+      this.logger.warn(e as any);
       if (opts?.internal?.throwOnFailedPublish) {
         throw e;
       }

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -612,7 +612,7 @@ export class Relayer extends IRelayer {
         this.transportExplicitlyClosed = false;
       } else {
         await this.transportOpen().catch((error) =>
-          this.logger.error(error, (error as Error)?.message),
+          this.logger.warn(error, (error as Error)?.message),
         );
       }
     });
@@ -644,7 +644,7 @@ export class Relayer extends IRelayer {
 
     this.reconnectTimeout = setTimeout(async () => {
       await this.transportOpen().catch((error) =>
-        this.logger.error(error, (error as Error)?.message),
+        this.logger.warn(error, (error as Error)?.message),
       );
       this.reconnectTimeout = undefined;
       this.reconnectInProgress = false;

--- a/packages/core/src/controllers/store.ts
+++ b/packages/core/src/controllers/store.ts
@@ -165,12 +165,12 @@ export class Store<Key, Data extends Record<string, any>> extends IStore<Key, Da
           "MISSING_OR_INVALID",
           `Record was recently deleted - ${this.name}: ${key}`,
         );
-        this.logger.error(message);
+        this.logger.warn(message);
         throw new Error(message);
       }
 
       const { message } = getInternalError("NO_MATCHING_KEY", `${this.name}: ${key}`);
-      this.logger.error(message);
+      this.logger.warn(message);
       throw new Error(message);
     }
     return value;
@@ -187,7 +187,7 @@ export class Store<Key, Data extends Record<string, any>> extends IStore<Key, Da
       if (!persisted.length) return;
       if (this.map.size) {
         const { message } = getInternalError("RESTORE_WILL_OVERRIDE", this.name);
-        this.logger.error(message);
+        this.logger.warn(message);
         throw new Error(message);
       }
       this.cached = persisted;
@@ -195,7 +195,7 @@ export class Store<Key, Data extends Record<string, any>> extends IStore<Key, Da
       this.logger.trace({ type: "method", method: "restore", value: this.values });
     } catch (e) {
       this.logger.debug(`Failed to Restore value for ${this.name}`);
-      this.logger.error(e as any);
+      this.logger.warn(e as any);
     }
   }
 

--- a/packages/core/src/controllers/subscriber.ts
+++ b/packages/core/src/controllers/subscriber.ts
@@ -120,7 +120,7 @@ export class Subscriber extends ISubscriber {
       return id;
     } catch (e) {
       this.logger.debug(`Failed to Subscribe Topic`);
-      this.logger.error(e as any);
+      this.logger.warn(e as any);
       throw e;
     }
   };
@@ -226,7 +226,7 @@ export class Subscriber extends ISubscriber {
       this.logger.trace({ type: "method", method: "unsubscribe", params: { topic, id, opts } });
     } catch (e) {
       this.logger.debug(`Failed to Unsubscribe Topic`);
-      this.logger.error(e as any);
+      this.logger.warn(e as any);
       throw e;
     }
   }
@@ -494,8 +494,8 @@ export class Subscriber extends ISubscriber {
         !persisted.every((s) => s.topic === this.subscriptions.get(s.id)?.topic)
       ) {
         const { message } = getInternalError("RESTORE_WILL_OVERRIDE", this.name);
-        this.logger.error(message);
-        this.logger.error(`${this.name}: ${JSON.stringify(this.values)}`);
+        this.logger.warn(message);
+        this.logger.warn(`${this.name}: ${JSON.stringify(this.values)}`);
         throw new Error(message);
       }
       this.cached = persisted;
@@ -503,7 +503,7 @@ export class Subscriber extends ISubscriber {
       this.logger.trace({ type: "method", method: "restore", subscriptions: this.values });
     } catch (e) {
       this.logger.debug(`Failed to Restore subscriptions for ${this.name}`);
-      this.logger.error(e as any);
+      this.logger.warn(e as any);
     }
   }
 

--- a/packages/core/src/controllers/verify.ts
+++ b/packages/core/src/controllers/verify.ts
@@ -203,7 +203,7 @@ export class Verify extends IVerify {
         return validation;
       }
     } catch (e) {
-      this.logger.error(e);
+      this.logger.warn(e);
       this.logger.warn("error validating attestation");
     }
     const newKey = await this.fetchAndPersistPublicKey();
@@ -213,7 +213,7 @@ export class Verify extends IVerify {
         return validation;
       }
     } catch (e) {
-      this.logger.error(e);
+      this.logger.warn(e);
       this.logger.warn("error validating attestation");
     }
     return undefined;

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -227,7 +227,7 @@ export class Core extends ICore {
       this.logger.info(`Core Initialization Success`);
     } catch (error) {
       this.logger.warn(error, `Core Initialization Failure at epoch ${Date.now()}`);
-      this.logger.error((error as any).message);
+      this.logger.warn((error as any).message);
       throw error;
     }
   }

--- a/packages/sign-client/src/client.ts
+++ b/packages/sign-client/src/client.ts
@@ -89,7 +89,7 @@ export class SignClient extends ISignClient {
     try {
       return await this.engine.connect(params);
     } catch (error: any) {
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   };
@@ -98,7 +98,7 @@ export class SignClient extends ISignClient {
     try {
       return await this.engine.pair(params);
     } catch (error: any) {
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   };
@@ -107,7 +107,7 @@ export class SignClient extends ISignClient {
     try {
       return await this.engine.approve(params);
     } catch (error: any) {
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   };
@@ -116,7 +116,7 @@ export class SignClient extends ISignClient {
     try {
       return await this.engine.reject(params);
     } catch (error: any) {
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   };
@@ -125,7 +125,7 @@ export class SignClient extends ISignClient {
     try {
       return await this.engine.update(params);
     } catch (error: any) {
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   };
@@ -134,7 +134,7 @@ export class SignClient extends ISignClient {
     try {
       return await this.engine.extend(params);
     } catch (error: any) {
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   };
@@ -143,7 +143,7 @@ export class SignClient extends ISignClient {
     try {
       return await this.engine.request<T>(params);
     } catch (error: any) {
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   };
@@ -152,7 +152,7 @@ export class SignClient extends ISignClient {
     try {
       return await this.engine.respond(params);
     } catch (error: any) {
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   };
@@ -161,7 +161,7 @@ export class SignClient extends ISignClient {
     try {
       return await this.engine.ping(params);
     } catch (error: any) {
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   };
@@ -170,7 +170,7 @@ export class SignClient extends ISignClient {
     try {
       return await this.engine.emit(params);
     } catch (error: any) {
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   };
@@ -179,7 +179,7 @@ export class SignClient extends ISignClient {
     try {
       return await this.engine.disconnect(params);
     } catch (error: any) {
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   };
@@ -188,7 +188,7 @@ export class SignClient extends ISignClient {
     try {
       return this.engine.find(params);
     } catch (error: any) {
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   };
@@ -197,7 +197,7 @@ export class SignClient extends ISignClient {
     try {
       return this.engine.getPendingSessionRequests();
     } catch (error: any) {
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   };
@@ -206,7 +206,7 @@ export class SignClient extends ISignClient {
     try {
       return await this.engine.authenticate(params, walletUniversalLink);
     } catch (error: any) {
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   };
@@ -215,7 +215,7 @@ export class SignClient extends ISignClient {
     try {
       return this.engine.formatAuthMessage(params);
     } catch (error: any) {
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   };
@@ -224,7 +224,7 @@ export class SignClient extends ISignClient {
     try {
       return await this.engine.approveSessionAuthenticate(params);
     } catch (error: any) {
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   };
@@ -233,7 +233,7 @@ export class SignClient extends ISignClient {
     try {
       return await this.engine.rejectSessionAuthenticate(params);
     } catch (error: any) {
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   };
@@ -252,7 +252,7 @@ export class SignClient extends ISignClient {
       this.logger.info(`SignClient Initialization Success`);
     } catch (error: any) {
       this.logger.info(`SignClient Initialization Failure`);
-      this.logger.error(error.message);
+      this.logger.warn(error.message);
       throw error;
     }
   }

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -263,7 +263,7 @@ export class Engine extends IEngine {
         active = pairing.active;
       }
     } catch (error) {
-      this.client.logger.error(`connect() -> pairing.get(${topic}) failed`);
+      this.client.logger.warn(`connect() -> pairing.get(${topic}) failed`);
       throw error;
     }
     if (!topic || !active) {
@@ -358,7 +358,7 @@ export class Engine extends IEngine {
     try {
       return await this.client.core.pairing.pair(params);
     } catch (error) {
-      this.client.logger.error("pair() failed");
+      this.client.logger.warn("pair() failed");
       throw error;
     }
   };
@@ -380,7 +380,7 @@ export class Engine extends IEngine {
     try {
       await this.isValidProposalId(params?.id);
     } catch (error) {
-      this.client.logger.error(`approve() -> proposal.get(${params?.id}) failed`);
+      this.client.logger.warn(`approve() -> proposal.get(${params?.id}) failed`);
       configEvent.setError(EVENT_CLIENT_SESSION_ERRORS.proposal_not_found);
       throw error;
     }
@@ -388,7 +388,7 @@ export class Engine extends IEngine {
     try {
       await this.isValidApprove(params);
     } catch (error) {
-      this.client.logger.error("approve() -> isValidApprove() failed");
+      this.client.logger.warn("approve() -> isValidApprove() failed");
       configEvent.setError(
         EVENT_CLIENT_SESSION_ERRORS.session_approve_namespace_validation_failure,
       );
@@ -505,7 +505,7 @@ export class Engine extends IEngine {
 
       event.addTrace(EVENT_CLIENT_SESSION_TRACES.session_approve_publish_success);
     } catch (error) {
-      this.client.logger.error(error);
+      this.client.logger.warn(error);
       // if the publish fails, delete the session and throw an error
       this.client.session.delete(sessionTopic, getSdkError("USER_DISCONNECTED"));
       await this.client.core.relayer.unsubscribe(sessionTopic);
@@ -533,7 +533,7 @@ export class Engine extends IEngine {
     try {
       await this.isValidReject(params);
     } catch (error) {
-      this.client.logger.error("reject() -> isValidReject() failed");
+      this.client.logger.warn("reject() -> isValidReject() failed");
       throw error;
     }
     const { id, reason } = params;
@@ -542,7 +542,7 @@ export class Engine extends IEngine {
       const proposal = this.client.proposal.get(id);
       pairingTopic = proposal.pairingTopic;
     } catch (error) {
-      this.client.logger.error(`reject() -> proposal.get(${id}) failed`);
+      this.client.logger.warn(`reject() -> proposal.get(${id}) failed`);
       throw error;
     }
 
@@ -564,7 +564,7 @@ export class Engine extends IEngine {
     try {
       await this.isValidUpdate(params);
     } catch (error) {
-      this.client.logger.error("update() -> isValidUpdate() failed");
+      this.client.logger.warn("update() -> isValidUpdate() failed");
       throw error;
     }
     const { topic, namespaces } = params;
@@ -592,7 +592,7 @@ export class Engine extends IEngine {
       clientRpcId,
       relayRpcId,
     }).catch((error) => {
-      this.client.logger.error(error);
+      this.client.logger.warn(error);
       this.client.session.update(topic, { namespaces: oldNamespaces });
       reject(error);
     });
@@ -605,7 +605,7 @@ export class Engine extends IEngine {
     try {
       await this.isValidExtend(params);
     } catch (error) {
-      this.client.logger.error("extend() -> isValidExtend() failed");
+      this.client.logger.warn("extend() -> isValidExtend() failed");
       throw error;
     }
 
@@ -636,7 +636,7 @@ export class Engine extends IEngine {
     try {
       await this.isValidRequest(params);
     } catch (error) {
-      this.client.logger.error("request() -> isValidRequest() failed");
+      this.client.logger.warn("request() -> isValidRequest() failed");
       throw error;
     }
     const { chainId, request, topic, expiry = ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl } = params;
@@ -786,7 +786,7 @@ export class Engine extends IEngine {
     try {
       await this.isValidPing(params);
     } catch (error) {
-      this.client.logger.error("ping() -> isValidPing() failed");
+      this.client.logger.warn("ping() -> isValidPing() failed");
       throw error;
     }
     const { topic } = params;
@@ -1035,7 +1035,7 @@ export class Engine extends IEngine {
       for (const cacao of cacaos) {
         const isValid = await validateSignedCacao({ cacao, projectId: this.client.core.projectId });
         if (!isValid) {
-          this.client.logger.error(cacao, "Signature verification failed");
+          this.client.logger.warn(cacao, "Signature verification failed");
           reject(getSdkError("SESSION_SETTLEMENT_FAILED", "Signature verification failed"));
         }
 
@@ -1412,7 +1412,7 @@ export class Engine extends IEngine {
             await this.onRelayMessage(message);
           }
         } catch (error) {
-          this.client.logger.error(error);
+          this.client.logger.warn(error);
         }
       }
     }, 50);
@@ -1443,7 +1443,7 @@ export class Engine extends IEngine {
       );
       this.client.logger.info(`Duplicate pairings clean up finished`);
     } catch (error) {
-      this.client.logger.error(error);
+      this.client.logger.warn(error);
     }
   };
 
@@ -1584,7 +1584,7 @@ export class Engine extends IEngine {
       message = await this.client.core.crypto.encode(topic, payload, { encoding });
     } catch (error) {
       await this.cleanup();
-      this.client.logger.error(`sendRequest() -> core.crypto.encode() for topic ${topic} failed`);
+      this.client.logger.warn(`sendRequest() -> core.crypto.encode() for topic ${topic} failed`);
       throw error;
     }
 
@@ -1623,7 +1623,7 @@ export class Engine extends IEngine {
       } else {
         this.client.core.relayer
           .publish(topic, message, opts)
-          .catch((error) => this.client.logger.error(error));
+          .catch((error) => this.client.logger.warn(error));
       }
     }
 
@@ -1720,7 +1720,7 @@ export class Engine extends IEngine {
     } catch (error) {
       // if encoding fails e.g. due to missing keychain, we want to cleanup all related data as its unusable
       await this.cleanup();
-      this.client.logger.error(`sendResult() -> core.crypto.encode() for topic ${topic} failed`);
+      this.client.logger.warn(`sendResult() -> core.crypto.encode() for topic ${topic} failed`);
       throw error;
     }
     let record;
@@ -1736,7 +1736,7 @@ export class Engine extends IEngine {
         );
       }
     } catch (error) {
-      this.client.logger.error(`sendResult() -> history.get(${topic}, ${id}) failed`);
+      this.client.logger.warn(`sendResult() -> history.get(${topic}, ${id}) failed`);
       throw error;
     }
 
@@ -1761,7 +1761,7 @@ export class Engine extends IEngine {
       } else {
         this.client.core.relayer
           .publish(topic, message, opts)
-          .catch((error) => this.client.logger.error(error));
+          .catch((error) => this.client.logger.warn(error));
       }
     }
 
@@ -1781,14 +1781,14 @@ export class Engine extends IEngine {
       });
     } catch (error) {
       await this.cleanup();
-      this.client.logger.error(`sendError() -> core.crypto.encode() for topic ${topic} failed`);
+      this.client.logger.warn(`sendError() -> core.crypto.encode() for topic ${topic} failed`);
       throw error;
     }
     let record;
     try {
       record = await this.client.core.history.get(topic, id);
     } catch (error) {
-      this.client.logger.error(`sendError() -> history.get(${topic}, ${id}) failed`);
+      this.client.logger.warn(`sendError() -> history.get(${topic}, ${id}) failed`);
       throw error;
     }
 
@@ -1883,7 +1883,7 @@ export class Engine extends IEngine {
       }
       await this.client.core.relayer.messages.ack(topic, message);
     } catch (error) {
-      this.client.logger.error(error);
+      this.client.logger.warn(error);
     }
   }
 
@@ -2057,7 +2057,7 @@ export class Engine extends IEngine {
         error: err,
         rpcOpts: ENGINE_RPC_OPTS.wc_sessionPropose.autoReject,
       });
-      this.client.logger.error(err);
+      this.client.logger.warn(err);
     }
   };
 
@@ -2139,7 +2139,7 @@ export class Engine extends IEngine {
       );
 
       if (!pendingSession) {
-        return this.client.logger.error(`Pending session not found for topic ${topic}`);
+        return this.client.logger.warn(`Pending session not found for topic ${topic}`);
       }
 
       const proposal = this.client.proposal.get(pendingSession.proposalId);
@@ -2196,7 +2196,7 @@ export class Engine extends IEngine {
         topic,
         error: err,
       });
-      this.client.logger.error(err);
+      this.client.logger.warn(err);
     }
   };
 
@@ -2251,7 +2251,7 @@ export class Engine extends IEngine {
         topic,
         error: err,
       });
-      this.client.logger.error(err);
+      this.client.logger.warn(err);
     }
   };
 
@@ -2295,7 +2295,7 @@ export class Engine extends IEngine {
         topic,
         error: err,
       });
-      this.client.logger.error(err);
+      this.client.logger.warn(err);
     }
   };
 
@@ -2330,7 +2330,7 @@ export class Engine extends IEngine {
         topic,
         error: err,
       });
-      this.client.logger.error(err);
+      this.client.logger.warn(err);
     }
   };
 
@@ -2374,9 +2374,9 @@ export class Engine extends IEngine {
           result: true,
         }),
         this.cleanupPendingSentRequestsForTopic({ topic, error: getSdkError("USER_DISCONNECTED") }),
-      ]).catch((err) => this.client.logger.error(err));
+      ]).catch((err) => this.client.logger.warn(err));
     } catch (err: any) {
-      this.client.logger.error(err);
+      this.client.logger.warn(err);
     }
   };
 
@@ -2423,7 +2423,7 @@ export class Engine extends IEngine {
         topic,
         error: err,
       });
-      this.client.logger.error(err);
+      this.client.logger.warn(err);
     }
   };
 
@@ -2470,7 +2470,7 @@ export class Engine extends IEngine {
         topic,
         error: err,
       });
-      this.client.logger.error(err);
+      this.client.logger.warn(err);
     }
   };
 
@@ -2531,7 +2531,7 @@ export class Engine extends IEngine {
         verifyContext,
       });
     } catch (err: any) {
-      this.client.logger.error(err);
+      this.client.logger.warn(err);
 
       const receiverPublicKey = payload.params.requester.publicKey;
       const senderPublicKey = await this.client.core.crypto.generateKeyPair();
@@ -2615,7 +2615,7 @@ export class Engine extends IEngine {
     try {
       this.emitSessionRequest(request);
     } catch (error) {
-      this.client.logger.error(error);
+      this.client.logger.warn(error);
     }
   };
 

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -338,7 +338,7 @@ export class EthereumProvider implements IEthereumProvider {
       this.setAccounts(accounts);
       this.events.emit("connect", { chainId: toHexChainId(this.chainId) });
     } catch (error) {
-      this.signer.logger.error(error);
+      this.signer.logger.warn(error);
       throw error;
     } finally {
       this.modal?.close();
@@ -400,7 +400,7 @@ export class EthereumProvider implements IEthereumProvider {
 
       return result;
     } catch (error) {
-      this.signer.logger.error(error);
+      this.signer.logger.warn(error);
       throw error;
     } finally {
       this.modal?.close();
@@ -630,7 +630,7 @@ export class EthereumProvider implements IEthereumProvider {
         try {
           this.modal = appKit;
         } catch (e) {
-          this.signer.logger.error(e);
+          this.signer.logger.warn(e);
           throw new Error("Could not generate WalletConnectModal Instance");
         }
       }
@@ -676,8 +676,8 @@ export class EthereumProvider implements IEthereumProvider {
       this.setChainIds(chainId ? [this.formatChainId(chainId)] : namespace?.accounts);
       this.setAccounts(namespace?.accounts);
     } catch (error) {
-      this.signer.logger.error("Failed to load persisted session, clearing state...");
-      this.signer.logger.error(error);
+      this.signer.logger.warn("Failed to load persisted session, clearing state...");
+      this.signer.logger.warn(error);
       await this.disconnect().catch((error) => this.signer.logger.warn(error));
     }
   }

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -291,7 +291,7 @@ export class UniversalProvider implements IUniversalProvider {
       try {
         this.session = this.client.session.get(this.providerOpts.session.topic);
       } catch (error) {
-        this.logger.error(error, "Failed to get session");
+        this.logger.warn(error, "Failed to get session");
         throw new Error(
           `The provided session: ${this.providerOpts?.session?.topic} doesn't exist in the Sign client`,
         );


### PR DESCRIPTION
## Description

This PR refactors error logging to use warning-level logging instead across multiple packages in the WalletConnect codebase. The changes downgrade logger.error() calls to logger.warn() in error handling blocks, primarily in catch clauses where errors are being logged before re-throwing or in scenarios where errors are non-fatal.

Key Changes:

- Systematic replacement of logger.error() with logger.warn() in error handling contexts
- Changes affect production code across sign-client, core, and provider packages
- No changes to error handling logic, only the severity level of logged messages

The change is made as error logs are generally non actionable but polute services like sentry

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
n/a

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Downgrades numerous logger.error calls to logger.warn across core, sign-client, and providers to reduce log severity for recoverable paths.
> 
> - **Logging level changes (error → warn)**
>   - **Core/controllers**: `crypto`, `expirer`, `history`, `messages`, `pairing`, `publisher`, `relayer`, `store`, `subscriber`, `verify`, `core` – downgrade error logs for decode/restore/subscribe/publish/reconnect and validation failures.
>   - **Sign Client**: `client` and `controllers/engine` – warn on engine method failures, request/response handling, session events, and processing queues.
>   - **Providers**:
>     - `ethereum-provider/EthereumProvider` – warn on connect/auth/modal/init/persisted-session handling.
>     - `universal-provider/UniversalProvider` – warn when retrieving non-existent sessions during init.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36330988eeb5c574aeadfc7f67d4e86760d0cc0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->