### PR TITLE
chore: changed rollup config to support dynamic imports in react native

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,19 +5,40 @@ import json from "@rollup/plugin-json";
 import visualizer from "rollup-plugin-visualizer";
 
 export const input = "./src/index.ts";
+const isProduction = process.env.NODE_ENV === "production";
+
 export const plugins = [
-  nodeResolve({ preferBuiltins: false, browser: true }),
+  // Resolve import paths
+  nodeResolve({
+    preferBuiltins: false,
+    browser: true,
+    extensions: [".ts", ".js", ".native.ts", ".native.js"],
+  }),
+
+  //Inline JSON imports
   json(),
-  commonjs(),
+
+  // Convert CJS → ESM
+  commonjs({
+    transformMixedEsModules: true,
+    ignoreDynamicRequires: true,
+    include: [/node_modules/],
+  }),
+
+  // Transpile TS/JSX
   esbuild({
     minify: true,
+    target: "es2020",
     tsconfig: "./tsconfig.json",
-    loaders: {
-      ".json": "json",
-    },
+    loaders: { ".json": "json" },
+    legalComments: "none",
+    treeShaking: true,
+    drop: isProduction ? ["console", "debugger"] : [],
   }),
-  visualizer(),
-];
+
+  // Visualize bundle for debugging
+  !isProduction && visualizer({ open: false }),
+].filter(Boolean);
 
 export default function createConfig(
   packageName,
@@ -28,9 +49,39 @@ export default function createConfig(
   extraBuilds = [],
 ) {
   return [
+    // ESM build (primary for modern bundlers and React Native)
     {
       input,
       plugins,
+      external: packageDependencies, // Keep dependencies external for bundlers
+      output: {
+        file: "./dist/index.js",
+        format: "es",
+        exports: "named",
+        sourcemap: isProduction ? "hidden" : true,
+        compact: isProduction,
+        ...es,
+      },
+    },
+    // CJS build (for Node.js and older bundlers)
+    {
+      input,
+      plugins,
+      external: packageDependencies,
+      output: {
+        file: "./dist/index.cjs",
+        format: "cjs",
+        exports: "named",
+        sourcemap: true,
+        interop: "auto",
+        ...cjs,
+      },
+    },
+    // UMD build (for browsers)
+    {
+      input,
+      plugins,
+      external: packageDependencies,
       output: {
         file: "./dist/index.umd.js",
         format: "umd",
@@ -39,29 +90,6 @@ export default function createConfig(
         sourcemap: true,
         ...umd,
       },
-    },
-    {
-      input,
-      plugins,
-      external: packageDependencies,
-      output: [
-        {
-          file: "./dist/index.cjs",
-          format: "cjs",
-          exports: "named",
-          name: packageName,
-          sourcemap: true,
-          ...cjs,
-        },
-        {
-          file: "./dist/index.js",
-          format: "es",
-          exports: "named",
-          name: packageName,
-          sourcemap: true,
-          ...es,
-        },
-      ],
     },
     ...extraBuilds,
   ];


### PR DESCRIPTION
## Description

Changed rollup config to enable dynamic imports on react native

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Tested locally on iOS and Android emulators

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

⚠️ Not tested on web

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restructures Rollup to emit ESM/CJS/UMD bundles, adds `.native` resolution for React Native, and applies env-aware optimizations.
> 
> - **Build Outputs**:
>   - Split into distinct builds: `es` → `./dist/index.js`, `cjs` → `./dist/index.cjs`, `umd` → `./dist/index.umd.js`.
>   - `external: packageDependencies` for all builds; ES sourcemaps now `hidden` in production; ES output compacted in production.
> - **Module Resolution**:
>   - `nodeResolve` now resolves `".ts", ".js", ".native.ts", ".native.js"` with `browser: true`.
> - **Bundling/Transpile**:
>   - `commonjs` configured for mixed ESM and to ignore dynamic requires; `esbuild` targets `es2020`, enables tree-shaking, removes legal comments, and drops `console`/`debugger` in production.
> - **Tooling**:
>   - `visualizer` runs only in non-production builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4eeb14ff770d45d8c083da08edac71faa9252062. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->