### PR TITLE
fix(react-native-compat): correct import paths for native modules

### DIFF
--- a/.changeset/fix-native-module-imports.md
+++ b/.changeset/fix-native-module-imports.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/react-native-compat": patch
+---
+
+Fixed incorrect relative import paths for TurboModule native modules

--- a/packages/react-native-compat/module/index.ts
+++ b/packages/react-native-compat/module/index.ts
@@ -14,11 +14,11 @@ const PAY_LINKING_ERROR =
 const isTurboModuleEnabled = global.__turboModuleProxy != null;
 
 const RNWalletConnectModule = isTurboModuleEnabled
-  ? require("../module/NativeRNWalletConnectModule.ts").default
+  ? require("./NativeRNWalletConnectModule.ts").default
   : NativeModules.RNWalletConnectModule;
 
 const RNWalletConnectPay = isTurboModuleEnabled
-  ? require("../module/NativeRNWalletConnectPay.ts").default
+  ? require("./NativeRNWalletConnectPay.ts").default
   : NativeModules.RNWalletConnectPay;
 
 function getExpoModule(): any | undefined {


### PR DESCRIPTION
## Summary

- Fixed incorrect relative import paths for TurboModule native modules in `packages/react-native-compat/module/index.ts`
- The imports were using `../module/` but the file is already in the `module` directory, so it should be `./`

## Changes

```mermaid
graph LR
    A[module/index.ts] -->|Before: ../module/| B[module/NativeRNWalletConnectModule.ts]
    A -->|After: ./| B
    A -->|Before: ../module/| C[module/NativeRNWalletConnectPay.ts]
    A -->|After: ./| C
```

## Test Plan

- [x] Verify TurboModule imports resolve correctly in React Native apps with the new architecture enabled
- [x] Ensure backward compatibility with bridge-based native module loading

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes TurboModule resolution in React Native new architecture.
> 
> - Updates `packages/react-native-compat/module/index.ts` to require `./NativeRNWalletConnectModule.ts` and `./NativeRNWalletConnectPay.ts` instead of `../module/...`
> - Adds changeset for a patch release of `@walletconnect/react-native-compat`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91d0d7d238930c21fb484ab9e27b56a10da79b46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->