### PR TITLE
chore: make @reown/appkit an optional dependency

### DIFF
--- a/providers/ethereum-provider/package.json
+++ b/providers/ethereum-provider/package.json
@@ -57,8 +57,13 @@
     "@walletconnect/logger": "3.0.0",
     "events": "3.3.0"
   },
-  "optionalDependencies": {
-    "@reown/appkit": "1.8.11"
+  "peerDependencies": {
+    "@reown/appkit": "^1.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@reown/appkit": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "hardhat": "^3.0.6",

--- a/providers/ethereum-provider/package.json
+++ b/providers/ethereum-provider/package.json
@@ -45,7 +45,6 @@
     "prettier": "prettier --check '{src,test}/**/*.{js,ts,jsx,tsx}'"
   },
   "dependencies": {
-    "@reown/appkit": "1.8.11",
     "@walletconnect/jsonrpc-http-connection": "1.0.8",
     "@walletconnect/jsonrpc-provider": "1.0.14",
     "@walletconnect/jsonrpc-types": "1.0.4",
@@ -57,6 +56,9 @@
     "@walletconnect/utils": "2.23.0",
     "@walletconnect/logger": "3.0.0",
     "events": "3.3.0"
+  },
+  "optionalDependencies": {
+    "@reown/appkit": "1.8.11"
   },
   "devDependencies": {
     "hardhat": "^3.0.6",

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -601,6 +601,15 @@ export class EthereumProvider implements IEthereumProvider {
     this.registerEventListeners();
     await this.loadPersistedSession();
     if (this.rpc.showQrModal) {
+      // Validate @reown/appkit is available before attempting to use it
+      try {
+        await import("@reown/appkit/core");
+      } catch (e) {
+        throw new Error(
+          "QR modal requires @reown/appkit. Install with: npm install @reown/appkit",
+        );
+      }
+
       let appKit;
       try {
         const createAppKit = await getAppkit();
@@ -624,7 +633,9 @@ export class EthereumProvider implements IEthereumProvider {
         });
       } catch (e) {
         console.warn(e);
-        throw new Error("To use QR modal, please install @reown/appkit package");
+        throw new Error(
+          "QR modal requires @reown/appkit. Install with: npm install @reown/appkit",
+        );
       }
       if (appKit) {
         try {


### PR DESCRIPTION
Make @reown/appkit an optional peer dependency

  Summary

  Moves @reown/appkit from a required dependency to an optional peer dependency, reducing bundle size and installation time for users who don't need QR modal functionality.

  Motivation

  Only users with showQrModal: true need the @reown/appkit package, which is a significant dependency. Making it optional:
  - Reduces bundle size for the majority of users who don't use the QR modal
  - Faster installation with fewer dependencies to download
  - Better separation of concerns - makes it explicit that AppKit is a feature enhancement

  Changes

  1. Package.json (providers/ethereum-provider/package.json)

  - Moved @reown/appkit from dependencies to peerDependencies with version range ^1.8.0
  - Added peerDependenciesMeta to mark it as optional
  - This provides multi-layered feedback:
    - Install time: Package managers warn if peer dependency is missing
    - Build time: TypeScript may detect missing types depending on config
    - Runtime: Validation code provides clear error with installation instructions

  2. Runtime Validation (src/EthereumProvider.ts)

  - Added early validation check in initialize() method before dynamic import
  - Validates @reown/appkit availability immediately when showQrModal: true
  - Improved error message: "QR modal requires @reown/appkit. Install with: npm install @reown/appkit"
  - Fail-fast behavior ensures errors surface at initialization, not during user interaction

  Breaking Changes

  None. This is a non-breaking change:
  - Package managers (npm/yarn/pnpm) automatically install peer dependencies by default
  - Existing users will see no difference in behavior
  - Users who explicitly use --no-optional will get clear error messages if they need the QR modal

  Migration Guide

  For users with showQrModal: false (default):
  - No action required
  - May see a peer dependency warning at install time (can be safely ignored)

  For users with showQrModal: true:
  - Ensure @reown/appkit is installed: npm install @reown/appkit
  - If using npm/yarn/pnpm defaults, it's already installed automatically
  - Clear error message provided if package is missing

  Testing

  - Tested runtime validation triggers correctly when package is missing
  - Tested successful initialization when package is present
  - Verified error messages are actionable and include installation instructions