### PR TITLE
fix(universal-provider): prevent TypeError on chainChanged during cleanup

### DIFF
--- a/.changeset/fix-chain-changed-race-condition.md
+++ b/.changeset/fix-chain-changed-race-condition.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/universal-provider": patch
+---
+
+Fixed TypeError in onChainChanged when provider is undefined during cleanup race conditions

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -223,8 +223,8 @@ export class UniversalProvider implements IUniversalProvider {
       // ignore without active session
       if (!this.session) return;
       const [namespace, chainId] = this.validateChain(chain);
-      const provider = this.getProvider(namespace);
-      provider.setDefaultChain(chainId, rpcUrl);
+      // provider may be undefined during cleanup race conditions
+      this.getProvider(namespace)?.setDefaultChain(chainId, rpcUrl);
     } catch (error) {
       // ignore the error if the fx is used prematurely before namespaces are set
       if (!/Please call connect/.test((error as Error).message)) throw error;
@@ -484,7 +484,8 @@ export class UniversalProvider implements IUniversalProvider {
     this.updateNamespaceChain(namespace, chainId);
 
     if (!internal) {
-      this.getProvider(namespace).setDefaultChain(chainId);
+      // provider may be undefined during cleanup race conditions
+      this.getProvider(namespace)?.setDefaultChain(chainId);
     } else {
       // emit the events during the `internal` cycle of chain change
       // otherwise events are emitted twice

--- a/providers/universal-provider/src/UniversalProvider.ts
+++ b/providers/universal-provider/src/UniversalProvider.ts
@@ -223,8 +223,13 @@ export class UniversalProvider implements IUniversalProvider {
       // ignore without active session
       if (!this.session) return;
       const [namespace, chainId] = this.validateChain(chain);
-      // provider may be undefined during cleanup race conditions
-      this.getProvider(namespace)?.setDefaultChain(chainId, rpcUrl);
+      const provider = this.getProvider(namespace);
+      if (provider) {
+        provider.setDefaultChain(chainId, rpcUrl);
+      } else if (this.session) {
+        this.logger.warn(`Provider for namespace '${namespace}' not found in setDefaultChain`);
+      }
+      // If session is undefined, we're in cleanup - silently ignore
     } catch (error) {
       // ignore the error if the fx is used prematurely before namespaces are set
       if (!/Please call connect/.test((error as Error).message)) throw error;
@@ -484,8 +489,13 @@ export class UniversalProvider implements IUniversalProvider {
     this.updateNamespaceChain(namespace, chainId);
 
     if (!internal) {
-      // provider may be undefined during cleanup race conditions
-      this.getProvider(namespace)?.setDefaultChain(chainId);
+      const provider = this.getProvider(namespace);
+      if (provider) {
+        provider.setDefaultChain(chainId);
+      } else if (this.session) {
+        this.logger.warn(`Provider for namespace '${namespace}' not found during chain change`);
+      }
+      // If session is undefined, we're in cleanup - silently ignore
     } else {
       // emit the events during the `internal` cycle of chain change
       // otherwise events are emitted twice


### PR DESCRIPTION
## Summary

- Added explicit provider check before calling `setDefaultChain` in `onChainChanged` and public `setDefaultChain` methods
- Prevents `TypeError: Cannot read properties of undefined (reading 'setDefaultChain')` during race conditions
- Logs a warning if provider is missing during an active session (to catch real issues)

## Problem

When a `chainChanged` event is processed concurrently with session cleanup (e.g., `session_delete`), the provider may become undefined, causing an unhandled promise rejection that crashes the application.

```mermaid
sequenceDiagram
    participant Wallet
    participant SignClient
    participant UniversalProvider
    
    Wallet->>SignClient: session_event (chainChanged)
    Wallet->>SignClient: session_delete
    SignClient->>UniversalProvider: onChainChanged()
    Note over UniversalProvider: passes namespaces check
    SignClient->>UniversalProvider: cleanup()
    Note over UniversalProvider: session = undefined
    UniversalProvider->>UniversalProvider: getProvider() returns undefined
    Note over UniversalProvider: TypeError: Cannot read 'setDefaultChain'
```

## Fix

Instead of using silent optional chaining (`?.`), we now explicitly check for the provider and handle each case appropriately:

```typescript
const provider = this.getProvider(namespace);
if (provider) {
  provider.setDefaultChain(chainId);
} else if (this.session) {
  // Provider missing during active session - log warning
  this.logger.warn(`Provider for namespace '${namespace}' not found`);
}
// If session is undefined, we're in cleanup - silently ignore
```

**Behavior:**
- Provider exists → call `setDefaultChain` normally
- Provider missing + active session → log warning (indicates a real issue that should be investigated)
- Provider missing + no session → silently ignore (cleanup race condition)

Closes #7062

## Test plan

- [x] Existing tests pass
- [x] Race condition during cleanup is handled gracefully
- [x] Real issues (missing provider during active session) are logged as warnings