### PR TITLE
chore: added missing pending promise expiry message

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -573,7 +573,14 @@ export class Engine extends IEngine {
     }
     const { topic, namespaces } = params;
 
-    const { done: acknowledged, resolve, reject } = createDelayedPromise<void>();
+    const {
+      done: acknowledged,
+      resolve,
+      reject,
+    } = createDelayedPromise<void>(
+      FIVE_MINUTES,
+      "Session update request expired without receiving any acknowledgement",
+    );
     const clientRpcId = payloadId();
     const relayRpcId = getBigIntRpcId().toString() as any;
 
@@ -615,7 +622,14 @@ export class Engine extends IEngine {
 
     const { topic } = params;
     const clientRpcId = payloadId();
-    const { done: acknowledged, resolve, reject } = createDelayedPromise<void>();
+    const {
+      done: acknowledged,
+      resolve,
+      reject,
+    } = createDelayedPromise<void>(
+      FIVE_MINUTES,
+      "Session extend request expired without receiving any acknowledgement",
+    );
     this.events.once(engineEvent("session_extend", clientRpcId), ({ error }: any) => {
       if (error) reject(error);
       else resolve();
@@ -797,7 +811,10 @@ export class Engine extends IEngine {
     if (this.client.session.keys.includes(topic)) {
       const clientRpcId = payloadId();
       const relayRpcId = getBigIntRpcId().toString() as any;
-      const { done, resolve, reject } = createDelayedPromise<void>();
+      const { done, resolve, reject } = createDelayedPromise<void>(
+        FIVE_MINUTES,
+        "Ping request expired without receiving any acknowledgement",
+      );
       this.events.once(engineEvent("session_ping", clientRpcId), ({ error }: any) => {
         if (error) reject(error);
         else resolve();


### PR DESCRIPTION
## Description
This PR adds timeout configuration to createDelayedPromise calls for three session management methods (update, extend, and ping) in the Sign Client engine. Previously, these methods created delayed promises without explicit timeout values or error messages.

- Adds 5-minute timeout with descriptive error messages to session update, extend, and ping operations
- Improves user experience by providing clear feedback when operations expire
- Aligns timeout behavior with other operations in the codebase (e.g., session request, session proposal)

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
n/a
## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit 5-minute timeouts with expiry messages for pending acknowledgements in `update`, `extend`, and `ping` flows.
> 
> - **Sign Client Engine (`packages/sign-client/src/controllers/engine.ts`)**:
>   - Add 5-minute timeout and explicit expiry messages to `createDelayedPromise` for:
>     - `update()` session ack: "Session update request expired without receiving any acknowledgement".
>     - `extend()` session ack: "Session extend request expired without receiving any acknowledgement".
>     - `ping()` session ack: "Ping request expired without receiving any acknowledgement".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28c7b38845165d75d0de2a2e1cfea591b0d23832. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->