### PR TITLE
fix: use json output to get release tag name in wasm workflow

### DIFF
--- a/.github/workflows/update_pay_wasm.yml
+++ b/.github/workflows/update_pay_wasm.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LATEST_RELEASE=$(gh release list --repo reown-com/yttrium --limit 50 | awk '{print $1}' | grep "^wasm-pay-" | head -1)
+          LATEST_RELEASE=$(gh release list --repo reown-com/yttrium --limit 50 --json tagName --jq '.[].tagName' | grep "^wasm-pay-" | head -1)
           if [ -z "$LATEST_RELEASE" ]; then
             echo "No wasm-pay releases found"
             exit 1


### PR DESCRIPTION
## Summary

Fixes the `update_pay_wasm.yml` workflow failing to find wasm-pay releases.

The issue was that `gh release list` outputs the release **title** in the first column (e.g., "Yttrium WASM Pay 0.10.0"), not the tag name (`wasm-pay-0.10.0`). The `awk '{print $1}'` was extracting "Yttrium" which doesn't match the `^wasm-pay-` pattern.

### Fix
Use `--json tagName --jq '.[].tagName'` to reliably extract tag names instead of parsing the text output.

## Test plan
- [ ] Run the `Update Pay WASM` workflow manually and verify it finds the latest wasm-pay release

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI workflow change that only affects how release metadata is fetched; no runtime or product code paths are modified.
> 
> **Overview**
> Fixes the `update_pay_wasm.yml` workflow’s “latest yttrium release” detection by switching `gh release list` parsing from text/`awk` to structured JSON output.
> 
> The workflow now extracts `tagName` via `--json tagName --jq '.[].tagName'`, ensuring the `^wasm-pay-` filter matches actual tags and preventing false “no releases found” failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 892088d077e48a794f1108690d40239902f008dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->