### PR TITLE
chore: redudant disconnect ack

### DIFF
--- a/.changeset/lemon-facts-reply.md
+++ b/.changeset/lemon-facts-reply.md
@@ -1,0 +1,12 @@
+---
+"@walletconnect/sign-client": patch
+"@walletconnect/core": patch
+"@walletconnect/react-native-compat": patch
+"@walletconnect/types": patch
+"@walletconnect/utils": patch
+"@walletconnect/ethereum-provider": patch
+"@walletconnect/signer-connection": patch
+"@walletconnect/universal-provider": patch
+---
+
+Removed redundant sign-client to sign-client ACK when session disconnect request is received

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -336,6 +336,8 @@ export class Engine extends IEngine {
       }
     });
 
+    await this.setProposal(proposal.id, proposal);
+
     await this.sendProposeSession({
       proposal,
       publishOpts: {
@@ -346,9 +348,11 @@ export class Engine extends IEngine {
           correlationId: proposal.id,
         },
       },
+    }).catch((error) => {
+      this.deleteProposal(proposal.id);
+      throw error;
     });
 
-    await this.setProposal(proposal.id, proposal);
     return { uri, approval };
   };
 
@@ -1466,15 +1470,16 @@ export class Engine extends IEngine {
     this.client.core.storage
       .removeItem(WALLETCONNECT_DEEPLINK_CHOICE)
       .catch((e) => this.client.logger.warn(e));
-    this.getPendingSessionRequests().forEach((r) => {
-      if (r.topic === topic) {
-        this.deletePendingSessionRequest(r.id, getSdkError("USER_DISCONNECTED"));
-      }
-    });
     // reset the queue state back to idle if a request for the deleted session is still in the queue
     if (topic === this.sessionRequestQueue.queue[0]?.topic) {
       this.sessionRequestQueue.state = ENGINE_QUEUE_STATES.idle;
     }
+    for (const r of this.getPendingSessionRequests()) {
+      if (r.topic === topic) {
+        await this.deletePendingSessionRequest(r.id, getSdkError("USER_DISCONNECTED"));
+      }
+    }
+
     if (emitEvent) this.client.events.emit("session_delete", { id, topic });
   };
 
@@ -2178,9 +2183,6 @@ export class Engine extends IEngine {
         metadata: session.peer.metadata,
       });
 
-      this.client.events.emit("session_connect", { session });
-      this.events.emit(engineEvent("session_connect", pendingSession.proposalId), { session });
-
       this.pendingSessions.delete(pendingSession.proposalId);
       this.deleteProposal(pendingSession.proposalId, false);
       this.cleanupDuplicatePairings(session);
@@ -2188,8 +2190,12 @@ export class Engine extends IEngine {
       await this.sendResult<"wc_sessionSettle">({
         id: payload.id,
         topic,
+        throwOnFailedPublish: true,
         result: true,
       });
+
+      this.client.events.emit("session_connect", { session });
+      this.events.emit(engineEvent("session_connect", pendingSession.proposalId), { session });
     } catch (err: any) {
       await this.sendError({
         id,
@@ -2360,21 +2366,9 @@ export class Engine extends IEngine {
   ) => {
     const { id } = payload;
     try {
-      this.isValidDisconnect({ topic, reason: payload.params });
-      await Promise.all([
-        new Promise((resolve) => {
-          // RPC request needs to happen before deletion as it utilizes session encryption
-          this.client.core.relayer.once(RELAYER_EVENTS.publish, async () => {
-            resolve(await this.deleteSession({ topic, id }));
-          });
-        }),
-        this.sendResult<"wc_sessionDelete">({
-          id,
-          topic,
-          result: true,
-        }),
-        this.cleanupPendingSentRequestsForTopic({ topic, error: getSdkError("USER_DISCONNECTED") }),
-      ]).catch((err) => this.client.logger.error(err));
+      await this.isValidDisconnect({ topic, reason: payload.params });
+      this.cleanupPendingSentRequestsForTopic({ topic, error: getSdkError("USER_DISCONNECTED") });
+      await this.deleteSession({ topic, id });
     } catch (err: any) {
       this.client.logger.error(err);
     }
@@ -2586,12 +2580,6 @@ export class Engine extends IEngine {
         (r) => r.topic === topic && r.request.method === "wc_sessionRequest",
       );
       forSession.forEach((r) => {
-        const id = r.request.id;
-        const target = engineEvent("session_request", id);
-        const listeners = this.events.listenerCount(target);
-        if (listeners === 0) {
-          throw new Error(`emitting ${target} without any listeners`);
-        }
         // notify .request() handler of the rejection
         this.events.emit(engineEvent("session_request", r.request.id), {
           error,

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -1474,11 +1474,12 @@ export class Engine extends IEngine {
     if (topic === this.sessionRequestQueue.queue[0]?.topic) {
       this.sessionRequestQueue.state = ENGINE_QUEUE_STATES.idle;
     }
-    for (const r of this.getPendingSessionRequests()) {
-      if (r.topic === topic) {
-        await this.deletePendingSessionRequest(r.id, getSdkError("USER_DISCONNECTED"));
-      }
-    }
+
+    await Promise.all(
+      this.getPendingSessionRequests()
+        .filter((r) => r.topic === topic)
+        .map((r) => this.deletePendingSessionRequest(r.id, getSdkError("USER_DISCONNECTED"))),
+    );
 
     if (emitEvent) this.client.events.emit("session_delete", { id, topic });
   };

--- a/packages/sign-client/test/sdk/auth.spec.ts
+++ b/packages/sign-client/test/sdk/auth.spec.ts
@@ -15,7 +15,7 @@ import { ethers } from "ethers";
 import { ENGINE_RPC_OPTS, SignClient } from "../../src";
 import { TEST_APP_METADATA_B, TEST_SIGN_CLIENT_OPTIONS, deleteClients, throttle } from "../shared";
 
-describe("Authenticated Sessions", () => {
+describe.concurrent("Authenticated Sessions", () => {
   let cryptoWallet: ethers.HDNodeWallet;
 
   beforeAll(() => {

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -35,7 +35,7 @@ import {
   RELAYER_EVENTS,
 } from "@walletconnect/core";
 
-describe("Sign Client Integration", () => {
+describe.concurrent("Sign Client Integration", () => {
   it("init", async () => {
     const client = await SignClient.init({
       ...TEST_SIGN_CLIENT_OPTIONS,
@@ -74,7 +74,7 @@ describe("Sign Client Integration", () => {
     await deleteClients({ A: client, B: undefined });
   });
 
-  describe("connect", () => {
+  describe.concurrent("connect", () => {
     it("connect (with new pairing)", async () => {
       const clients = await initTwoClients({}, {}, { logger: "warn" });
 
@@ -513,8 +513,8 @@ describe("Sign Client Integration", () => {
     });
   });
 
-  describe("disconnect", () => {
-    describe("pairing", () => {
+  describe.concurrent("disconnect", () => {
+    describe.concurrent("pairing", () => {
       it("deletes the pairing on disconnect", async () => {
         const {
           clients,
@@ -532,7 +532,7 @@ describe("Sign Client Integration", () => {
         await deleteClients(clients);
       });
     });
-    describe("session", () => {
+    describe.concurrent("session", () => {
       it("deletes the session on disconnect", async () => {
         const {
           clients,
@@ -560,7 +560,7 @@ describe("Sign Client Integration", () => {
         await deleteClients(clients);
       });
     });
-    describe("deeplinks", () => {
+    describe.concurrent("deeplinks", () => {
       it("should clear `WALLETCONNECT_DEEPLINK_CHOICE` from storage on disconnect", async () => {
         const {
           clients,
@@ -576,7 +576,7 @@ describe("Sign Client Integration", () => {
         await deleteClients(clients);
       });
     });
-    describe("request queue", () => {
+    describe.concurrent("request queue", () => {
       it("should reset request queue state on disconnect", async () => {
         const {
           clients,
@@ -595,11 +595,9 @@ describe("Sign Client Integration", () => {
             clients.B.once("session_request", async (params) => {
               expect(clients.B.pendingRequest.getAll().length).to.eq(1);
 
-              await clients.A.disconnect({ topic, reason: getSdkError("USER_DISCONNECTED") });
-
               // @ts-expect-error - sessionRequestQueue is private property
               expect(clients.B.engine.sessionRequestQueue.state).to.eq(ENGINE_QUEUE_STATES.active);
-
+              await clients.A.disconnect({ topic, reason: getSdkError("USER_DISCONNECTED") });
               resolve();
             });
             clients.A.request({
@@ -611,13 +609,12 @@ describe("Sign Client Integration", () => {
             });
           }),
         ]);
-
         await deleteClients(clients);
       });
     });
   });
 
-  describe("ping", () => {
+  describe.concurrent("ping", () => {
     it("throws if the topic is not a known pairing or session topic", async () => {
       const clients = await initTwoClients();
       const fakeTopic = "nonsense";
@@ -626,8 +623,8 @@ describe("Sign Client Integration", () => {
       );
       await deleteClients(clients);
     });
-    describe("pairing", () => {
-      describe("with existing pairing", () => {
+    describe.concurrent("pairing", () => {
+      describe.concurrent("with existing pairing", () => {
         it("A pings B", async () => {
           const {
             clients,
@@ -646,8 +643,8 @@ describe("Sign Client Integration", () => {
         });
       });
     });
-    describe("session", () => {
-      describe("with existing session", () => {
+    describe.concurrent("session", () => {
+      describe.concurrent("with existing session", () => {
         it("A pings B", async () => {
           const {
             clients,
@@ -704,7 +701,7 @@ describe("Sign Client Integration", () => {
           await deleteClients(clients);
         });
 
-        it("can set tvf params", async () => {
+        it("can set evm tvf params", async () => {
           const {
             clients,
             sessionA: { topic },
@@ -714,146 +711,18 @@ describe("Sign Client Integration", () => {
             { logger: "error" },
             {
               requiredNamespaces: {
-                solana: {
-                  methods: [
-                    "solana_signTransaction",
-                    "solana_signAllTransactions",
-                    "solana_signAndSendTransaction",
-                  ],
-                  events: [],
-                  chains: ["solana:devnet"],
-                },
                 eip155: {
                   methods: ["eth_sendTransaction", "wallet_sendCalls"],
                   events: [],
                   chains: ["eip155:1"],
                 },
-                sui: {
-                  methods: ["sui_signTransaction", "sui_signAndExecuteTransaction"],
-                  events: [],
-                  chains: ["sui:devnet"],
-                },
-                hedera: {
-                  methods: ["hedera_signAndExecuteTransaction", "hedera_executeTransaction"],
-                  events: [],
-                  chains: ["hedera:mainnet"],
-                },
-                near: {
-                  methods: ["near_signTransaction", "near_signTransactions"],
-                  events: [],
-                  chains: ["near:testnet"],
-                },
-                tron: {
-                  methods: ["tron_signTransaction"],
-                  events: [],
-                  chains: ["tron:mainnet"],
-                },
-                xrpl: {
-                  methods: ["xrpl_signTransaction", "xrpl_signTransactionFor"],
-                  events: [],
-                  chains: ["xrpl:mainnet"],
-                },
-                algorand: {
-                  methods: ["algo_signTxn"],
-                  events: [],
-                  chains: ["algorand:mainnet"],
-                },
-                bip122: {
-                  methods: ["sendTransfer"],
-                  events: [],
-                  chains: ["bip122:mainnet"],
-                },
-                stacks: {
-                  methods: ["stacks_stxTransfer"],
-                  events: [],
-                  chains: ["stacks:mainnet"],
-                },
-                polkadot: {
-                  methods: ["polkadot_signTransaction"],
-                  events: [],
-                  chains: ["polkadot:mainnet"],
-                },
-                cosmos: {
-                  methods: ["cosmos_signDirect"],
-                  events: [],
-                  chains: ["cosmos:mainnet"],
-                },
               },
               namespaces: {
-                solana: {
-                  chains: ["solana:devnet"],
-                  methods: [
-                    "solana_signTransaction",
-                    "solana_signAllTransactions",
-                    "solana_signAndSendTransaction",
-                  ],
-                  events: [],
-                  accounts: ["solana:devnet:0x"],
-                },
                 eip155: {
                   methods: ["eth_sendTransaction", "wallet_sendCalls"],
                   events: [],
+                  chains: ["eip155:1"],
                   accounts: ["eip155:1:0x"],
-                },
-                sui: {
-                  methods: ["sui_signTransaction", "sui_signAndExecuteTransaction"],
-                  events: [],
-                  chains: ["sui:devnet"],
-                  accounts: ["sui:devnet:0x"],
-                },
-                hedera: {
-                  methods: ["hedera_signAndExecuteTransaction", "hedera_executeTransaction"],
-                  events: [],
-                  chains: ["hedera:mainnet"],
-                  accounts: ["hedera:mainnet:0x"],
-                },
-                near: {
-                  methods: ["near_signTransaction", "near_signTransactions"],
-                  events: [],
-                  chains: ["near:testnet"],
-                  accounts: ["near:testnet:0x"],
-                },
-                tron: {
-                  methods: ["tron_signTransaction"],
-                  events: [],
-                  chains: ["tron:mainnet"],
-                  accounts: ["tron:mainnet:0x"],
-                },
-                xrpl: {
-                  methods: ["xrpl_signTransaction", "xrpl_signTransactionFor"],
-                  events: [],
-                  chains: ["xrpl:mainnet"],
-                  accounts: ["xrpl:mainnet:0x"],
-                },
-                algorand: {
-                  methods: ["algo_signTxn"],
-                  events: [],
-                  chains: ["algorand:mainnet"],
-                  accounts: ["algorand:mainnet:0x"],
-                },
-                bip122: {
-                  methods: ["sendTransfer"],
-                  events: [],
-                  chains: ["bip122:mainnet"],
-                  accounts: ["bip122:mainnet:0x"],
-                },
-                stacks: {
-                  methods: ["stacks_stxTransfer"],
-                  events: [],
-                  chains: ["stacks:mainnet"],
-                  accounts: ["stacks:mainnet:0x"],
-                },
-                polkadot: {
-                  methods: ["polkadot_signTransaction"],
-                  events: [],
-                  chains: ["polkadot:mainnet"],
-                  accounts: ["polkadot:mainnet:0x"],
-                },
-                cosmos: {
-                  methods: ["cosmos_signDirect"],
-                  events: [],
-                  chains: ["cosmos:mainnet"],
-                  accounts: ["cosmos:mainnet:0x"],
                 },
               },
             },
@@ -1200,6 +1069,44 @@ describe("Sign Client Integration", () => {
             }),
           ]);
 
+          await throttle(1_000);
+          await deleteClients(clients);
+        });
+        it("can set solana tvf params", async () => {
+          const {
+            clients,
+            sessionA: { topic },
+          } = await initTwoPairedClients(
+            {},
+            {},
+            { logger: "error" },
+            {
+              requiredNamespaces: {
+                solana: {
+                  methods: [
+                    "solana_signTransaction",
+                    "solana_signAllTransactions",
+                    "solana_signAndSendTransaction",
+                  ],
+                  events: [],
+                  chains: ["solana:devnet"],
+                },
+              },
+              namespaces: {
+                solana: {
+                  methods: [
+                    "solana_signTransaction",
+                    "solana_signAllTransactions",
+                    "solana_signAndSendTransaction",
+                  ],
+                  events: [],
+                  chains: ["solana:devnet"],
+                  accounts: ["solana:devnet:0x"],
+                },
+              },
+            },
+          );
+
           // solana solana_signAndSendTransaction example
           await Promise.all([
             new Promise<void>((resolve) => {
@@ -1444,6 +1351,36 @@ describe("Sign Client Integration", () => {
             }),
           ]);
 
+          await throttle(1_000);
+          await deleteClients(clients);
+        });
+        it("can set sui tvf params", async () => {
+          const {
+            clients,
+            sessionA: { topic },
+          } = await initTwoPairedClients(
+            {},
+            {},
+            { logger: "error" },
+            {
+              requiredNamespaces: {
+                sui: {
+                  methods: ["sui_signTransaction", "sui_signAndExecuteTransaction"],
+                  events: [],
+                  chains: ["sui:devnet"],
+                },
+              },
+
+              namespaces: {
+                sui: {
+                  methods: ["sui_signTransaction", "sui_signAndExecuteTransaction"],
+                  events: [],
+                  chains: ["sui:devnet"],
+                  accounts: ["sui:devnet:0x"],
+                },
+              },
+            },
+          );
           // sui sui_signTransaction example
           await Promise.all([
             new Promise<void>((resolve) => {
@@ -1606,6 +1543,35 @@ describe("Sign Client Integration", () => {
               resolve();
             }),
           ]);
+          await throttle(1_000);
+          await deleteClients(clients);
+        });
+        it("can set hedera tvf params", async () => {
+          const {
+            clients,
+            sessionA: { topic },
+          } = await initTwoPairedClients(
+            {},
+            {},
+            { logger: "error" },
+            {
+              requiredNamespaces: {
+                hedera: {
+                  methods: ["hedera_signAndExecuteTransaction", "hedera_executeTransaction"],
+                  events: [],
+                  chains: ["hedera:mainnet"],
+                },
+              },
+              namespaces: {
+                hedera: {
+                  methods: ["hedera_signAndExecuteTransaction", "hedera_executeTransaction"],
+                  events: [],
+                  chains: ["hedera:mainnet"],
+                  accounts: ["hedera:mainnet:0x"],
+                },
+              },
+            },
+          );
 
           // hedera hedera_signAndExecuteTransaction example
           await Promise.all([
@@ -1774,6 +1740,36 @@ describe("Sign Client Integration", () => {
               resolve();
             }),
           ]);
+
+          await throttle(1_000);
+          await deleteClients(clients);
+        });
+        it("it can set near tvf params", async () => {
+          const {
+            clients,
+            sessionA: { topic },
+          } = await initTwoPairedClients(
+            {},
+            {},
+            { logger: "error" },
+            {
+              requiredNamespaces: {
+                near: {
+                  methods: ["near_signTransaction", "near_signTransactions"],
+                  events: [],
+                  chains: ["near:testnet"],
+                },
+              },
+              namespaces: {
+                near: {
+                  methods: ["near_signTransaction", "near_signTransactions"],
+                  events: [],
+                  chains: ["near:testnet"],
+                  accounts: ["near:testnet:0x"],
+                },
+              },
+            },
+          );
 
           // near near_signTransaction example
           await Promise.all([
@@ -1961,6 +1957,36 @@ describe("Sign Client Integration", () => {
             }),
           ]);
 
+          await throttle(1_000);
+          await deleteClients(clients);
+        });
+        it("it can set tron tvf params", async () => {
+          const {
+            clients,
+            sessionA: { topic },
+          } = await initTwoPairedClients(
+            {},
+            {},
+            { logger: "error" },
+            {
+              requiredNamespaces: {
+                tron: {
+                  methods: ["tron_signTransaction"],
+                  events: [],
+                  chains: ["tron:mainnet"],
+                },
+              },
+              namespaces: {
+                tron: {
+                  methods: ["tron_signTransaction"],
+                  events: [],
+                  chains: ["tron:mainnet"],
+                  accounts: ["tron:mainnet:0x"],
+                },
+              },
+            },
+          );
+
           // tron tron_signTransaction example
           await Promise.all([
             new Promise<void>((resolve) => {
@@ -2044,90 +2070,35 @@ describe("Sign Client Integration", () => {
             }),
           ]);
 
-          // xrpl xrpl_signTransaction example
-          await Promise.all([
-            new Promise<void>((resolve) => {
-              clients.B.once("session_request", async (args) => {
-                const pendingRequests = clients.B.pendingRequest.getAll();
-                const { id, topic, params } = pendingRequests[0];
-                expect(params).toEqual(args.params);
-                expect(topic).toEqual(args.topic);
-                expect(id).toEqual(args.id);
-                const expectedTxHashes = ["0x1234567890"];
-                const transaction = {
-                  tx_json: {
-                    hash: expectedTxHashes[0],
-                  },
-                };
-
-                const result = formatJsonRpcResult(id, transaction);
-
-                let checkedWalletPublish = false;
-                clients.B.core.relayer.once(RELAYER_EVENTS.publish, (publishPayload: any) => {
-                  const tvf = publishPayload.params;
-                  if (!tvf) {
-                    return console.error("xrpl tvf is undefined");
-                  }
-                  if (!tvf.chainId || !tvf.rpcMethods || !tvf.txHashes) {
-                    return console.error("xrpl tvf is missing required fields");
-                  }
-                  if (tvf.rpcMethods.length !== 1 && tvf.rpcMethods[0] !== "xrpl_signTransaction") {
-                    return console.error("xrpl tvf rpcMethods is invalid", tvf.rpcMethods);
-                  }
-                  if (tvf.txHashes.join(",") !== expectedTxHashes.join(",")) {
-                    return console.error(
-                      "xrpl txHashes do not match: transactionId",
-                      tvf.txHashes,
-                      result.result,
-                    );
-                  }
-
-                  checkedWalletPublish = true;
-                });
-
-                await clients.B.respond({
-                  topic,
-                  response: result,
-                });
-
-                expect(checkedWalletPublish).to.be.true;
-                resolve();
-              });
-            }),
-            new Promise<void>(async (resolve) => {
-              const requestParams = {
-                method: "xrpl_signTransaction",
-                params: [
-                  {
-                    data: "0xdeadbeef",
-                  },
-                ],
-              };
-              let checkedDappPublish = false;
-
-              clients.A.core.relayer.once(RELAYER_EVENTS.publish, (publishPayload: any) => {
-                checkedDappPublish = true;
-                const tvf = publishPayload.params;
-                expect(tvf).to.exist;
-                expect(tvf?.chainId).to.eq(TEST_REQUEST_PARAMS.chainId);
-                expect(tvf?.rpcMethods).to.eql([requestParams.method]);
-                expect(tvf?.txHashes).to.be.undefined;
-                expect(tvf?.contractAddresses).to.eql([requestParams.params[0].to]);
-              });
-
-              await clients.A.request({
-                topic,
-                ...TEST_REQUEST_PARAMS,
-                request: {
-                  ...TEST_REQUEST_PARAMS.request,
-                  ...requestParams,
+          await throttle(1_000);
+          await deleteClients(clients);
+        });
+        it("it can set xrpl tvf params", async () => {
+          const {
+            clients,
+            sessionA: { topic },
+          } = await initTwoPairedClients(
+            {},
+            {},
+            { logger: "error" },
+            {
+              requiredNamespaces: {
+                xrpl: {
+                  methods: ["xrpl_signTransaction", "xrpl_signTransactionFor"],
+                  events: [],
+                  chains: ["xrpl:mainnet"],
                 },
-                chainId: "xrpl:mainnet",
-              });
-              expect(checkedDappPublish).to.be.true;
-              resolve();
-            }),
-          ]);
+              },
+              namespaces: {
+                xrpl: {
+                  methods: ["xrpl_signTransaction", "xrpl_signTransactionFor"],
+                  events: [],
+                  chains: ["xrpl:mainnet"],
+                  accounts: ["xrpl:mainnet:0x"],
+                },
+              },
+            },
+          );
 
           // xrpl xrpl_signTransactionFor example
           await Promise.all([
@@ -2217,6 +2188,36 @@ describe("Sign Client Integration", () => {
             }),
           ]);
 
+          await throttle(1_000);
+          await deleteClients(clients);
+        });
+        it("it can set algorand tvf params", async () => {
+          const {
+            clients,
+            sessionA: { topic },
+          } = await initTwoPairedClients(
+            {},
+            {},
+            { logger: "error" },
+            {
+              requiredNamespaces: {
+                algorand: {
+                  methods: ["algo_signTxn"],
+                  events: [],
+                  chains: ["algorand:mainnet"],
+                },
+              },
+              namespaces: {
+                algorand: {
+                  methods: ["algo_signTxn"],
+                  events: [],
+                  chains: ["algorand:mainnet"],
+                  accounts: ["algorand:mainnet:0x"],
+                },
+              },
+            },
+          );
+
           // algorand algo_signTxn example
           await Promise.all([
             new Promise<void>((resolve) => {
@@ -2299,6 +2300,36 @@ describe("Sign Client Integration", () => {
               resolve();
             }),
           ]);
+
+          await throttle(1_000);
+          await deleteClients(clients);
+        });
+        it("it can set bip122 tvf params", async () => {
+          const {
+            clients,
+            sessionA: { topic },
+          } = await initTwoPairedClients(
+            {},
+            {},
+            { logger: "error" },
+            {
+              requiredNamespaces: {
+                bip122: {
+                  methods: ["sendTransfer"],
+                  events: [],
+                  chains: ["bip122:mainnet"],
+                },
+              },
+              namespaces: {
+                bip122: {
+                  methods: ["sendTransfer"],
+                  events: [],
+                  chains: ["bip122:mainnet"],
+                  accounts: ["bip122:mainnet:0x"],
+                },
+              },
+            },
+          );
 
           // bip122 sendTransfer example
           await Promise.all([
@@ -2383,6 +2414,36 @@ describe("Sign Client Integration", () => {
             }),
           ]);
 
+          await throttle(1_000);
+          await deleteClients(clients);
+        });
+        it("it can set stacks tvf params", async () => {
+          const {
+            clients,
+            sessionA: { topic },
+          } = await initTwoPairedClients(
+            {},
+            {},
+            { logger: "error" },
+            {
+              requiredNamespaces: {
+                stacks: {
+                  methods: ["stacks_stxTransfer"],
+                  events: [],
+                  chains: ["stacks:mainnet"],
+                },
+              },
+              namespaces: {
+                stacks: {
+                  methods: ["stacks_stxTransfer"],
+                  events: [],
+                  chains: ["stacks:mainnet"],
+                  accounts: ["stacks:mainnet:0x"],
+                },
+              },
+            },
+          );
+
           // stacks stacks_stxTransfer example
           await Promise.all([
             new Promise<void>((resolve) => {
@@ -2465,6 +2526,36 @@ describe("Sign Client Integration", () => {
               resolve();
             }),
           ]);
+
+          await throttle(1_000);
+          await deleteClients(clients);
+        });
+        it("it can set polkadot tvf params", async () => {
+          const {
+            clients,
+            sessionA: { topic },
+          } = await initTwoPairedClients(
+            {},
+            {},
+            { logger: "error" },
+            {
+              requiredNamespaces: {
+                polkadot: {
+                  methods: ["polkadot_signTransaction"],
+                  events: [],
+                  chains: ["polkadot:mainnet"],
+                },
+              },
+              namespaces: {
+                polkadot: {
+                  methods: ["polkadot_signTransaction"],
+                  events: [],
+                  chains: ["polkadot:mainnet"],
+                  accounts: ["polkadot:mainnet:0x"],
+                },
+              },
+            },
+          );
 
           // polkadot polkadot_signTransaction example
           await Promise.all([
@@ -2568,6 +2659,36 @@ describe("Sign Client Integration", () => {
             }),
           ]);
 
+          await throttle(1_000);
+          await deleteClients(clients);
+        });
+        it("it can set cosmos tvf params", async () => {
+          const {
+            clients,
+            sessionA: { topic },
+          } = await initTwoPairedClients(
+            {},
+            {},
+            { logger: "error" },
+            {
+              requiredNamespaces: {
+                cosmos: {
+                  methods: ["cosmos_signDirect"],
+                  events: [],
+                  chains: ["cosmos:mainnet"],
+                },
+              },
+              namespaces: {
+                cosmos: {
+                  methods: ["cosmos_signDirect"],
+                  events: [],
+                  chains: ["cosmos:mainnet"],
+                  accounts: ["cosmos:mainnet:0x"],
+                },
+              },
+            },
+          );
+
           // cosmos cosmos_signDirect example
           await Promise.all([
             new Promise<void>((resolve) => {
@@ -2658,6 +2779,199 @@ describe("Sign Client Integration", () => {
                   ...requestParams,
                 },
                 chainId: "cosmos:mainnet",
+              });
+              expect(checkedDappPublish).to.be.true;
+              resolve();
+            }),
+          ]);
+
+          await throttle(1_000);
+          await deleteClients(clients);
+        });
+        it("can set sui tvf params", async () => {
+          const {
+            clients,
+            sessionA: { topic },
+          } = await initTwoPairedClients(
+            {},
+            {},
+            { logger: "error" },
+            {
+              requiredNamespaces: {
+                sui: {
+                  methods: ["sui_signTransaction", "sui_signAndExecuteTransaction"],
+                  events: [],
+                  chains: ["sui:devnet"],
+                },
+              },
+              namespaces: {
+                sui: {
+                  methods: ["sui_signTransaction", "sui_signAndExecuteTransaction"],
+                  events: [],
+                  chains: ["sui:devnet"],
+                  accounts: ["sui:devnet:0x"],
+                },
+              },
+            },
+          );
+
+          // sui sui_signTransaction example
+          await Promise.all([
+            new Promise<void>((resolve) => {
+              clients.B.once("session_request", async (args) => {
+                const pendingRequests = clients.B.pendingRequest.getAll();
+                const { id, topic, params } = pendingRequests[0];
+                expect(params).toEqual(args.params);
+                expect(topic).toEqual(args.topic);
+                expect(id).toEqual(args.id);
+
+                const result = formatJsonRpcResult(id, {
+                  transactionBytes:
+                    "AAACAAhkAAAAAAAAAAAg1fZH7bd9T9ox0DBFBkR/s8kuVar3e8XtS3fDMt1GBfoCAgABAQAAAQEDAAAAAAEBANX2R+23fU/aMdAwRQZEf7PJLlWq93vF7Ut3wzLdRgX6At/pRJzj2VpZgqXpSvEtd3GzPvt99hR8e/yOCGz/8nbRmA7QFAAAAAAgBy5vStJizn76LmJTBlDiONdR/2rSuzzS4L+Tp/Zs4hZ8cBxYkcSlxBD6QXvgS11E6d+DNek8LiA/beba6iH3l5gO0BQAAAAAIMpdmZjiqJ5GG9di1MAgD4S3uRr2gaMC7S1WsaeBwNIx1fZH7bd9T9ox0DBFBkR/s8kuVar3e8XtS3fDMt1GBfroAwAAAAAAAECrPAAAAAAAAA==",
+                });
+                const expectedTxHashes = ["C98G1Uwh5soPMtZZmjUFwbVzWLMoAHzi5jrX2BtABe8v"];
+                let checkedWalletPublish = false;
+                clients.B.core.relayer.once(RELAYER_EVENTS.publish, (publishPayload: any) => {
+                  const tvf = publishPayload.params;
+                  if (!tvf) {
+                    return console.error("sui tvf is undefined");
+                  }
+                  if (!tvf.chainId || !tvf.rpcMethods || !tvf.txHashes) {
+                    return console.error("sui tvf is missing required fields");
+                  }
+                  if (tvf.txHashes.join(",") !== expectedTxHashes.join(",")) {
+                    return console.error(
+                      "sui txHashes do not match: transactionBytes",
+                      tvf.txHashes,
+                      result.result.transactionBytes,
+                    );
+                  }
+
+                  checkedWalletPublish = true;
+                });
+
+                await clients.B.respond({
+                  topic,
+                  response: result,
+                });
+
+                expect(checkedWalletPublish).to.be.true;
+                resolve();
+              });
+            }),
+            new Promise<void>(async (resolve) => {
+              const requestParams = {
+                method: "sui_signTransaction",
+                params: [
+                  {
+                    data: "0xdeadbeef",
+                  },
+                ],
+              };
+              let checkedDappPublish = false;
+
+              clients.A.core.relayer.once(RELAYER_EVENTS.publish, (publishPayload: any) => {
+                checkedDappPublish = true;
+                const tvf = publishPayload.params;
+                expect(tvf).to.exist;
+                expect(tvf?.chainId).to.eq(TEST_REQUEST_PARAMS.chainId);
+                expect(tvf?.rpcMethods).to.eql([requestParams.method]);
+                expect(tvf?.txHashes).to.be.undefined;
+                expect(tvf?.contractAddresses).to.eql([requestParams.params[0].to]);
+              });
+
+              await clients.A.request({
+                topic,
+                ...TEST_REQUEST_PARAMS,
+                request: {
+                  ...TEST_REQUEST_PARAMS.request,
+                  ...requestParams,
+                },
+                chainId: "sui:devnet",
+              });
+              expect(checkedDappPublish).to.be.true;
+              resolve();
+            }),
+          ]);
+
+          // sui sui_signAndExecuteTransaction example
+          await Promise.all([
+            new Promise<void>((resolve) => {
+              clients.B.once("session_request", async (args) => {
+                const pendingRequests = clients.B.pendingRequest.getAll();
+                const { id, topic, params } = pendingRequests[0];
+                expect(params).toEqual(args.params);
+                expect(topic).toEqual(args.topic);
+                expect(id).toEqual(args.id);
+                const expectedTxHashes = ["C98G1Uwh5soPMtZZmjUFwbVzWLMoAHzi5jrX2BtABe8v"];
+                const result = formatJsonRpcResult(id, {
+                  digest: expectedTxHashes[0],
+                });
+
+                let checkedWalletPublish = false;
+                clients.B.core.relayer.once(RELAYER_EVENTS.publish, (publishPayload: any) => {
+                  const tvf = publishPayload.params;
+                  if (!tvf) {
+                    return console.error("sui tvf is undefined");
+                  }
+                  if (!tvf.chainId || !tvf.rpcMethods || !tvf.txHashes) {
+                    return console.error("sui tvf is missing required fields");
+                  }
+                  if (
+                    tvf.rpcMethods.length !== 1 &&
+                    tvf.rpcMethods[0] !== "sui_signAndExecuteTransaction"
+                  ) {
+                    return console.error("sui tvf rpcMethods is invalid", tvf.rpcMethods);
+                  }
+                  if (tvf.txHashes.join(",") !== expectedTxHashes.join(",")) {
+                    return console.error(
+                      "sui txHashes do not match: digest",
+                      tvf.txHashes,
+                      result.result.digest,
+                    );
+                  }
+
+                  checkedWalletPublish = true;
+                });
+
+                await clients.B.respond({
+                  topic,
+                  response: result,
+                });
+
+                expect(checkedWalletPublish).to.be.true;
+                resolve();
+              });
+            }),
+            new Promise<void>(async (resolve) => {
+              const requestParams = {
+                method: "sui_signAndExecuteTransaction",
+                params: [
+                  {
+                    data: "0xdeadbeef",
+                  },
+                ],
+              };
+              let checkedDappPublish = false;
+
+              clients.A.core.relayer.once(RELAYER_EVENTS.publish, (publishPayload: any) => {
+                checkedDappPublish = true;
+                const tvf = publishPayload.params;
+                expect(tvf).to.exist;
+                expect(tvf?.chainId).to.eq(TEST_REQUEST_PARAMS.chainId);
+                expect(tvf?.rpcMethods).to.eql([requestParams.method]);
+                expect(tvf?.txHashes).to.be.undefined;
+                expect(tvf?.contractAddresses).to.eql([requestParams.params[0].to]);
+              });
+
+              await clients.A.request({
+                topic,
+                ...TEST_REQUEST_PARAMS,
+                request: {
+                  ...TEST_REQUEST_PARAMS.request,
+                  ...requestParams,
+                },
+                chainId: "sui:devnet",
               });
               expect(checkedDappPublish).to.be.true;
               resolve();
@@ -2893,7 +3207,7 @@ describe("Sign Client Integration", () => {
       });
     });
   });
-  describe("update", () => {
+  describe.concurrent("update", () => {
     it("updates session namespaces state with provided namespaces", async () => {
       const {
         clients,
@@ -2919,45 +3233,7 @@ describe("Sign Client Integration", () => {
     });
   });
 
-  describe("extend", () => {
-    it("updates session expiry state initiated by client A", async () => {
-      const {
-        clients,
-        sessionA: { topic },
-      } = await initTwoPairedClients({}, {}, { logger: "error" });
-      const prevExpiry = clients.A.session.get(topic).expiry;
-      vi.useFakeTimers({ shouldAdvanceTime: true });
-      // Fast-forward system time by 60 seconds after expiry was first set.
-      vi.setSystemTime(Date.now() + 60_000);
-      const { acknowledged } = await clients.A.extend({
-        topic,
-      });
-      await acknowledged();
-      const updatedExpiry = clients.A.session.get(topic).expiry;
-      expect(updatedExpiry).to.be.greaterThan(prevExpiry);
-      vi.useRealTimers();
-      await deleteClients(clients);
-    });
-    it("updates session expiry state initiated by client B", async () => {
-      const {
-        clients,
-        sessionA: { topic },
-      } = await initTwoPairedClients({}, {}, { logger: "error" });
-      const prevExpiry = clients.A.session.get(topic).expiry;
-      vi.useFakeTimers({ shouldAdvanceTime: true });
-      // Fast-forward system time by 60 seconds after expiry was first set.
-      vi.setSystemTime(Date.now() + 60_000);
-      const { acknowledged } = await clients.A.extend({
-        topic,
-      });
-      await acknowledged();
-      const updatedExpiry = clients.A.session.get(topic).expiry;
-      expect(updatedExpiry).to.be.greaterThan(prevExpiry);
-      vi.useRealTimers();
-      await deleteClients(clients);
-    });
-  });
-  describe("namespaces", () => {
+  describe.concurrent("namespaces", () => {
     it("should pair with empty namespaces", async () => {
       const clients = await initTwoClients();
       const requiredNamespaces = {};
@@ -2973,7 +3249,7 @@ describe("Sign Client Integration", () => {
     });
   });
 
-  describe("session requests", () => {
+  describe.concurrent("session requests", () => {
     it("should set custom request expiry", async () => {
       const {
         clients,
@@ -3118,44 +3394,7 @@ describe("Sign Client Integration", () => {
       await deleteClients(clients);
     });
   });
-  describe("Events Client", () => {
-    it("should create event during pairing flow", async () => {
-      const clients = await initTwoClients();
-      const { uri } = await clients.A.connect({});
-      if (!uri) throw new Error("URI is undefined");
-      await clients.B.pair({ uri });
-      const { topic } = parseUri(uri);
-      expect(clients.B.core.eventClient.events.size).to.eq(1);
-      const event = clients.B.core.eventClient.getEvent({ topic });
-      if (!event) throw new Error("Event is undefined");
-      expect(event).to.exist;
-      expect(event.props.event).to.eq("ERROR");
-      expect(event.props.type).to.eq(""); // there is no type yet as no error has happened
-      expect(event.props.properties.topic).to.eq(topic);
-      expect(event.props.properties.trace).to.exist;
-      expect(event.props.properties.trace.length).to.toBeGreaterThan(0);
-
-      await new Promise<void>((resolve) => {
-        clients.B.once("session_proposal", (params) => {
-          resolve();
-        });
-      });
-
-      expect(event.props.properties.trace).to.include(
-        EVENT_CLIENT_PAIRING_TRACES.emit_session_proposal,
-      );
-
-      vi.useFakeTimers({ shouldAdvanceTime: true });
-      vi.useFakeTimers({ shouldAdvanceTime: true, shouldClearNativeTimers: true });
-      vi.setSystemTime(Date.now() + 60_000 * 6);
-      await throttle(5_000);
-
-      expect(event.props.type).to.eq(EVENT_CLIENT_PAIRING_ERRORS.proposal_expired);
-
-      vi.useRealTimers();
-
-      await deleteClients(clients);
-    });
+  describe.concurrent("Events Client", () => {
     it("should set missing event listener error type", async () => {
       const clients = await initTwoClients();
       const { uri } = await clients.A.connect({});
@@ -3232,5 +3471,82 @@ describe("Sign Client Integration", () => {
 
       await deleteClients(clients);
     });
+  });
+});
+// don't use concurrency here as these tests change timeclock
+describe("extend", () => {
+  it("updates session expiry state initiated by client A", async () => {
+    const {
+      clients,
+      sessionA: { topic },
+    } = await initTwoPairedClients({}, {}, { logger: "error" });
+    const prevExpiry = clients.A.session.get(topic).expiry;
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    // Fast-forward system time by 60 seconds after expiry was first set.
+    vi.setSystemTime(Date.now() + 60_000);
+    const { acknowledged } = await clients.A.extend({
+      topic,
+    });
+    await acknowledged();
+    const updatedExpiry = clients.A.session.get(topic).expiry;
+    expect(updatedExpiry).to.be.greaterThan(prevExpiry);
+    vi.useRealTimers();
+    await deleteClients(clients);
+  });
+  it("updates session expiry state initiated by client B", async () => {
+    const {
+      clients,
+      sessionA: { topic },
+    } = await initTwoPairedClients({}, {}, { logger: "error" });
+    const prevExpiry = clients.A.session.get(topic).expiry;
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    // Fast-forward system time by 60 seconds after expiry was first set.
+    vi.setSystemTime(Date.now() + 60_000);
+    const { acknowledged } = await clients.A.extend({
+      topic,
+    });
+    await acknowledged();
+    const updatedExpiry = clients.A.session.get(topic).expiry;
+    expect(updatedExpiry).to.be.greaterThan(prevExpiry);
+    vi.useRealTimers();
+    await deleteClients(clients);
+  });
+
+  it("should create event during pairing flow", async () => {
+    const clients = await initTwoClients();
+    const { uri } = await clients.A.connect({});
+    if (!uri) throw new Error("URI is undefined");
+    await clients.B.pair({ uri });
+    const { topic } = parseUri(uri);
+    expect(clients.B.core.eventClient.events.size).to.eq(1);
+    const event = clients.B.core.eventClient.getEvent({ topic });
+    if (!event) throw new Error("Event is undefined");
+    expect(event).to.exist;
+    expect(event.props.event).to.eq("ERROR");
+    expect(event.props.type).to.eq(""); // there is no type yet as no error has happened
+    expect(event.props.properties.topic).to.eq(topic);
+    expect(event.props.properties.trace).to.exist;
+    expect(event.props.properties.trace.length).to.toBeGreaterThan(0);
+
+    await new Promise<void>((resolve) => {
+      clients.B.once("session_proposal", (params) => {
+        resolve();
+      });
+    });
+
+    expect(event.props.properties.trace).to.include(
+      EVENT_CLIENT_PAIRING_TRACES.emit_session_proposal,
+    );
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.useFakeTimers({ shouldAdvanceTime: true, shouldClearNativeTimers: true });
+    vi.setSystemTime(Date.now() + 60_000 * 6);
+    await throttle(5_000);
+
+    expect(event.props.type).to.eq(EVENT_CLIENT_PAIRING_ERRORS.proposal_expired);
+
+    vi.useRealTimers();
+
+    await deleteClients(clients);
   });
 });

--- a/packages/sign-client/test/sdk/persistence.spec.ts
+++ b/packages/sign-client/test/sdk/persistence.spec.ts
@@ -20,7 +20,7 @@ import { RelayerTypes } from "@walletconnect/types";
 const generateClientDbName = (prefix: string) =>
   `./test/tmp/${prefix}_${generateRandomBytes32()}.db`;
 
-describe("Sign Client Persistence", () => {
+describe.concurrent("Sign Client Persistence", () => {
   describe("ping", () => {
     describe("pairing", () => {
       describe("after restart", () => {

--- a/packages/sign-client/test/sdk/persistence.spec.ts
+++ b/packages/sign-client/test/sdk/persistence.spec.ts
@@ -66,7 +66,7 @@ describe.concurrent("Sign Client Persistence", () => {
               }
             }),
           ]);
-
+          await throttle(2000);
           await deleteClients(clients);
           // restart
           clients = await initTwoClients(
@@ -98,6 +98,7 @@ describe.concurrent("Sign Client Persistence", () => {
           await clients.A.ping({ topic });
           await clients.B.ping({ topic });
 
+          await throttle(2000);
           await deleteClients(clients);
         });
       });

--- a/packages/sign-client/test/sdk/transport.spec.ts
+++ b/packages/sign-client/test/sdk/transport.spec.ts
@@ -7,7 +7,7 @@ import {
   initTwoPairedClients,
 } from "../shared";
 
-describe("Sign Client Transport Tests", () => {
+describe.concurrent("Sign Client Transport Tests", () => {
   describe("transport", () => {
     it("should disconnect & reestablish socket transport", async () => {
       const {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     "process.env.DISABLE_GLOBAL_CORE": true,
   },
   test: {
-    testTimeout: 300_000,
-    hookTimeout: 300_000,
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
   },
 });


### PR DESCRIPTION
## Description

This PR removes redundant acknowledgment logic when handling session disconnect requests in the sign-client. The main change eliminates an unnecessary ACK response that was being sent back to the originating sign-client when a disconnect request was received, streamlining the disconnect flow.

Key Changes:

- Simplified disconnect request handling by removing redundant ACK logic
- Improved test concurrency by adding .concurrent to multiple test suites
- Refactored large test cases into smaller, focused tests for better isolation

The ACK is being removed because often by the time it was received by the peer, the session is already deleted resulting in error log


## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
tests


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the extra ACK on session disconnect and hardens session proposal/settlement handling, while converting test suites to concurrent with expanded TVF coverage and shorter timeouts.
> 
> - **Sign Client Engine**:
>   - Removes redundant ACK on session disconnect: simplify `onSessionDeleteRequest` to validate, cleanup pending sent requests, and `deleteSession` without sending a `wc_sessionDelete` result.
>   - Session proposal flow: set and expire-track proposals before publish; on publish failure, delete via `deleteProposal`.
>   - Session settle flow: add `throwOnFailedPublish` to `wc_sessionSettle` result and emit `session_connect` after successful publish.
>   - Cleanup: delete pending session requests in parallel for a topic; streamline `cleanupPendingSentRequestsForTopic` emissions.
> - **Tests**:
>   - Convert many suites to `describe.concurrent` (auth, client, disconnect/ping/namespaces/session requests, persistence, transport).
>   - Split/expand transaction verification fields (TVF) tests across chains (`eip155`, `solana`, `sui`, `hedera`, `near`, `tron`, `xrpl`, `algorand`, `bip122`, `stacks`, `polkadot`, `cosmos`).
>   - Isolate time-sensitive "extend" tests without concurrency; add throttles and minor ordering tweaks.
> - **Config**:
>   - Reduce Vitest `testTimeout` and `hookTimeout` to `60_000`.
> - **Changeset**:
>   - Patch bumps for `@walletconnect/*` packages with note on removing redundant disconnect ACK.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b4cc0a26f8ec231d2b9fa2c26278298f356e096. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->