### PR TITLE
refactor(utils): replace bs58 with @scure/base

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24061,7 +24061,6 @@
         "@walletconnect/window-getters": "1.0.1",
         "@walletconnect/window-metadata": "1.0.1",
         "blakejs": "1.2.1",
-        "bs58": "6.0.0",
         "detect-browser": "5.3.0",
         "ox": "0.9.3",
         "uint8arrays": "3.1.1"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -55,7 +55,6 @@
     "@walletconnect/window-getters": "1.0.1",
     "@walletconnect/window-metadata": "1.0.1",
     "blakejs": "1.2.1",
-    "bs58": "6.0.0",
     "detect-browser": "5.3.0",
     "ox": "0.9.3",
     "uint8arrays": "3.1.1"

--- a/packages/utils/src/polkadot.ts
+++ b/packages/utils/src/polkadot.ts
@@ -1,8 +1,8 @@
-import bs58 from "bs58";
+import { base58 } from "@scure/base";
 import { blake2b } from "blakejs";
 
 export function ss58AddressToPublicKey(address: string): Uint8Array {
-  const decoded = bs58.decode(address);
+  const decoded = base58.decode(address);
   if (decoded.length < 33) throw new Error("Too short to contain a public key");
   return decoded.slice(1, 33);
 }
@@ -66,7 +66,7 @@ function normalizeHex(input: string): string {
 }
 
 function guessSignatureTypeFromAddress(address: string): number {
-  const decoded = bs58.decode(address);
+  const decoded = base58.decode(address);
   const prefix = decoded[0];
   if (prefix === 42) return 0x00; // Ed25519
   if (prefix === 60) return 0x02; // Secp256k1

--- a/packages/utils/src/signatures.ts
+++ b/packages/utils/src/signatures.ts
@@ -1,10 +1,9 @@
 import { keccak_256 } from "@noble/hashes/sha3";
 import { Secp256k1, Signature } from "ox";
 import { sha256, sha512_256 } from "@noble/hashes/sha2";
-import bs58 from "bs58";
 import { blake2b } from "@noble/hashes/blake2";
 import { encode as msgpackEncode, decode as msgpackDecode } from "@msgpack/msgpack";
-import { base32 } from "@scure/base";
+import { base32, base58 } from "@scure/base";
 import { AuthTypes } from "@walletconnect/types";
 
 import { parseChainId } from "./caip.js";
@@ -150,7 +149,7 @@ export function extractSolanaTransactionId(solanaTransaction: string): string {
 
   const signatureBuffer = transactionBuffer.slice(1, 65);
 
-  return bs58.encode(signatureBuffer);
+  return base58.encode(signatureBuffer);
 }
 
 export function getSuiDigest(transaction: string) {
@@ -165,12 +164,12 @@ export function getSuiDigest(transaction: string) {
 
   const hash = blake2b(dataWithTag, { dkLen: 32 });
 
-  return bs58.encode(hash);
+  return base58.encode(hash);
 }
 
 export function getNearTransactionIdFromSignedTransaction(signedTransaction: unknown) {
   const hash = new Uint8Array(sha256(getNearUint8ArrayFromBytes(signedTransaction)));
-  const hashBase58 = bs58.encode(hash);
+  const hashBase58 = base58.encode(hash);
   return hashBase58;
 }
 


### PR DESCRIPTION
## Summary

- Replaced `bs58` package with `base58` from `@scure/base` (already a dependency)
- Removed `bs58` from dependencies in `packages/utils/package.json`
- Updated imports and usages in `signatures.ts` and `polkadot.ts`

## Motivation

`@scure/base` is already a dependency and provides the same base58 functionality. This removes a redundant dependency and uses the audited `@noble`/`@scure` family of cryptographic libraries consistently.

Closes #5704

## Test plan

- [x] All existing tests pass (2 pre-existing EIP-1271 network-related failures unrelated to this change)
- [x] Verified base58 encode/decode functionality works correctly via existing test cases:
  - Solana transaction ID extraction
  - Sui digest calculation
  - Near transaction hash extraction
  - Polkadot SS58 address decoding

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches base58 operations to `@scure/base` and removes `bs58` from utils.
> 
> - Replaces `bs58` with `@scure/base` `base58` in `signatures.ts` and `polkadot.ts` (all encode/decode calls updated)
> - Removes `bs58` from `packages/utils/package.json` dependencies
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42840e4f29982586852a018fa6771fe595846037. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->