### PR TITLE
refactor(pay): align SDK types with yttrium 0.10.14/0.10.15

### DIFF
--- a/packages/pay/README.md
+++ b/packages/pay/README.md
@@ -33,8 +33,9 @@ The SDK auto-detects the best available provider for your environment.
 import { WalletConnectPay } from "@walletconnect/pay";
 
 const client = new WalletConnectPay({
-  projectId: "your-project-id",
-  apiKey: "your-api-key",
+  appId: "your-app-id",
+  // OR use apiKey instead:
+  // apiKey: "your-api-key",
 });
 ```
 
@@ -134,12 +135,15 @@ if (options.collectData) {
 new WalletConnectPay(options: WalletConnectPayOptions)
 ```
 
-| Option    | Type   | Required | Description                     |
-| --------- | ------ | -------- | ------------------------------- |
-| projectId | string | Yes      | WalletConnect Project ID        |
-| apiKey    | string | Yes      | Pay API key                     |
-| baseUrl   | string | No       | Custom API base URL             |
-| logger    | Logger | No       | Custom logger instance or level |
+| Option   | Type   | Required | Description                                  |
+| -------- | ------ | -------- | -------------------------------------------- |
+| appId    | string | No*      | App ID for authentication                    |
+| apiKey   | string | No*      | API key for authentication                   |
+| clientId | string | No       | Client ID for tracking                       |
+| baseUrl  | string | No       | Custom API base URL                          |
+| logger   | Logger | No       | Custom logger instance or level              |
+
+\* Either `appId` or `apiKey` must be provided for authentication.
 
 #### Methods
 
@@ -224,6 +228,7 @@ type PaymentStatus = "requires_action" | "processing" | "succeeded" | "failed" |
 ```typescript
 interface PaymentOption {
   id: string;
+  account: string; // CAIP-10 account for this option
   amount: PayAmount;
   etaS: number;
   actions: Action[];

--- a/packages/pay/src/client.ts
+++ b/packages/pay/src/client.ts
@@ -30,8 +30,8 @@ import {
 import { createProvider, isProviderAvailable } from "./providers/index.js";
 
 export class WalletConnectPay {
-  public readonly projectId: string;
-  public readonly apiKey: string;
+  public readonly appId?: string;
+  public readonly apiKey?: string;
   public readonly baseUrl: string;
 
   private readonly logger: Logger;
@@ -42,7 +42,7 @@ export class WalletConnectPay {
    * @param opts - Client options
    */
   constructor(opts: WalletConnectPayOptions) {
-    this.projectId = opts.projectId;
+    this.appId = opts.appId;
     this.apiKey = opts.apiKey;
     this.baseUrl = opts.baseUrl ?? PAY_API_BASE_URL;
 
@@ -55,10 +55,13 @@ export class WalletConnectPay {
     this.logger.trace(`${LOGGER_CONTEXT} initialized`);
 
     // Build provider config
+    // Note: appId is used as projectId for error reporting/telemetry
     const providerConfig: PayProviderConfig = {
       baseUrl: this.baseUrl,
-      projectId: this.projectId,
-      apiKey: this.apiKey,
+      projectId: opts.appId,
+      apiKey: opts.apiKey,
+      appId: opts.appId,
+      clientId: opts.clientId,
       sdkName: SDK_NAME,
       sdkVersion: SDK_VERSION,
       sdkPlatform: getSdkPlatform(),

--- a/packages/pay/src/constants/client.ts
+++ b/packages/pay/src/constants/client.ts
@@ -9,7 +9,7 @@ export const PAY_API_BASE_URL = "https://api.pay.walletconnect.com";
 export const SDK_NAME = "js-walletconnect-pay";
 
 /** SDK version (from package.json) */
-export const SDK_VERSION = `1.0.0`;
+export const SDK_VERSION = `1.0.1`;
 
 /** Client context name */
 export const CLIENT_CONTEXT = "pay";

--- a/packages/pay/src/types/api.ts
+++ b/packages/pay/src/types/api.ts
@@ -29,6 +29,8 @@ export interface AmountDisplay {
   decimals: number;
   /** URL of the icon of the asset (if token) */
   iconUrl?: string;
+  /** URL of the network icon */
+  networkIconUrl?: string;
   /** Name of the network of the asset (if token) */
   networkName?: string;
 }
@@ -145,6 +147,8 @@ export interface PaymentInfo {
 export interface PaymentOption {
   /** ID of the option */
   id: string;
+  /** CAIP-10 account for this option */
+  account: string;
   /** The option's token and amount */
   amount: PayAmount;
   /** Estimated time to complete the option, in seconds */

--- a/packages/pay/src/types/client.ts
+++ b/packages/pay/src/types/client.ts
@@ -8,12 +8,13 @@ import type { Logger } from "@walletconnect/logger";
  * Options for initializing the Pay client
  */
 export interface WalletConnectPayOptions {
-  /** WalletConnect Project ID */
-  projectId: string;
-  /** API key for Pay service */
-  apiKey: string;
+  /** App ID for authentication (either apiKey or appId required) */
+  appId?: string;
+  /** API key for authentication (either apiKey or appId required) */
+  apiKey?: string;
   /** Custom base URL (defaults to production) */
   baseUrl?: string;
-  /** Custom logger instance */
-  logger?: Logger | string;
+  clientId?: string;
+  /** Custom logger instance or level */
+  logger?: Logger | "fatal" | "error" | "warn" | "info" | "debug" | "trace" | "silent";
 }

--- a/packages/pay/src/types/provider.ts
+++ b/packages/pay/src/types/provider.ts
@@ -22,9 +22,13 @@ export interface PayProviderConfig {
   /** Base URL for the Pay API */
   baseUrl: string;
   /** WalletConnect Project ID */
-  projectId: string;
-  /** API key for authentication */
-  apiKey: string;
+  projectId?: string;
+  /** API key for authentication (either apiKey or appId required) */
+  apiKey?: string;
+  /** App ID for authentication (either apiKey or appId required) */
+  appId?: string;
+  /** Client ID for tracking */
+  clientId?: string;
   /** SDK name for tracking */
   sdkName: string;
   /** SDK version for tracking */

--- a/packages/pay/test/mocks/provider.ts
+++ b/packages/pay/test/mocks/provider.ts
@@ -188,6 +188,7 @@ export function createMockPaymentOptionsResponse(
     options: [
       {
         id: "opt_1",
+        account: "eip155:8453:0x1234567890123456789012345678901234567890",
         amount: {
           unit: "caip19/eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
           value: "1000000",
@@ -196,6 +197,7 @@ export function createMockPaymentOptionsResponse(
             assetName: "USD Coin",
             decimals: 6,
             iconUrl: "https://example.com/usdc.png",
+            networkIconUrl: "https://example.com/base.png",
             networkName: "Base",
           },
         },
@@ -225,6 +227,7 @@ export function createMockPaymentOptionsWithInfo(
           assetName: "USD Coin",
           decimals: 6,
           iconUrl: "https://example.com/usdc.png",
+          networkIconUrl: "https://example.com/base.png",
           networkName: "Base",
         },
       },

--- a/packages/pay/test/pay.spec.ts
+++ b/packages/pay/test/pay.spec.ts
@@ -155,6 +155,7 @@ describe("WalletConnectPay with MockProvider", () => {
         options: [
           {
             id: "opt_usdc_base",
+            account: "eip155:8453:0xabc",
             amount: {
               unit: "caip19/eip155:8453/erc20:0xUSDC",
               value: "1000000",
@@ -170,6 +171,7 @@ describe("WalletConnectPay with MockProvider", () => {
           },
           {
             id: "opt_usdc_ethereum",
+            account: "eip155:1:0xabc",
             amount: {
               unit: "caip19/eip155:1/erc20:0xUSDC",
               value: "1000000",
@@ -185,6 +187,7 @@ describe("WalletConnectPay with MockProvider", () => {
           },
           {
             id: "opt_dai",
+            account: "eip155:1:0xabc",
             amount: {
               unit: "caip19/eip155:1/erc20:0xDAI",
               value: "1000000000000000000",

--- a/packages/react-native-compat/android/build.gradle
+++ b/packages/react-native-compat/android/build.gradle
@@ -112,7 +112,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   
   // Yttrium - WalletConnect Pay uniffi bindings
-  implementation("com.github.reown-com.yttrium:yttrium-wcpay:0.9.119") {
+  implementation("com.github.reown-com.yttrium:yttrium-wcpay:0.10.11") {
     // Exclude JNA jar, we'll use the AAR version for Android
     exclude group: 'net.java.dev.jna', module: 'jna'
   }

--- a/packages/react-native-compat/android/build.gradle
+++ b/packages/react-native-compat/android/build.gradle
@@ -112,7 +112,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   
   // Yttrium - WalletConnect Pay uniffi bindings
-  implementation("com.github.reown-com.yttrium:yttrium-wcpay:0.10.11") {
+  implementation("com.github.reown-com.yttrium:yttrium-wcpay:0.10.14") {
     // Exclude JNA jar, we'll use the AAR version for Android
     exclude group: 'net.java.dev.jna', module: 'jna'
   }

--- a/packages/react-native-compat/react-native-compat.podspec
+++ b/packages/react-native-compat/react-native-compat.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.swift_version = "5.0"
 
   # Yttrium - WalletConnect Pay uniffi bindings
-  s.dependency "YttriumWrapper", "0.10.11"
+  s.dependency "YttriumWrapper", "0.10.15"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/packages/react-native-compat/react-native-compat.podspec
+++ b/packages/react-native-compat/react-native-compat.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.swift_version = "5.0"
 
   # Yttrium - WalletConnect Pay uniffi bindings
-  s.dependency "YttriumWrapper", "0.10.0"
+  s.dependency "YttriumWrapper", "0.10.11"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
## Summary

- Update yttrium dependency to 0.10.14 in Android build.gradle
- Update YttriumWrapper dependency to 0.10.15 in iOS podspec
- Add `account` field to `PaymentOption` type (CAIP-10 account for each option)
- Add `networkIconUrl` field to `AmountDisplay` type
- Update `PayProviderConfig` to support `appId`/`clientId` authentication
- Update `WalletConnectPayOptions` to use `appId` instead of `projectId`
- Pass `appId` and `clientId` through to native provider
- Update README with new initialization options

## Test plan

- [x] All existing tests pass (41/41)
- [ ] Test with React Native app using the updated native module
- [ ] Verify yttrium 0.10.14 compatibility on Android
- [ ] Verify YttriumWrapper 0.10.15 compatibility on iOS