### PR TITLE
chore: add changesets for core and react-native-compat

### DIFF
--- a/.changeset/proud-loops-share.md
+++ b/.changeset/proud-loops-share.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/react-native-compat": patch
+---
+
+feat(react-native-compat): add RNWalletConnectPay native module for iOS and Android

--- a/.changeset/thick-flies-drive.md
+++ b/.changeset/thick-flies-drive.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/core": patch
+---
+
+fix(core): cancel scheduled reconnection when fatal error is received


### PR DESCRIPTION
## Summary

Adds missing changeset for PR #7122 (fix(core): cancel scheduled reconnection when fatal error is received) and PR #7105 → @walletconnect/react-native-compat (patch) - RNWalletConnectPay module

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds missing patch changesets.
> 
> - `@walletconnect/core`: fix to cancel scheduled reconnection on fatal error
> - `@walletconnect/react-native-compat`: introduce `RNWalletConnectPay` native module for iOS and Android
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d98d994cb8ee467375c33e5d793337f8ad261716. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->