### PR TITLE
test(canary): fix race condition in canary test

### DIFF
--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -1,9 +1,5 @@
 import { getSdkError } from "@walletconnect/utils";
-import {
-  testConnectMethod,
-  uploadCanaryResultsToCloudWatch,
-  publishToStatusPage,
-} from "../shared";
+import { testConnectMethod, uploadCanaryResultsToCloudWatch, publishToStatusPage } from "../shared";
 import {
   TEST_RELAY_URL,
   TEST_REQUEST_PARAMS,

--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -1,8 +1,6 @@
 import { getSdkError } from "@walletconnect/utils";
 import {
-  initTwoClients,
   testConnectMethod,
-  deleteClients,
   uploadCanaryResultsToCloudWatch,
   publishToStatusPage,
 } from "../shared";
@@ -232,6 +230,8 @@ describe("Canary", () => {
         }
       });
 
+      // Unsubscribe Client A first to avoid receiving Client B's ACK after cleanup
+      await clients.A.core.relayer.unsubscribe(sessionA.topic);
       await clients.A.disconnect({
         topic: sessionA.topic,
         reason: getSdkError("USER_DISCONNECTED"),


### PR DESCRIPTION
Unsubscribe Client A before disconnect to prevent receiving Client B's ACK response after encryption keys have been deleted. This fixes test failures with the faster WCN 2.0 backend where Client B's ACK arrives before Client A's unsubscribe completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> Creating a release? Please use the [Release PR Template](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/.github/pr_template_release.md) instead.

## Testing

Tested locally.
