### PR TITLE
fix(core): cancel scheduled reconnection when fatal error is received

### DIFF
--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -270,6 +270,8 @@ export class Relayer extends IRelayer {
 
   public async transportClose() {
     this.transportExplicitlyClosed = true;
+    clearTimeout(this.reconnectTimeout);
+    this.reconnectTimeout = undefined;
     await this.transportDisconnect();
   }
 
@@ -577,9 +579,10 @@ export class Relayer extends IRelayer {
   private onProviderErrorHandler = (error: Error) => {
     this.logger.fatal(`Fatal socket error: ${error.message}`);
     this.events.emit(RELAYER_EVENTS.error, error);
-    // close the transport when a fatal error is received as there's no way to recover from it
-    // usual cases are missing/invalid projectId, expired jwt token, invalid origin etc
     this.logger.fatal("Fatal socket error received, closing transport");
+    this.transportExplicitlyClosed = true;
+    clearTimeout(this.reconnectTimeout);
+    this.reconnectTimeout = undefined;
     this.transportClose();
   };
 

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -272,6 +272,7 @@ export class Relayer extends IRelayer {
     this.transportExplicitlyClosed = true;
     clearTimeout(this.reconnectTimeout);
     this.reconnectTimeout = undefined;
+    this.reconnectInProgress = false;
     await this.transportDisconnect();
   }
 
@@ -583,7 +584,8 @@ export class Relayer extends IRelayer {
     this.transportExplicitlyClosed = true;
     clearTimeout(this.reconnectTimeout);
     this.reconnectTimeout = undefined;
-    this.transportClose();
+    this.reconnectInProgress = false;
+    this.transportClose().catch((e) => this.logger.warn(e));
   };
 
   private registerProviderListeners = () => {

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -500,12 +500,11 @@ describe("Relayer", () => {
       // #when - simulate disconnect which schedules a reconnection
       relayer.provider.events.emit(RELAYER_PROVIDER_EVENTS.disconnect);
 
-      // Wait a bit to ensure reconnection is scheduled (reconnect timeout is 100ms)
+      // Wait to ensure reconnection is scheduled (reconnect timeout is 100ms)
       await throttle(50);
 
       // @ts-expect-error - accessing private property for testing
-      // At this point, a reconnection should be scheduled
-      const reconnectScheduled = relayer.reconnectTimeout !== undefined;
+      expect(relayer.reconnectTimeout).to.not.be.undefined;
 
       // Then fatal error arrives - this should cancel the scheduled reconnection
       relayer.provider.events.emit(
@@ -520,15 +519,11 @@ describe("Relayer", () => {
       expect(relayer.transportExplicitlyClosed).to.be.true;
 
       // @ts-expect-error - accessing private property for testing
-      // The reconnect timeout should have been cleared by the error handler
       expect(relayer.reconnectTimeout).to.be.undefined;
 
-      // If reconnection was scheduled, verify it was properly cancelled
-      if (reconnectScheduled) {
-        // Wait for heartbeat to ensure no reconnection happens
-        await throttle(6000);
-        expect(relayer.connected).to.be.false;
-      }
+      // Wait for heartbeat to ensure no reconnection happens
+      await throttle(6000);
+      expect(relayer.connected).to.be.false;
     });
   });
   describe.skipIf(!TEST_PROJECT_ID_MOBILE || !TEST_MOBILE_APP_ID)(

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -491,191 +491,233 @@ describe("Relayer", () => {
       await throttle(6500);
       expect(relayer.connected).to.be.false;
     });
-  });
-  describe("packageName and bundleId validations", () => {
-    beforeEach(async () => {
-      core = new Core({ ...TEST_CORE_OPTIONS, projectId: TEST_PROJECT_ID_MOBILE });
-      relayer = core.relayer;
-      await core.start();
-    });
 
-    it("[Android] packageName included in Cloud Settings - should connect", async () => {
-      // Mock Android environment
-      vi.spyOn(utils, "isAndroid").mockReturnValue(true);
-      vi.spyOn(utils, "isIos").mockReturnValue(false);
-      vi.spyOn(utils, "getAppId").mockReturnValue(TEST_MOBILE_APP_ID);
-
-      relayer = new Relayer({
-        core,
-        relayUrl: TEST_CORE_OPTIONS.relayUrl,
-        projectId: TEST_PROJECT_ID_MOBILE,
-      });
-
-      await relayer.init();
-      await relayer.subscribe(randomTopic);
-
-      // @ts-expect-error - accessing private property for testing
-      const wsUrl = relayer.provider.connection.url;
-      expect(wsUrl).to.include(`packageName=${TEST_MOBILE_APP_ID}`);
-      expect(relayer.connected).to.be.true;
-    });
-
-    it("[Android] packageName undefined - should connect", async () => {
-      // Mock Android environment
-      vi.spyOn(utils, "isAndroid").mockReturnValue(true);
-      vi.spyOn(utils, "isIos").mockReturnValue(false);
-      vi.spyOn(utils, "getAppId").mockReturnValue(undefined);
-
-      relayer = new Relayer({
-        core,
-        relayUrl: TEST_CORE_OPTIONS.relayUrl,
-        projectId: TEST_PROJECT_ID_MOBILE,
-      });
-
-      await relayer.init();
-      await relayer.subscribe(randomTopic);
-
-      // @ts-expect-error - accessing private property for testing
-      const wsUrl = relayer.provider.connection.url;
-      expect(wsUrl).not.to.include("packageName=");
-      expect(relayer.connected).to.be.true;
-    });
-
-    it("[Android] packageName not included in Cloud Settings - should fail", async () => {
-      // Mock Android environment
-      vi.spyOn(utils, "isAndroid").mockReturnValue(true);
-      vi.spyOn(utils, "isIos").mockReturnValue(false);
-      vi.spyOn(utils, "getAppId").mockReturnValue("com.example.wrong");
-
-      relayer = new Relayer({
-        core,
-        relayUrl: TEST_CORE_OPTIONS.relayUrl,
-        projectId: TEST_PROJECT_ID_MOBILE,
-      });
-
-      await relayer.init();
-
-      relayer.subscriber.subscriptions.set(randomTopic, {
-        topic: randomTopic,
-        id: randomTopic,
-        relay: { protocol: "irn" },
-      });
-
-      let errorReceived = false;
-      relayer.on(RELAYER_EVENTS.error, (payload) => {
-        expect(payload.message).to.include("Unauthorized: origin not allowed");
-        errorReceived = true;
-      });
-      await relayer.transportOpen().catch((e) => {});
-      await throttle(1000);
-      expect(errorReceived).to.be.true;
-    });
-
-    it("[iOS] bundleId included in Cloud Settings - should connect", async () => {
-      // Mock iOS environment
-      vi.spyOn(utils, "isAndroid").mockReturnValue(false);
-      vi.spyOn(utils, "isIos").mockReturnValue(true);
-      vi.spyOn(utils, "getAppId").mockReturnValue(TEST_MOBILE_APP_ID);
-
-      relayer = new Relayer({
-        core,
-        relayUrl: TEST_CORE_OPTIONS.relayUrl,
-        projectId: TEST_PROJECT_ID_MOBILE,
-      });
-
-      await relayer.init();
-      await relayer.subscribe(randomTopic);
-
-      // @ts-expect-error - accessing private property for testing
-      const wsUrl = relayer.provider.connection.url;
-      expect(wsUrl).to.include(`bundleId=${TEST_MOBILE_APP_ID}`);
-    });
-
-    it("[iOS] bundleId undefined - should connect", async () => {
-      // Mock iOS environment
-      vi.spyOn(utils, "isAndroid").mockReturnValue(false);
-      vi.spyOn(utils, "isIos").mockReturnValue(true);
-      vi.spyOn(utils, "getAppId").mockReturnValue(undefined);
-
-      relayer = new Relayer({
-        core,
-        relayUrl: TEST_CORE_OPTIONS.relayUrl,
-        projectId: TEST_PROJECT_ID_MOBILE,
-      });
-
-      await relayer.init();
-      relayer.subscriber.subscriptions.set(randomTopic, {
-        topic: randomTopic,
-        id: randomTopic,
-        relay: { protocol: "irn" },
-      });
+    it("should cancel scheduled reconnection when fatal error is received", async () => {
+      // #given - establish connection first
       await relayer.transportOpen();
-
-      // @ts-expect-error - accessing private property for testing
-      const wsUrl = relayer.provider.connection.url;
-      expect(wsUrl).not.to.include("bundleId=");
       expect(relayer.connected).to.be.true;
-    });
 
-    it("[iOS] bundleId not included in Cloud Settings - should fail", async () => {
-      // Mock iOS environment
-      vi.spyOn(utils, "isAndroid").mockReturnValue(false);
-      vi.spyOn(utils, "isIos").mockReturnValue(true);
-      vi.spyOn(utils, "getAppId").mockReturnValue("com.example.wrong");
+      // #when - simulate disconnect which schedules a reconnection
+      relayer.provider.events.emit(RELAYER_PROVIDER_EVENTS.disconnect);
 
-      relayer = new Relayer({
-        core,
-        relayUrl: TEST_CORE_OPTIONS.relayUrl,
-        projectId: TEST_PROJECT_ID_MOBILE,
-      });
-
-      await relayer.init();
-      relayer.subscriber.subscriptions.set(randomTopic, {
-        topic: randomTopic,
-        id: randomTopic,
-        relay: { protocol: "irn" },
-      });
-
-      let errorReceived = false;
-      relayer.on(RELAYER_EVENTS.error, (payload) => {
-        expect(payload.message).to.include("Unauthorized: origin not allowed");
-        errorReceived = true;
-      });
-
-      await relayer.transportOpen().catch((e) => {});
-
-      await throttle(1000);
-      expect(errorReceived).to.be.true;
-    });
-
-    it("[Web] packageName and bundleId not set - should connect", async () => {
-      // Mock non-mobile environment
-      vi.spyOn(utils, "isAndroid").mockReturnValue(false);
-      vi.spyOn(utils, "isIos").mockReturnValue(false);
-      vi.spyOn(utils, "getAppId").mockReturnValue(TEST_MOBILE_APP_ID);
-
-      relayer = new Relayer({
-        core,
-        relayUrl: TEST_CORE_OPTIONS.relayUrl,
-        projectId: TEST_PROJECT_ID_MOBILE,
-      });
-
-      await relayer.init();
-      relayer.subscriber.subscriptions.set(randomTopic, {
-        topic: randomTopic,
-        id: randomTopic,
-        relay: { protocol: "irn" },
-      });
-      await relayer.transportOpen();
+      // Wait a bit to ensure reconnection is scheduled (reconnect timeout is 100ms)
+      await throttle(50);
 
       // @ts-expect-error - accessing private property for testing
-      const wsUrl = relayer.provider.connection.url;
-      expect(wsUrl).not.to.include("packageName=");
-      expect(wsUrl).not.to.include("bundleId=");
-    });
+      // At this point, a reconnection should be scheduled
+      const reconnectScheduled = relayer.reconnectTimeout !== undefined;
 
-    afterEach(() => {
-      vi.restoreAllMocks();
+      // Then fatal error arrives - this should cancel the scheduled reconnection
+      relayer.provider.events.emit(
+        RELAYER_PROVIDER_EVENTS.error,
+        new Error("Unauthorized: origin not allowed"),
+      );
+
+      // #then - wait past the reconnect timeout (100ms) + buffer
+      await throttle(200);
+
+      // The transport should be marked as explicitly closed
+      expect(relayer.transportExplicitlyClosed).to.be.true;
+
+      // @ts-expect-error - accessing private property for testing
+      // The reconnect timeout should have been cleared by the error handler
+      expect(relayer.reconnectTimeout).to.be.undefined;
+
+      // If reconnection was scheduled, verify it was properly cancelled
+      if (reconnectScheduled) {
+        // Wait for heartbeat to ensure no reconnection happens
+        await throttle(6000);
+        expect(relayer.connected).to.be.false;
+      }
     });
   });
+  describe.skipIf(!TEST_PROJECT_ID_MOBILE || !TEST_MOBILE_APP_ID)(
+    "packageName and bundleId validations",
+    () => {
+      beforeEach(async () => {
+        core = new Core({ ...TEST_CORE_OPTIONS, projectId: TEST_PROJECT_ID_MOBILE });
+        relayer = core.relayer;
+        await core.start();
+      });
+
+      it("[Android] packageName included in Cloud Settings - should connect", async () => {
+        // Mock Android environment
+        vi.spyOn(utils, "isAndroid").mockReturnValue(true);
+        vi.spyOn(utils, "isIos").mockReturnValue(false);
+        vi.spyOn(utils, "getAppId").mockReturnValue(TEST_MOBILE_APP_ID);
+
+        relayer = new Relayer({
+          core,
+          relayUrl: TEST_CORE_OPTIONS.relayUrl,
+          projectId: TEST_PROJECT_ID_MOBILE,
+        });
+
+        await relayer.init();
+        await relayer.subscribe(randomTopic);
+
+        // @ts-expect-error - accessing private property for testing
+        const wsUrl = relayer.provider.connection.url;
+        expect(wsUrl).to.include(`packageName=${TEST_MOBILE_APP_ID}`);
+        expect(relayer.connected).to.be.true;
+      });
+
+      it("[Android] packageName undefined - should connect", async () => {
+        // Mock Android environment
+        vi.spyOn(utils, "isAndroid").mockReturnValue(true);
+        vi.spyOn(utils, "isIos").mockReturnValue(false);
+        vi.spyOn(utils, "getAppId").mockReturnValue(undefined);
+
+        relayer = new Relayer({
+          core,
+          relayUrl: TEST_CORE_OPTIONS.relayUrl,
+          projectId: TEST_PROJECT_ID_MOBILE,
+        });
+
+        await relayer.init();
+        await relayer.subscribe(randomTopic);
+
+        // @ts-expect-error - accessing private property for testing
+        const wsUrl = relayer.provider.connection.url;
+        expect(wsUrl).not.to.include("packageName=");
+        expect(relayer.connected).to.be.true;
+      });
+
+      it("[Android] packageName not included in Cloud Settings - should fail", async () => {
+        // Mock Android environment
+        vi.spyOn(utils, "isAndroid").mockReturnValue(true);
+        vi.spyOn(utils, "isIos").mockReturnValue(false);
+        vi.spyOn(utils, "getAppId").mockReturnValue("com.example.wrong");
+
+        relayer = new Relayer({
+          core,
+          relayUrl: TEST_CORE_OPTIONS.relayUrl,
+          projectId: TEST_PROJECT_ID_MOBILE,
+        });
+
+        await relayer.init();
+
+        relayer.subscriber.subscriptions.set(randomTopic, {
+          topic: randomTopic,
+          id: randomTopic,
+          relay: { protocol: "irn" },
+        });
+
+        let errorReceived = false;
+        relayer.on(RELAYER_EVENTS.error, (payload) => {
+          expect(payload.message).to.include("Unauthorized: origin not allowed");
+          errorReceived = true;
+        });
+        await relayer.transportOpen().catch((e) => {});
+        await throttle(1000);
+        expect(errorReceived).to.be.true;
+      });
+
+      it("[iOS] bundleId included in Cloud Settings - should connect", async () => {
+        // Mock iOS environment
+        vi.spyOn(utils, "isAndroid").mockReturnValue(false);
+        vi.spyOn(utils, "isIos").mockReturnValue(true);
+        vi.spyOn(utils, "getAppId").mockReturnValue(TEST_MOBILE_APP_ID);
+
+        relayer = new Relayer({
+          core,
+          relayUrl: TEST_CORE_OPTIONS.relayUrl,
+          projectId: TEST_PROJECT_ID_MOBILE,
+        });
+
+        await relayer.init();
+        await relayer.subscribe(randomTopic);
+
+        // @ts-expect-error - accessing private property for testing
+        const wsUrl = relayer.provider.connection.url;
+        expect(wsUrl).to.include(`bundleId=${TEST_MOBILE_APP_ID}`);
+      });
+
+      it("[iOS] bundleId undefined - should connect", async () => {
+        // Mock iOS environment
+        vi.spyOn(utils, "isAndroid").mockReturnValue(false);
+        vi.spyOn(utils, "isIos").mockReturnValue(true);
+        vi.spyOn(utils, "getAppId").mockReturnValue(undefined);
+
+        relayer = new Relayer({
+          core,
+          relayUrl: TEST_CORE_OPTIONS.relayUrl,
+          projectId: TEST_PROJECT_ID_MOBILE,
+        });
+
+        await relayer.init();
+        relayer.subscriber.subscriptions.set(randomTopic, {
+          topic: randomTopic,
+          id: randomTopic,
+          relay: { protocol: "irn" },
+        });
+        await relayer.transportOpen();
+
+        // @ts-expect-error - accessing private property for testing
+        const wsUrl = relayer.provider.connection.url;
+        expect(wsUrl).not.to.include("bundleId=");
+        expect(relayer.connected).to.be.true;
+      });
+
+      it("[iOS] bundleId not included in Cloud Settings - should fail", async () => {
+        // Mock iOS environment
+        vi.spyOn(utils, "isAndroid").mockReturnValue(false);
+        vi.spyOn(utils, "isIos").mockReturnValue(true);
+        vi.spyOn(utils, "getAppId").mockReturnValue("com.example.wrong");
+
+        relayer = new Relayer({
+          core,
+          relayUrl: TEST_CORE_OPTIONS.relayUrl,
+          projectId: TEST_PROJECT_ID_MOBILE,
+        });
+
+        await relayer.init();
+        relayer.subscriber.subscriptions.set(randomTopic, {
+          topic: randomTopic,
+          id: randomTopic,
+          relay: { protocol: "irn" },
+        });
+
+        let errorReceived = false;
+        relayer.on(RELAYER_EVENTS.error, (payload) => {
+          expect(payload.message).to.include("Unauthorized: origin not allowed");
+          errorReceived = true;
+        });
+
+        await relayer.transportOpen().catch((e) => {});
+
+        await throttle(1000);
+        expect(errorReceived).to.be.true;
+      });
+
+      it("[Web] packageName and bundleId not set - should connect", async () => {
+        // Mock non-mobile environment
+        vi.spyOn(utils, "isAndroid").mockReturnValue(false);
+        vi.spyOn(utils, "isIos").mockReturnValue(false);
+        vi.spyOn(utils, "getAppId").mockReturnValue(TEST_MOBILE_APP_ID);
+
+        relayer = new Relayer({
+          core,
+          relayUrl: TEST_CORE_OPTIONS.relayUrl,
+          projectId: TEST_PROJECT_ID_MOBILE,
+        });
+
+        await relayer.init();
+        relayer.subscriber.subscriptions.set(randomTopic, {
+          topic: randomTopic,
+          id: randomTopic,
+          relay: { protocol: "irn" },
+        });
+        await relayer.transportOpen();
+
+        // @ts-expect-error - accessing private property for testing
+        const wsUrl = relayer.provider.connection.url;
+        expect(wsUrl).not.to.include("packageName=");
+        expect(wsUrl).not.to.include("bundleId=");
+      });
+
+      afterEach(() => {
+        vi.restoreAllMocks();
+      });
+    },
+  );
 });


### PR DESCRIPTION
## Summary
- Fix race condition where relayer keeps retrying after receiving fatal error from relay
- Clear `reconnectTimeout` when fatal error is received to cancel any scheduled reconnection
- Skip mobile validation tests when required env vars (`TEST_PROJECT_ID_MOBILE`, `TEST_MOBILE_APP_ID`) are not available

## Problem

When the relay sends a fatal error (e.g., invalid projectId, unauthorized origin), the relayer was not properly stopping reconnection attempts due to a race condition:

1. `disconnect` event triggers `onProviderDisconnect()` which schedules reconnection in 100ms
2. `error` event sets `transportExplicitlyClosed = true`
3. But the scheduled reconnection still fires and calls `connect()` which resets `transportExplicitlyClosed = false`
4. Endless retry loop ensues

https://linear.app/reown/issue/WK-958/ws-reconnection-not-stopping-on-fatal-errors

## Solution

Clear the `reconnectTimeout` in both `transportClose()` and `onProviderErrorHandler()` to ensure any pending reconnection is cancelled when a fatal error is received.

```mermaid
flowchart TD
    A[Fatal Error Received] --> B[onProviderErrorHandler]
    B --> C[Set transportExplicitlyClosed = true]
    B --> D[Clear reconnectTimeout ✅]
    B --> E[Call transportClose]
    
    F[Disconnect Event] --> G[onProviderDisconnect]
    G --> H[Schedule reconnection]
    H --> I[Cancelled by error handler ✅]
```

## Test plan
- [x] Added test "should cancel scheduled reconnection when fatal error is received"
- [x] All existing relayer tests pass (29 passed, 7 skipped)
- [x] Skip mobile validation tests when env vars not available to fix flaky local tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops unintended reconnect loops after fatal relay errors.
> 
> - Clear `reconnectTimeout` and reset flags in `transportClose()` and `onProviderErrorHandler()` to cancel any scheduled reconnection and mark transport explicitly closed
> - Call `transportClose()` on fatal error with safe error handling
> - Add test: `should cancel scheduled reconnection when fatal error is received`
> - Wrap mobile packageName/bundleId validation suite with `describe.skipIf(!TEST_PROJECT_ID_MOBILE || !TEST_MOBILE_APP_ID)` to avoid running without required env vars
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e34ad87a6147d4cc3e1b5e0d3944a4c4ef74aa37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->