### PR TITLE
chore: add changeset for bs58 replacement

### DIFF
--- a/.changeset/replace-bs58-with-scure-base.md
+++ b/.changeset/replace-bs58-with-scure-base.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/utils": patch
+---
+
+Replaced bs58 dependency with @scure/base for base58 encoding/decoding


### PR DESCRIPTION
## Summary

- Adds changeset for the bs58 to @scure/base replacement (#7146)

This is a patch version bump for `@walletconnect/utils`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Records a patch changeset for `@walletconnect/utils` documenting the replacement of `bs58` with `@scure/base` for Base58 encoding/decoding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 737c6d4a3c1afcc1de037325e1c45575ddb9414f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->