### PR TITLE
chore: add changesets for pay stable release and yttrium update

### DIFF
--- a/.changeset/forty-lies-vanish.md
+++ b/.changeset/forty-lies-vanish.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/pay": patch
+---
+
+Stable release of `@walletconnect/pay`

--- a/.changeset/two-ways-bathe.md
+++ b/.changeset/two-ways-bathe.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/react-native-compat": patch
+---
+
+Updated Yttrium version iOS-"0.10.15"/Android-"0.10.14"


### PR DESCRIPTION
## Summary

- Adds changeset for `@walletconnect/pay` stable release (patch)
- Adds changeset for `@walletconnect/react-native-compat` with Yttrium version update (iOS 0.10.15 / Android 0.10.14)

## Test plan

- [ ] CI passes
- [ ] Changesets are valid and correctly formatted

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prepares release metadata via changesets.
> 
> - Adds patch changeset for `@walletconnect/pay` marking a stable release
> - Adds patch changeset for `@walletconnect/react-native-compat` updating Yttrium to iOS `0.10.15` and Android `0.10.14`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d7ab8cafc47d14f8f8f3beed4b038d46862988d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->