### PR TITLE
chore(react-native-compat): update Yttrium dependencies

### DIFF
--- a/packages/react-native-compat/android/build.gradle
+++ b/packages/react-native-compat/android/build.gradle
@@ -112,7 +112,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   
   // Yttrium - WalletConnect Pay uniffi bindings
-  implementation("com.github.reown-com.yttrium:yttrium-wcpay:0.10.14") {
+  implementation("com.github.reown-com.yttrium:yttrium-wcpay:0.10.29") {
     // Exclude JNA jar, we'll use the AAR version for Android
     exclude group: 'net.java.dev.jna', module: 'jna'
   }

--- a/packages/react-native-compat/react-native-compat.podspec
+++ b/packages/react-native-compat/react-native-compat.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.swift_version = "5.0"
 
   # Yttrium - WalletConnect Pay uniffi bindings
-  s.dependency "YttriumWrapper", "0.10.30"
+  s.dependency "YttriumWrapper", "0.10.31"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/packages/react-native-compat/react-native-compat.podspec
+++ b/packages/react-native-compat/react-native-compat.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.swift_version = "5.0"
 
   # Yttrium - WalletConnect Pay uniffi bindings
-  s.dependency "YttriumWrapper", "0.10.15"
+  s.dependency "YttriumWrapper", "0.10.30"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
## Summary

- Update Android `yttrium-wcpay` dependency from 0.10.14 to 0.10.29
- Update iOS `YttriumWrapper` dependency from 0.10.15 to 0.10.30

These updates bring the latest WalletConnect Pay uniffi bindings for React Native.

## Test plan

- [ ] Verify Android build compiles with updated Yttrium dependency
- [ ] Verify iOS build compiles with updated YttriumWrapper dependency
- [ ] Test WalletConnect Pay functionality on both platforms

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bumps; main risk is platform build/runtime regressions introduced by the updated Yttrium artifacts.
> 
> **Overview**
> Updates the `react-native-compat` native dependency versions for WalletConnect Pay uniffi bindings: Android `yttrium-wcpay` is bumped from `0.10.14` to `0.10.29`, and iOS `YttriumWrapper` is bumped from `0.10.15` to `0.10.31`. No other build or runtime logic changes are included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3662554aba760de9abd1f91a522f4db8a5c6a734. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->