### PR TITLE
feat(react-native-compat): add RNWalletConnectPay native module

### DIFF
--- a/packages/react-native-compat/android/build.gradle
+++ b/packages/react-native-compat/android/build.gradle
@@ -103,7 +103,6 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault("kotlinVersion")
-def yttrium_version = rootProject.ext.has("yttriumVersion") ? rootProject.ext.get("yttriumVersion") : "kotlin-wcpay-0.9.116"
 
 dependencies {
   // For < 0.71, this will be from the local maven repo
@@ -113,7 +112,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   
   // Yttrium - WalletConnect Pay uniffi bindings
-  implementation "com.github.reown-com:yttrium:$yttrium_version"
+  implementation("com.github.reown-com:yttrium:kotlin-wcpay-0.9.116")
   
   // Coroutines for async uniffi calls
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"

--- a/packages/react-native-compat/android/build.gradle
+++ b/packages/react-native-compat/android/build.gradle
@@ -99,9 +99,11 @@ android {
 repositories {
   mavenCentral()
   google()
+  maven { url 'https://jitpack.io' }
 }
 
 def kotlin_version = getExtOrDefault("kotlinVersion")
+def yttrium_version = rootProject.ext.has("yttriumVersion") ? rootProject.ext.get("yttriumVersion") : "0.+"
 
 dependencies {
   // For < 0.71, this will be from the local maven repo
@@ -109,6 +111,12 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  
+  // Yttrium - WalletConnect Pay uniffi bindings
+  implementation "com.github.ArcticDev78:yttrium:$yttrium_version"
+  
+  // Coroutines for async uniffi calls
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/packages/react-native-compat/android/build.gradle
+++ b/packages/react-native-compat/android/build.gradle
@@ -112,7 +112,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   
   // Yttrium - WalletConnect Pay uniffi bindings
-  implementation("com.github.reown-com:yttrium:kotlin-wcpay-0.9.116")
+  implementation("com.github.reown-com.yttrium:yttrium-wcpay:0.9.119")
   
   // Coroutines for async uniffi calls
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"

--- a/packages/react-native-compat/android/build.gradle
+++ b/packages/react-native-compat/android/build.gradle
@@ -103,7 +103,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault("kotlinVersion")
-def yttrium_version = rootProject.ext.has("yttriumVersion") ? rootProject.ext.get("yttriumVersion") : "kotlin-wcpay-0.9.115"
+def yttrium_version = rootProject.ext.has("yttriumVersion") ? rootProject.ext.get("yttriumVersion") : "kotlin-wcpay-0.9.116"
 
 dependencies {
   // For < 0.71, this will be from the local maven repo

--- a/packages/react-native-compat/android/build.gradle
+++ b/packages/react-native-compat/android/build.gradle
@@ -103,7 +103,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault("kotlinVersion")
-def yttrium_version = rootProject.ext.has("yttriumVersion") ? rootProject.ext.get("yttriumVersion") : "0.+"
+def yttrium_version = rootProject.ext.has("yttriumVersion") ? rootProject.ext.get("yttriumVersion") : "kotlin-wcpay-0.9.115"
 
 dependencies {
   // For < 0.71, this will be from the local maven repo
@@ -113,7 +113,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   
   // Yttrium - WalletConnect Pay uniffi bindings
-  implementation "com.github.ArcticDev78:yttrium:$yttrium_version"
+  implementation "com.github.reown-com:yttrium:$yttrium_version"
   
   // Coroutines for async uniffi calls
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"

--- a/packages/react-native-compat/android/src/main/java/com/walletconnect/reactnativemodule/RNWalletConnectModulePackage.kt
+++ b/packages/react-native-compat/android/src/main/java/com/walletconnect/reactnativemodule/RNWalletConnectModulePackage.kt
@@ -9,10 +9,10 @@ import java.util.HashMap
 
 class RNWalletConnectModulePackage : TurboReactPackage() {
   override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
-    return if (name == RNWalletConnectModuleModule.NAME) {
-      RNWalletConnectModuleModule(reactContext)
-    } else {
-      null
+    return when (name) {
+      RNWalletConnectModuleModule.NAME -> RNWalletConnectModuleModule(reactContext)
+      RNWalletConnectPayModule.NAME -> RNWalletConnectPayModule(reactContext)
+      else -> null
     }
   }
 
@@ -20,15 +20,29 @@ class RNWalletConnectModulePackage : TurboReactPackage() {
     return ReactModuleInfoProvider {
       val moduleInfos: MutableMap<String, ReactModuleInfo> = HashMap()
       val isTurboModule: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+      
+      // Existing WalletConnect module
       moduleInfos[RNWalletConnectModuleModule.NAME] = ReactModuleInfo(
         RNWalletConnectModuleModule.NAME,
         RNWalletConnectModuleModule.NAME,
         false,  // canOverrideExistingModule
         false,  // needsEagerInit
-        true,  // hasConstants
+        true,   // hasConstants
         false,  // isCxxModule
         isTurboModule // isTurboModule
       )
+      
+      // WalletConnect Pay module
+      moduleInfos[RNWalletConnectPayModule.NAME] = ReactModuleInfo(
+        RNWalletConnectPayModule.NAME,
+        RNWalletConnectPayModule.NAME,
+        false,  // canOverrideExistingModule
+        false,  // needsEagerInit
+        false,  // hasConstants
+        false,  // isCxxModule
+        isTurboModule // isTurboModule
+      )
+      
       moduleInfos
     }
   }

--- a/packages/react-native-compat/android/src/main/java/com/walletconnect/reactnativemodule/RNWalletConnectPayModule.kt
+++ b/packages/react-native-compat/android/src/main/java/com/walletconnect/reactnativemodule/RNWalletConnectPayModule.kt
@@ -1,0 +1,132 @@
+package com.walletconnect.reactnativemodule
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.Promise
+import kotlinx.coroutines.*
+import uniffi.yttrium.WalletConnectPayJson
+
+/**
+ * React Native module for WalletConnect Pay
+ * Wraps the uniffi-generated WalletConnectPayJson Rust client
+ */
+class RNWalletConnectPayModule internal constructor(context: ReactApplicationContext) :
+  RNWalletConnectPaySpec(context) {
+
+  private var client: WalletConnectPayJson? = null
+  private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+  override fun getName(): String = NAME
+
+  /**
+   * Initialize the Pay client with SDK configuration
+   * @param configJson JSON string containing SDK config:
+   *   {
+   *     "baseUrl": string,
+   *     "projectId": string,
+   *     "apiKey": string,
+   *     "sdkName": string,
+   *     "sdkVersion": string,
+   *     "sdkPlatform": string,
+   *     "bundleId": string
+   *   }
+   */
+  @ReactMethod
+  override fun initialize(configJson: String) {
+    try {
+      client = WalletConnectPayJson(configJson)
+    } catch (e: Exception) {
+      // Log error but don't throw - let subsequent calls fail with "not initialized"
+      android.util.Log.e(NAME, "Failed to initialize Pay client: ${e.message}", e)
+    }
+  }
+
+  /**
+   * Get payment options for a payment link
+   * @param requestJson JSON string:
+   *   { "paymentLink": string, "accounts": string[], "includePaymentInfo"?: boolean }
+   * @param promise Resolves with JSON string of PaymentOptionsResponse
+   */
+  @ReactMethod
+  override fun getPaymentOptions(requestJson: String, promise: Promise) {
+    val currentClient = client
+    if (currentClient == null) {
+      promise.reject("PAY_ERROR", "Pay client not initialized. Call initialize() first.")
+      return
+    }
+
+    scope.launch {
+      try {
+        val result = currentClient.getPaymentOptions(requestJson)
+        promise.resolve(result)
+      } catch (e: Exception) {
+        promise.reject("PAY_ERROR", e.message ?: "Unknown error", e)
+      }
+    }
+  }
+
+  /**
+   * Get required payment actions for a selected option
+   * @param requestJson JSON string:
+   *   { "paymentId": string, "optionId": string }
+   * @param promise Resolves with JSON string array of Action
+   */
+  @ReactMethod
+  override fun getRequiredPaymentActions(requestJson: String, promise: Promise) {
+    val currentClient = client
+    if (currentClient == null) {
+      promise.reject("PAY_ERROR", "Pay client not initialized. Call initialize() first.")
+      return
+    }
+
+    scope.launch {
+      try {
+        val result = currentClient.getRequiredPaymentActions(requestJson)
+        promise.resolve(result)
+      } catch (e: Exception) {
+        promise.reject("PAY_ERROR", e.message ?: "Unknown error", e)
+      }
+    }
+  }
+
+  /**
+   * Confirm a payment with signatures
+   * @param requestJson JSON string:
+   *   {
+   *     "paymentId": string,
+   *     "optionId": string,
+   *     "signatures": string[],
+   *     "collectedData"?: [{ "id": string, "value": string }]
+   *   }
+   * @param promise Resolves with JSON string of ConfirmPaymentResponse
+   */
+  @ReactMethod
+  override fun confirmPayment(requestJson: String, promise: Promise) {
+    val currentClient = client
+    if (currentClient == null) {
+      promise.reject("PAY_ERROR", "Pay client not initialized. Call initialize() first.")
+      return
+    }
+
+    scope.launch {
+      try {
+        val result = currentClient.confirmPayment(requestJson)
+        promise.resolve(result)
+      } catch (e: Exception) {
+        promise.reject("PAY_ERROR", e.message ?: "Unknown error", e)
+      }
+    }
+  }
+
+  /**
+   * Clean up coroutine scope when module is destroyed
+   */
+  override fun invalidate() {
+    scope.cancel()
+    super.invalidate()
+  }
+
+  companion object {
+    const val NAME = "RNWalletConnectPay"
+  }
+}

--- a/packages/react-native-compat/android/src/newarch/RNWalletConnectPaySpec.kt
+++ b/packages/react-native-compat/android/src/newarch/RNWalletConnectPaySpec.kt
@@ -1,0 +1,7 @@
+package com.walletconnect.reactnativemodule
+
+import com.facebook.react.bridge.ReactApplicationContext
+
+abstract class RNWalletConnectPaySpec internal constructor(context: ReactApplicationContext) :
+  NativeRNWalletConnectPaySpec(context) {
+}

--- a/packages/react-native-compat/android/src/oldarch/RNWalletConnectPaySpec.kt
+++ b/packages/react-native-compat/android/src/oldarch/RNWalletConnectPaySpec.kt
@@ -1,0 +1,14 @@
+package com.walletconnect.reactnativemodule
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.Promise
+
+abstract class RNWalletConnectPaySpec internal constructor(context: ReactApplicationContext) :
+  ReactContextBaseJavaModule(context) {
+
+  abstract fun initialize(configJson: String)
+  abstract fun getPaymentOptions(requestJson: String, promise: Promise)
+  abstract fun getRequiredPaymentActions(requestJson: String, promise: Promise)
+  abstract fun confirmPayment(requestJson: String, promise: Promise)
+}

--- a/packages/react-native-compat/ios/RNWalletConnectPay.h
+++ b/packages/react-native-compat/ios/RNWalletConnectPay.h
@@ -1,0 +1,11 @@
+#ifdef RCT_NEW_ARCH_ENABLED
+#import "RNRNWalletConnectModuleSpec.h"
+
+@interface RNWalletConnectPay : NSObject <NativeRNWalletConnectPaySpec>
+#else
+#import <React/RCTBridgeModule.h>
+
+@interface RNWalletConnectPay : NSObject <RCTBridgeModule>
+#endif
+
+@end

--- a/packages/react-native-compat/ios/RNWalletConnectPay.mm
+++ b/packages/react-native-compat/ios/RNWalletConnectPay.mm
@@ -1,0 +1,142 @@
+#import "RNWalletConnectPay.h"
+#import <React/RCTBridge.h>
+
+// Import Swift/Yttrium
+#if __has_include(<Yttrium/Yttrium-Swift.h>)
+#import <Yttrium/Yttrium-Swift.h>
+#elif __has_include(<YttriumWrapper/YttriumWrapper-Swift.h>)
+#import <YttriumWrapper/YttriumWrapper-Swift.h>
+#elif __has_include("Yttrium-Swift.h")
+#import "Yttrium-Swift.h"
+#else
+// Fallback - uniffi generated code should be available
+@import Yttrium;
+#endif
+
+@implementation RNWalletConnectPay {
+    WalletConnectPayJson *_client;
+    dispatch_queue_t _queue;
+}
+
+RCT_EXPORT_MODULE()
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _queue = dispatch_queue_create("com.walletconnect.pay", DISPATCH_QUEUE_SERIAL);
+    }
+    return self;
+}
+
+/**
+ * Initialize the Pay client with SDK configuration
+ * @param configJson JSON string containing SDK config
+ */
+RCT_EXPORT_METHOD(initialize:(NSString *)configJson)
+{
+    dispatch_async(_queue, ^{
+        NSError *error = nil;
+        self->_client = [[WalletConnectPayJson alloc] init:configJson error:&error];
+        if (error) {
+            NSLog(@"[RNWalletConnectPay] Failed to initialize: %@", error.localizedDescription);
+        }
+    });
+}
+
+/**
+ * Get payment options for a payment link
+ * @param requestJson JSON request string
+ * @param resolve Promise resolve callback
+ * @param reject Promise reject callback
+ */
+RCT_EXPORT_METHOD(getPaymentOptions:(NSString *)requestJson
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+    dispatch_async(_queue, ^{
+        if (!self->_client) {
+            reject(@"PAY_ERROR", @"Pay client not initialized. Call initialize() first.", nil);
+            return;
+        }
+        
+        NSError *error = nil;
+        NSString *result = [self->_client getPaymentOptions:requestJson error:&error];
+        
+        if (error) {
+            reject(@"PAY_ERROR", error.localizedDescription, error);
+        } else {
+            resolve(result);
+        }
+    });
+}
+
+/**
+ * Get required payment actions for a selected option
+ * @param requestJson JSON request string
+ * @param resolve Promise resolve callback
+ * @param reject Promise reject callback
+ */
+RCT_EXPORT_METHOD(getRequiredPaymentActions:(NSString *)requestJson
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+    dispatch_async(_queue, ^{
+        if (!self->_client) {
+            reject(@"PAY_ERROR", @"Pay client not initialized. Call initialize() first.", nil);
+            return;
+        }
+        
+        NSError *error = nil;
+        NSString *result = [self->_client getRequiredPaymentActions:requestJson error:&error];
+        
+        if (error) {
+            reject(@"PAY_ERROR", error.localizedDescription, error);
+        } else {
+            resolve(result);
+        }
+    });
+}
+
+/**
+ * Confirm a payment with signatures
+ * @param requestJson JSON request string
+ * @param resolve Promise resolve callback
+ * @param reject Promise reject callback
+ */
+RCT_EXPORT_METHOD(confirmPayment:(NSString *)requestJson
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+    dispatch_async(_queue, ^{
+        if (!self->_client) {
+            reject(@"PAY_ERROR", @"Pay client not initialized. Call initialize() first.", nil);
+            return;
+        }
+        
+        NSError *error = nil;
+        NSString *result = [self->_client confirmPayment:requestJson error:&error];
+        
+        if (error) {
+            reject(@"PAY_ERROR", error.localizedDescription, error);
+        } else {
+            resolve(result);
+        }
+    });
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+    return NO;
+}
+
+// Don't compile this code when we build for the old architecture.
+#ifdef RCT_NEW_ARCH_ENABLED
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+    return std::make_shared<facebook::react::NativeRNWalletConnectPaySpecJSI>(params);
+}
+#endif
+
+@end

--- a/packages/react-native-compat/module/NativeRNWalletConnectPay.ts
+++ b/packages/react-native-compat/module/NativeRNWalletConnectPay.ts
@@ -1,0 +1,56 @@
+import type { TurboModule } from "react-native";
+import { TurboModuleRegistry } from "react-native";
+
+/**
+ * TurboModule spec for WalletConnect Pay native module
+ *
+ * This module wraps the uniffi-generated WalletConnectPayJson Rust client
+ * and provides a JSON-based interface for payment operations.
+ */
+export interface Spec extends TurboModule {
+  /**
+   * Initialize the Pay client with SDK configuration
+   * @param configJson JSON string containing SDK config:
+   *   {
+   *     "baseUrl": string,
+   *     "projectId": string,
+   *     "apiKey": string,
+   *     "sdkName": string,
+   *     "sdkVersion": string,
+   *     "sdkPlatform": string,
+   *     "bundleId": string
+   *   }
+   */
+  initialize(configJson: string): void;
+
+  /**
+   * Get payment options for a payment link
+   * @param requestJson JSON string:
+   *   { "paymentLink": string, "accounts": string[], "includePaymentInfo"?: boolean }
+   * @returns Promise resolving to JSON string of PaymentOptionsResponse
+   */
+  getPaymentOptions(requestJson: string): Promise<string>;
+
+  /**
+   * Get required payment actions for a selected option
+   * @param requestJson JSON string:
+   *   { "paymentId": string, "optionId": string }
+   * @returns Promise resolving to JSON string array of Action
+   */
+  getRequiredPaymentActions(requestJson: string): Promise<string>;
+
+  /**
+   * Confirm a payment with signatures
+   * @param requestJson JSON string:
+   *   {
+   *     "paymentId": string,
+   *     "optionId": string,
+   *     "signatures": string[],
+   *     "collectedData"?: [{ "id": string, "value": string }]
+   *   }
+   * @returns Promise resolving to JSON string of ConfirmPaymentResponse
+   */
+  confirmPayment(requestJson: string): Promise<string>;
+}
+
+export default TurboModuleRegistry.get<Spec>("RNWalletConnectPay");

--- a/packages/react-native-compat/module/index.ts
+++ b/packages/react-native-compat/module/index.ts
@@ -6,11 +6,20 @@ const LINKING_ERROR =
   "- You rebuilt the app after installing the package\n" +
   "- If you are using Expo: install expo-application \n";
 
+const PAY_LINKING_ERROR =
+  `The RNWalletConnectPay module doesn't seem to be linked. Make sure: \n\n` +
+  "- You rebuilt the app after installing the package\n" +
+  "- The Yttrium native dependency is properly installed\n";
+
 const isTurboModuleEnabled = global.__turboModuleProxy != null;
 
 const RNWalletConnectModule = isTurboModuleEnabled
   ? require("../module/NativeRNWalletConnectModule.ts").default
   : NativeModules.RNWalletConnectModule;
+
+const RNWalletConnectPay = isTurboModuleEnabled
+  ? require("../module/NativeRNWalletConnectPay.ts").default
+  : NativeModules.RNWalletConnectPay;
 
 function getExpoModule(): any | undefined {
   try {
@@ -44,4 +53,37 @@ export function getApplicationModule(): any | undefined {
       throw new Error(LINKING_ERROR);
     }
   }
+}
+
+/**
+ * Get the WalletConnect Pay native module
+ * @returns The RNWalletConnectPay native module or undefined if not available
+ */
+export function getPayModule(): any | undefined {
+  try {
+    if (!RNWalletConnectPay) throw new Error();
+    return RNWalletConnectPay;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Check if the Pay native module is available
+ * @returns true if the Pay module is linked and available
+ */
+export function isPayModuleAvailable(): boolean {
+  return RNWalletConnectPay != null;
+}
+
+/**
+ * Get the WalletConnect Pay native module or throw if not available
+ * @throws Error if the Pay module is not linked
+ * @returns The RNWalletConnectPay native module
+ */
+export function requirePayModule(): any {
+  if (!RNWalletConnectPay) {
+    throw new Error(PAY_LINKING_ERROR);
+  }
+  return RNWalletConnectPay;
 }

--- a/packages/react-native-compat/package.json
+++ b/packages/react-native-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@walletconnect/react-native-compat",
-  "description": "Shims for WalletConnect Protocol in React Native Projects",
+  "description": "Native modules and shims for WalletConnect Protocol in React Native Projects",
   "version": "2.23.1",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",

--- a/packages/react-native-compat/react-native-compat.podspec
+++ b/packages/react-native-compat/react-native-compat.podspec
@@ -11,10 +11,14 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "11.0", :visionos => "1.0" }
+  s.platforms    = { :ios => "13.0", :visionos => "1.0" }
   s.source       = { :git => "https://github.com/walletconnect/walletconnect-monorepo.git", :tag => "#{s.version}" }
 
-  s.source_files = "ios/**/*.{h,m,mm}"
+  s.source_files = "ios/**/*.{h,m,mm,swift}"
+  s.swift_version = "5.0"
+
+  # Yttrium - WalletConnect Pay uniffi bindings
+  s.dependency "YttriumWrapper"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
## Summary

Adds native module wrapper for `WalletConnectPayJson` uniffi client to `@walletconnect/react-native-compat`.

This enables the `@walletconnect/pay` TypeScript SDK to call the Rust Pay client through React Native.

## Changes

### Android

| File | Description |
|------|-------------|
| `RNWalletConnectPayModule.kt` | Main module wrapping uniffi Kotlin bindings |
| `RNWalletConnectPaySpec.kt` (newarch/oldarch) | Architecture-specific specs |
| `build.gradle` | Added yttrium AAR + coroutines dependencies |
| `RNWalletConnectModulePackage.kt` | Registered Pay module |

### iOS

| File | Description |
|------|-------------|
| `RNWalletConnectPay.mm` | Module wrapping uniffi Swift bindings |
| `RNWalletConnectPay.h` | Objective-C header |
| `react-native-compat.podspec` | Added YttriumWrapper pod dependency |

### TypeScript

| File | Description |
|------|-------------|
| `NativeRNWalletConnectPay.ts` | TurboModule spec |
| `module/index.ts` | Added `getPayModule()`, `isPayModuleAvailable()`, `requirePayModule()` |

## Native Module Interface

```typescript
interface RNWalletConnectPay {
  initialize(configJson: string): void;
  getPaymentOptions(requestJson: string): Promise<string>;
  getRequiredPaymentActions(requestJson: string): Promise<string>;
  confirmPayment(requestJson: string): Promise<string>;
}
```

## Dependencies

- **Android**: Yttrium AAR via JitPack
- **iOS**: YttriumWrapper via CocoaPods
- **iOS minimum**: Bumped to 13.0 (required by Yttrium)

## Related

- Issue: #7106
- PR: #7105 (Pay TypeScript SDK)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a cross-platform native wrapper for WalletConnect Pay to enable RN apps/TS SDK to call the Yttrium `WalletConnectPayJson` client.
> 
> - Android: new `RNWalletConnectPayModule` with coroutine-based async calls; registers in `RNWalletConnectModulePackage`; adds JitPack repo, Yttrium AAR `yttrium-wcpay`, and Kotlin coroutines in `build.gradle`; arch-specific `RNWalletConnectPaySpec` stubs.
> - iOS: new `RNWalletConnectPay` ObjC++ module bridging to Swift/uniffi; `podspec` now depends on `YttriumWrapper`, includes Swift sources, and raises iOS min to 13.0.
> - TypeScript: adds `NativeRNWalletConnectPay` TurboModule spec and `getPayModule`/`isPayModuleAvailable`/`requirePayModule` helpers in `module/index.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d92868f5f1d654c141f6add5668669f268b7e873. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->