### PR TITLE
chore: resubscribe when no result is received

### DIFF
--- a/packages/sign-client/src/constants/engine.ts
+++ b/packages/sign-client/src/constants/engine.ts
@@ -3,6 +3,10 @@ import { EngineTypes } from "@walletconnect/types";
 
 export const ENGINE_CONTEXT = "engine";
 
+export const MAX_RESUBSCRIBE_ATTEMPTS_ON_PENDING_RESULTS = 3;
+
+export const RESUBSCRIBE_INTERVAL = 30;
+
 export const ENGINE_RPC_OPTS: EngineTypes.RpcOptsMap = {
   wc_sessionPropose: {
     req: {

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -26,7 +26,7 @@ import {
   ErrorResponse,
   getBigIntRpcId,
 } from "@walletconnect/jsonrpc-utils";
-import { FIVE_MINUTES, ONE_SECOND, toMiliseconds } from "@walletconnect/time";
+import { FIVE_MINUTES, fromMiliseconds, ONE_SECOND, toMiliseconds } from "@walletconnect/time";
 import {
   EnginePrivate,
   EngineTypes,
@@ -122,7 +122,10 @@ import {
   ENGINE_QUEUE_STATES,
   AUTH_PUBLIC_KEY_NAME,
   TVF_METHODS,
+  RESUBSCRIBE_INTERVAL,
+  MAX_RESUBSCRIBE_ATTEMPTS_ON_PENDING_RESULTS,
 } from "../constants/index.js";
+import { HEARTBEAT_EVENTS } from "@walletconnect/heartbeat";
 
 export class Engine extends IEngine {
   public name = ENGINE_CONTEXT;
@@ -172,6 +175,18 @@ export class Engine extends IEngine {
     }
   > = new Map();
 
+  // most flows depend on sending a request and receiving a result from the peer sign-client sdk
+  // this map is used to store the messages that are waiting for a result
+  // the key is the clientRpcId of the request, the value is the topic of the request
+  private requestWaitingForResult: Map<
+    number,
+    {
+      topic: string;
+      waitingSince: number;
+      resubscribeAttempts?: number;
+    }
+  > = new Map();
+
   constructor(client: IEngine["client"]) {
     super(client);
   }
@@ -179,6 +194,7 @@ export class Engine extends IEngine {
   public init: IEngine["init"] = async () => {
     if (!this.initialized) {
       await this.cleanup();
+      this.registerHeartbeatEvents();
       this.registerRelayerEvents();
       this.registerExpirerEvents();
       this.registerPairingEvents();
@@ -365,7 +381,7 @@ export class Engine extends IEngine {
     });
 
     await this.setProposal(proposal.id, proposal);
-
+    this.requestWaitingForResult.set(proposal.id, { topic, waitingSince: Date.now() });
     await this.sendProposeSession({
       proposal,
       publishOpts: {
@@ -378,6 +394,7 @@ export class Engine extends IEngine {
       },
     }).catch((error) => {
       this.deleteProposal(proposal.id);
+      this.requestWaitingForResult.delete(proposal.id);
       throw error;
     });
 
@@ -741,6 +758,8 @@ export class Engine extends IEngine {
       chainId,
     };
 
+    this.requestWaitingForResult.set(clientRpcId, { topic, waitingSince: Date.now() });
+
     return await Promise.all([
       new Promise<void>(async (resolve) => {
         await this.sendRequest({
@@ -752,7 +771,10 @@ export class Engine extends IEngine {
           expiry,
           throwOnFailedPublish: true,
           tvf: this.getTVFParams(clientRpcId, protocolRequestParams),
-        }).catch((error) => reject(error));
+        }).catch((error) => {
+          this.requestWaitingForResult.delete(clientRpcId);
+          reject(error);
+        });
         this.client.events.emit("session_request_sent", {
           topic,
           request,
@@ -847,13 +869,20 @@ export class Engine extends IEngine {
         else resolve();
       });
       await Promise.all([
-        this.sendRequest({
-          topic,
-          method: "wc_sessionPing",
-          params: {},
-          throwOnFailedPublish: true,
-          clientRpcId,
-          relayRpcId,
+        new Promise<void>(async (resolve) => {
+          this.requestWaitingForResult.set(clientRpcId, { topic, waitingSince: Date.now() });
+          await this.sendRequest({
+            topic,
+            method: "wc_sessionPing",
+            params: {},
+            throwOnFailedPublish: true,
+            clientRpcId,
+            relayRpcId,
+          }).catch((error) => {
+            this.requestWaitingForResult.delete(clientRpcId);
+            reject(error);
+          });
+          resolve();
         }),
         done(),
       ]);
@@ -1884,6 +1913,47 @@ export class Engine extends IEngine {
     await this.client.core.relayer.confirmOnlineStateOrThrow();
   }
 
+  // ---------- Heartbeat Event ----------------------------------- //
+
+  /**
+   * This function is used to register the heartbeat events for the engine
+   * It checks if any requests are still waiting for a result and resubscribes to the topic if needed
+   * It also logs a warning if the request is still waiting for a result after the maximum number of attempts
+   * It also logs a debug message if the request is resubscribed to the topic
+   * It also logs a warning if the request is still waiting for a result after the maximum number of attempts
+   */
+  private registerHeartbeatEvents() {
+    this.client.core.heartbeat.on(HEARTBEAT_EVENTS.pulse, async () => {
+      for (const [clientRpcId, request] of this.requestWaitingForResult.entries()) {
+        const attempts = (request.resubscribeAttempts || 0) + 1;
+        if (fromMiliseconds(Date.now() - request.waitingSince) > attempts * RESUBSCRIBE_INTERVAL) {
+          if (attempts <= MAX_RESUBSCRIBE_ATTEMPTS_ON_PENDING_RESULTS) {
+            this.client.logger.debug(
+              `Resubscribing to topic ${request.topic} for request ${clientRpcId}, attempt ${attempts}`,
+            );
+            try {
+              this.requestWaitingForResult.set(clientRpcId, {
+                ...request,
+                resubscribeAttempts: attempts,
+              });
+              await this.client.core.relayer.subscribe(request.topic, {
+                internal: { throwOnFailedPublish: true },
+              });
+            } catch (error) {
+              this.client.logger.warn(
+                `Failed to resubscribe to topic ${request.topic} for request ${clientRpcId}, attempt ${attempts}`,
+              );
+            }
+          } else {
+            this.client.logger.warn(
+              `Request ${clientRpcId} still hasn't received a result after ${attempts * RESUBSCRIBE_INTERVAL}s, giving up`,
+            );
+          }
+        }
+      }
+    });
+  }
+
   // ---------- Relay Events Router ----------------------------------- //
 
   private registerRelayerEvents() {
@@ -2019,6 +2089,8 @@ export class Engine extends IEngine {
     const { topic, payload, transportType } = event;
     const record = await this.client.core.history.get(topic, payload.id);
     const resMethod = record.request.method as JsonRpcTypes.WcMethod;
+
+    this.requestWaitingForResult.delete(payload.id);
 
     switch (resMethod) {
       case "wc_sessionPropose":

--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -16,13 +16,14 @@ import { describe, it, expect, afterEach } from "vitest";
 import { SignClient } from "../../src";
 import { formatJsonRpcResult } from "@walletconnect/jsonrpc-utils";
 import { RELAYER_EVENTS } from "@walletconnect/core";
+import { ISignClient } from "@walletconnect/types";
 
 const environment = process.env.ENVIRONMENT || "dev";
 const region = process.env.REGION || "unknown";
 const logger = process.env.LOGGER || "error";
-const log = (log: string) => {
+const log = (log: string, level = "log") => {
   // eslint-disable-next-line no-console
-  console.log(log);
+  console[level](log);
 };
 
 describe("Canary", () => {
@@ -219,6 +220,23 @@ describe("Canary", () => {
 
       if (environment === "prod") {
         await publishToStatusPage(latencyMs);
+      }
+
+      // @ts-expect-error- private property
+      const clientARequestsWaitingForResult = A.engine.requestWaitingForResult?.values() || [];
+      // @ts-expect-error- private property
+      const clientBRequestsWaitingForResult = B.engine.requestWaitingForResult?.values() || [];
+      if (clientARequestsWaitingForResult.length > 0) {
+        log(
+          `Client A (${await A.core.crypto.getClientId()}) has ${clientARequestsWaitingForResult.length} requests waiting for result, ${JSON.stringify(clientARequestsWaitingForResult)}`,
+          "error",
+        );
+      }
+      if (clientBRequestsWaitingForResult.length > 0) {
+        log(
+          `Client B (${await B.core.crypto.getClientId()}) has ${clientBRequestsWaitingForResult.length} requests waiting for result, ${JSON.stringify(clientBRequestsWaitingForResult)}`,
+          "error",
+        );
       }
 
       const clientDisconnect = new Promise<void>((resolve, reject) => {

--- a/packages/sign-client/test/canary/canary.spec.ts
+++ b/packages/sign-client/test/canary/canary.spec.ts
@@ -222,10 +222,14 @@ describe("Canary", () => {
         await publishToStatusPage(latencyMs);
       }
 
-      // @ts-expect-error- private property
-      const clientARequestsWaitingForResult = A.engine.requestWaitingForResult?.values() || [];
-      // @ts-expect-error- private property
-      const clientBRequestsWaitingForResult = B.engine.requestWaitingForResult?.values() || [];
+      const clientARequestsWaitingForResult = Array.from(
+        // @ts-expect-error- private property
+        A.engine.requestWaitingForResult?.values() || [],
+      );
+      const clientBRequestsWaitingForResult = Array.from(
+        // @ts-expect-error- private property
+        B.engine.requestWaitingForResult?.values() || [],
+      );
       if (clientARequestsWaitingForResult.length > 0) {
         log(
           `Client A (${await A.core.crypto.getClientId()}) has ${clientARequestsWaitingForResult.length} requests waiting for result, ${JSON.stringify(clientARequestsWaitingForResult)}`,


### PR DESCRIPTION
## Description

This PR implements a resubscription mechanism to handle pending requests that haven't received responses from peer clients. The feature uses a heartbeat to periodically check for requests waiting too long and automatically resubscribes to topics to ensure message delivery.

Key changes:

- Added requestWaitingForResult map to track pending requests with timestamps
- Implemented heartbeat-based monitoring that resubscribes to topics for stale requests
- Added diagnostic logging in canary tests to identify requests stuck without responses

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds heartbeat-driven resubscription for requests awaiting results and tracks them across propose/request/ping flows; tests now log any pending requests.
> 
> - **Engine (sign-client)**
>   - Introduces `requestWaitingForResult` map to track RPCs awaiting responses; entries added for `wc_sessionPropose`, `wc_sessionRequest`, and `wc_sessionPing`, and cleared on response/error.
>   - Registers heartbeat listener to periodically resubscribe to request topics if results are delayed, using `RESUBSCRIBE_INTERVAL` and `MAX_RESUBSCRIBE_ATTEMPTS_ON_PENDING_RESULTS` with debug/warn logging.
>   - Imports `fromMiliseconds` and `HEARTBEAT_EVENTS`; wires heartbeat during `init()`.
> - **Constants**
>   - Adds `RESUBSCRIBE_INTERVAL` and `MAX_RESUBSCRIBE_ATTEMPTS_ON_PENDING_RESULTS` in `constants/engine.ts`.
> - **Tests (canary)**
>   - Enhances logger helper to support log levels.
>   - After flow, logs pending `engine.requestWaitingForResult` items for both clients if any.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8ac7366107ed8da22964a66d58122ac9c54f3a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->