### PR TITLE
fix: handle batch subscribe failure and trigger transport restart

### DIFF
--- a/.changeset/fix-batch-subscribe-error-handling.md
+++ b/.changeset/fix-batch-subscribe-error-handling.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/core": patch
+---
+
+Fixed batch subscribe silently swallowing errors and marking topics as subscribed when the RPC failed. Failed topics are now kept in pending for retry, and connection_stalled triggers a transport restart with exponential backoff.

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -319,11 +319,14 @@ export class Relayer extends IRelayer {
   }
 
   private async resetTransport() {
+    // Guards must be set synchronously before any async work:
+    // - reconnectInProgress prevents onProviderDisconnect from scheduling a competing reconnect
+    // - clearTimeout prevents a pending reconnectTimeout from firing during transportDisconnect
     this.reconnectInProgress = true;
-    await this.transportDisconnect();
-    await this.subscriber.stop();
     clearTimeout(this.reconnectTimeout);
     this.reconnectTimeout = undefined;
+    await this.transportDisconnect();
+    await this.subscriber.stop();
     this.reconnectInProgress = false;
   }
 

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -97,6 +97,11 @@ export class Relayer extends IRelayer {
   private reconnectInProgress = false;
   private requestsInFlight: string[] = [];
   private connectTimeout = toMiliseconds(ONE_SECOND * 15);
+  private stalledRestartInProgress = false;
+  private stalledRestartTimeout: NodeJS.Timeout | undefined;
+  private stalledRestartBackoff = 0;
+  private readonly stalledRestartBaseInterval = toMiliseconds(ONE_SECOND * 2);
+  private readonly stalledRestartMaxInterval = toMiliseconds(THIRTY_SECONDS);
   constructor(opts: RelayerOptions) {
     super(opts);
     this.core = opts.core;
@@ -273,6 +278,8 @@ export class Relayer extends IRelayer {
     clearTimeout(this.reconnectTimeout);
     this.reconnectTimeout = undefined;
     this.reconnectInProgress = false;
+    clearTimeout(this.stalledRestartTimeout);
+    this.stalledRestartInProgress = false;
     await this.transportDisconnect();
   }
 
@@ -567,6 +574,7 @@ export class Relayer extends IRelayer {
 
   private onConnectHandler = () => {
     this.logger.warn({}, "Relayer connected 🛜");
+    this.stalledRestartBackoff = 0;
     this.startPingTimeout();
     this.events.emit(RELAYER_EVENTS.connect);
   };
@@ -632,6 +640,26 @@ export class Relayer extends IRelayer {
           this.logger.warn(error, (error as Error)?.message);
         }
       }
+    });
+
+    this.events.on(RELAYER_EVENTS.connection_stalled, () => {
+      if (this.transportExplicitlyClosed) return;
+      if (this.stalledRestartInProgress) return;
+      this.stalledRestartInProgress = true;
+
+      const delay = Math.min(
+        this.stalledRestartBackoff * this.stalledRestartBaseInterval,
+        this.stalledRestartMaxInterval,
+      );
+      this.stalledRestartBackoff++;
+
+      this.logger.warn(`Connection stalled, restarting transport${delay ? ` in ${delay}ms` : ""}...`);
+      this.stalledRestartTimeout = setTimeout(() => {
+        this.stalledRestartInProgress = false;
+        this.restartTransport().catch((error) =>
+          this.logger.error(error, (error as Error)?.message),
+        );
+      }, delay);
     });
   }
 

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -321,6 +321,7 @@ export class Relayer extends IRelayer {
   private async resetTransport() {
     this.reconnectInProgress = true;
     await this.transportDisconnect();
+    await this.subscriber.stop();
     clearTimeout(this.reconnectTimeout);
     this.reconnectTimeout = undefined;
     this.reconnectInProgress = false;

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -275,13 +275,10 @@ export class Relayer extends IRelayer {
 
   public async transportClose() {
     this.transportExplicitlyClosed = true;
-    clearTimeout(this.reconnectTimeout);
-    this.reconnectTimeout = undefined;
-    this.reconnectInProgress = false;
     clearTimeout(this.stalledRestartTimeout);
     this.stalledRestartInProgress = false;
     this.stalledRestartBackoff = 0;
-    await this.transportDisconnect();
+    await this.resetTransport();
   }
 
   async transportOpen(relayUrl?: string) {
@@ -317,8 +314,15 @@ export class Relayer extends IRelayer {
     if (this.connectionAttemptInProgress) return;
     this.relayUrl = relayUrl || this.relayUrl;
     await this.confirmOnlineStateOrThrow();
-    await this.transportClose();
+    await this.resetTransport();
     await this.transportOpen();
+  }
+
+  private async resetTransport() {
+    await this.transportDisconnect();
+    clearTimeout(this.reconnectTimeout);
+    this.reconnectTimeout = undefined;
+    this.reconnectInProgress = false;
   }
 
   public async confirmOnlineStateOrThrow() {

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -653,7 +653,9 @@ export class Relayer extends IRelayer {
       );
       this.stalledRestartBackoff++;
 
-      this.logger.warn(`Connection stalled, restarting transport${delay ? ` in ${delay}ms` : ""}...`);
+      this.logger.warn(
+        `Connection stalled, restarting transport${delay ? ` in ${delay}ms` : ""}...`,
+      );
       this.stalledRestartTimeout = setTimeout(() => {
         this.stalledRestartInProgress = false;
         this.restartTransport().catch((error) =>

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -670,6 +670,7 @@ export class Relayer extends IRelayer {
       );
       this.stalledRestartTimeout = setTimeout(async () => {
         try {
+          if (this.transportExplicitlyClosed) return;
           await this.restartTransport();
         } catch (error) {
           this.logger.error(error, (error as Error)?.message);

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -319,6 +319,7 @@ export class Relayer extends IRelayer {
   }
 
   private async resetTransport() {
+    this.reconnectInProgress = true;
     await this.transportDisconnect();
     clearTimeout(this.reconnectTimeout);
     this.reconnectTimeout = undefined;

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -653,10 +653,13 @@ export class Relayer extends IRelayer {
       if (this.stalledRestartInProgress) return;
       this.stalledRestartInProgress = true;
 
-      const delay = Math.min(
-        this.stalledRestartBackoff * this.stalledRestartBaseInterval,
-        this.stalledRestartMaxInterval,
-      );
+      const delay =
+        this.stalledRestartBackoff === 0
+          ? 0
+          : Math.min(
+              Math.pow(2, this.stalledRestartBackoff - 1) * this.stalledRestartBaseInterval,
+              this.stalledRestartMaxInterval,
+            );
       this.stalledRestartBackoff++;
 
       this.logger.warn(

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -280,6 +280,7 @@ export class Relayer extends IRelayer {
     this.reconnectInProgress = false;
     clearTimeout(this.stalledRestartTimeout);
     this.stalledRestartInProgress = false;
+    this.stalledRestartBackoff = 0;
     await this.transportDisconnect();
   }
 
@@ -574,7 +575,6 @@ export class Relayer extends IRelayer {
 
   private onConnectHandler = () => {
     this.logger.warn({}, "Relayer connected 🛜");
-    this.stalledRestartBackoff = 0;
     this.startPingTimeout();
     this.events.emit(RELAYER_EVENTS.connect);
   };
@@ -656,11 +656,14 @@ export class Relayer extends IRelayer {
       this.logger.warn(
         `Connection stalled, restarting transport${delay ? ` in ${delay}ms` : ""}...`,
       );
-      this.stalledRestartTimeout = setTimeout(() => {
-        this.stalledRestartInProgress = false;
-        this.restartTransport().catch((error) =>
-          this.logger.error(error, (error as Error)?.message),
-        );
+      this.stalledRestartTimeout = setTimeout(async () => {
+        try {
+          await this.restartTransport();
+        } catch (error) {
+          this.logger.error(error, (error as Error)?.message);
+        } finally {
+          this.stalledRestartInProgress = false;
+        }
       }, delay);
     });
   }

--- a/packages/core/src/controllers/subscriber.ts
+++ b/packages/core/src/controllers/subscriber.ts
@@ -312,8 +312,8 @@ export class Subscriber extends ISubscriber {
     return null;
   }
 
-  private async rpcBatchSubscribe(subscriptions: SubscriberTypes.Params[]) {
-    if (!subscriptions.length) return;
+  private async rpcBatchSubscribe(subscriptions: SubscriberTypes.Params[]): Promise<boolean> {
+    if (!subscriptions.length) return true;
     const relay = subscriptions[0].relay;
     const api = getRelayProtocolApi(relay!.protocol);
     const request: RequestArguments<RelayJsonRpc.BatchSubscribeParams> = {
@@ -325,19 +325,23 @@ export class Subscriber extends ISubscriber {
     this.logger.debug(`Outgoing Relay Payload`);
     this.logger.trace({ type: "payload", direction: "outgoing", request });
     try {
-      const subscribe = await createExpiringPromise(
-        new Promise((resolve) => {
+      await createExpiringPromise(
+        new Promise((resolve, reject) => {
           this.relayer
             .request(request)
-            .catch((e) => this.logger.warn(e))
-            .then(resolve);
+            .then(resolve)
+            .catch((e) => {
+              this.logger.warn(e);
+              reject(e);
+            });
         }),
         this.subscribeTimeout,
         "rpcBatchSubscribe failed, please try again",
       );
-      await subscribe;
+      return true;
     } catch (err) {
       this.relayer.events.emit(RELAYER_EVENTS.connection_stalled);
+      return false;
     }
   }
 
@@ -510,7 +514,16 @@ export class Subscriber extends ISubscriber {
   private async batchSubscribe(subscriptions: SubscriberTypes.Params[]) {
     if (!subscriptions.length) return;
 
-    await this.rpcBatchSubscribe(subscriptions);
+    const success = await this.rpcBatchSubscribe(subscriptions);
+    if (!success) {
+      this.logger.warn(
+        `Batch subscribe failed for ${subscriptions.length} topics, adding to pending for retry`,
+      );
+      subscriptions.forEach((s) => {
+        this.pending.set(s.topic, s);
+      });
+      return;
+    }
     this.onBatchSubscribe(
       await Promise.all(
         subscriptions.map(async (s) => {

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -715,4 +715,84 @@ describe("Relayer", () => {
       });
     },
   );
+
+  describe("connection_stalled", () => {
+    let restartStub: Sinon.SinonStub;
+
+    beforeEach(async () => {
+      core = new Core(TEST_CORE_OPTIONS);
+      relayer = core.relayer;
+      await core.start();
+      relayer.subscriber.topicMap.set(randomTopic, randomTopic);
+      restartStub = Sinon.stub(relayer, "restartTransport").resolves();
+    });
+    afterEach(async () => {
+      restartStub.restore();
+      await disconnectSocket(relayer);
+    });
+
+    it("should call restartTransport immediately on first connection_stalled", async () => {
+      // #when
+      relayer.events.emit(RELAYER_EVENTS.connection_stalled);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // #then - first emission has 0 delay (backoff=0 * base)
+      expect(restartStub.calledOnce).to.be.true;
+    });
+
+    it("should not call restartTransport when transport is explicitly closed", async () => {
+      // #given
+      await relayer.transportClose();
+
+      // #when
+      relayer.events.emit(RELAYER_EVENTS.connection_stalled);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // #then
+      expect(restartStub.called).to.be.false;
+    });
+
+    it("should not trigger multiple restarts from rapid connection_stalled emissions", async () => {
+      // #when - emit multiple times rapidly
+      relayer.events.emit(RELAYER_EVENTS.connection_stalled);
+      relayer.events.emit(RELAYER_EVENTS.connection_stalled);
+      relayer.events.emit(RELAYER_EVENTS.connection_stalled);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // #then - only one restart despite multiple emissions
+      expect(restartStub.calledOnce).to.be.true;
+    });
+
+    it("should apply exponential backoff on subsequent connection_stalled emissions", async () => {
+      // #when - first emission (0ms delay)
+      relayer.events.emit(RELAYER_EVENTS.connection_stalled);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(restartStub.calledOnce).to.be.true;
+
+      // #when - second emission (2s delay) - should NOT fire yet after 50ms
+      relayer.events.emit(RELAYER_EVENTS.connection_stalled);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(restartStub.callCount).to.equal(1);
+
+      // #then - should fire after the 2s backoff
+      await new Promise((resolve) => setTimeout(resolve, 2100));
+      expect(restartStub.callCount).to.equal(2);
+    });
+
+    it("should reset backoff after successful connection", async () => {
+      // #given - trigger first stalled restart (immediate)
+      relayer.events.emit(RELAYER_EVENTS.connection_stalled);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(restartStub.callCount).to.equal(1);
+
+      // #when - simulate successful connection via onConnectHandler
+      // @ts-expect-error - private method
+      relayer.onConnectHandler();
+
+      // #then - next stalled event should be immediate again (backoff reset)
+      relayer.events.emit(RELAYER_EVENTS.connection_stalled);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(restartStub.callCount).to.equal(2);
+    });
+  });
 });

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -728,7 +728,7 @@ describe("Relayer", () => {
     });
     afterEach(async () => {
       restartStub.restore();
-      await disconnectSocket(relayer);
+      await relayer.transportClose();
     });
 
     it("should call restartTransport immediately on first connection_stalled", async () => {

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -779,17 +779,33 @@ describe("Relayer", () => {
       expect(restartStub.callCount).to.equal(2);
     });
 
-    it("should reset backoff after successful connection", async () => {
-      // #given - trigger first stalled restart (immediate)
+    it("should NOT reset backoff on successful connection", async () => {
+      // #given - trigger first stalled restart (immediate, backoff goes 0 → 1)
       relayer.events.emit(RELAYER_EVENTS.connection_stalled);
       await new Promise((resolve) => setTimeout(resolve, 50));
       expect(restartStub.callCount).to.equal(1);
 
-      // #when - simulate successful connection via onConnectHandler
+      // #when - simulate successful connection
       // @ts-expect-error - private method
       relayer.onConnectHandler();
 
-      // #then - next stalled event should be immediate again (backoff reset)
+      // #then - next stalled event should NOT be immediate (backoff=1 → 2s delay)
+      relayer.events.emit(RELAYER_EVENTS.connection_stalled);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(restartStub.callCount).to.equal(1);
+    });
+
+    it("should reset backoff after explicit transportClose", async () => {
+      // #given - trigger first stalled restart (immediate, backoff goes 0 → 1)
+      relayer.events.emit(RELAYER_EVENTS.connection_stalled);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(restartStub.callCount).to.equal(1);
+
+      // #when - explicit transport close resets backoff
+      await relayer.transportClose();
+      relayer.transportExplicitlyClosed = false;
+
+      // #then - next stalled event should be immediate again (backoff was reset to 0)
       relayer.events.emit(RELAYER_EVENTS.connection_stalled);
       await new Promise((resolve) => setTimeout(resolve, 50));
       expect(restartStub.callCount).to.equal(2);

--- a/packages/core/test/subscriber.spec.ts
+++ b/packages/core/test/subscriber.spec.ts
@@ -256,7 +256,8 @@ describe("Subscriber", () => {
       requestStub = Sinon.stub(relayer, "request");
     });
 
-    afterEach(() => {
+    afterEach(async () => {
+      await relayer.transportClose();
       restartStub.restore();
       requestStub.restore();
     });

--- a/packages/core/test/subscriber.spec.ts
+++ b/packages/core/test/subscriber.spec.ts
@@ -9,6 +9,7 @@ import {
   CORE_DEFAULT,
   CORE_STORAGE_PREFIX,
   MESSAGES_STORAGE_VERSION,
+  RELAYER_EVENTS,
   RELAYER_PROVIDER_EVENTS,
   Subscriber,
   SUBSCRIBER_CONTEXT,
@@ -243,6 +244,119 @@ describe("Subscriber", () => {
           }),
         ),
       ).to.be.true;
+    });
+  });
+
+  describe("batchSubscribe error handling", () => {
+    let restartStub: Sinon.SinonStub;
+    let requestStub: Sinon.SinonStub;
+
+    beforeEach(() => {
+      restartStub = Sinon.stub(relayer, "restartTransport").resolves();
+      requestStub = Sinon.stub(relayer, "request");
+    });
+
+    afterEach(() => {
+      restartStub.restore();
+      requestStub.restore();
+    });
+
+    it("should not mark topics as subscribed when batch subscribe RPC fails", async () => {
+      // #given
+      requestStub.rejects(new Error("relay error"));
+      const topic = generateRandomBytes32();
+
+      // @ts-expect-error - private property
+      subscriber.cached = [{ topic, relay: { protocol: "irn" } }];
+
+      // #when - simulate reconnect which triggers batchSubscribe via onRestart
+      // @ts-expect-error - private method
+      await subscriber.onRestart();
+
+      // #then - batch subscribe RPC was attempted with the correct topic
+      expect(requestStub.calledOnce).to.equal(true);
+      expect(
+        requestStub.calledWith(
+          Sinon.match({ method: "irn_batchSubscribe", params: { topics: [topic] } }),
+        ),
+      ).to.equal(true);
+      // topics should NOT be in subscriptions/topicMap
+      expect(subscriber.subscriptions.size).to.equal(0);
+      expect(subscriber.topics.length).to.equal(0);
+      expect(await subscriber.isSubscribed(topic)).to.equal(false);
+    });
+
+    it("should add failed batch topics to pending for retry", async () => {
+      // #given
+      requestStub.rejects(new Error("relay error"));
+      const topic = generateRandomBytes32();
+
+      // @ts-expect-error - private property
+      subscriber.cached = [{ topic, relay: { protocol: "irn" } }];
+
+      // #when
+      // @ts-expect-error - private method
+      await subscriber.onRestart();
+
+      // #then - batch subscribe RPC was attempted
+      expect(requestStub.calledOnce).to.equal(true);
+      expect(
+        requestStub.calledWith(
+          Sinon.match({ method: "irn_batchSubscribe", params: { topics: [topic] } }),
+        ),
+      ).to.equal(true);
+      // topics should be in pending for retry on next heartbeat
+      expect(subscriber.pending.has(topic)).to.equal(true);
+    });
+
+    it("should emit connection_stalled when batch subscribe fails", async () => {
+      // #given
+      requestStub.rejects(new Error("relay error"));
+      const topic = generateRandomBytes32();
+      const stalledSpy = Sinon.spy();
+      relayer.events.on(RELAYER_EVENTS.connection_stalled, stalledSpy);
+
+      // @ts-expect-error - private property
+      subscriber.cached = [{ topic, relay: { protocol: "irn" } }];
+
+      // #when
+      // @ts-expect-error - private method
+      await subscriber.onRestart();
+
+      // #then - batch subscribe RPC was attempted
+      expect(requestStub.calledOnce).to.equal(true);
+      expect(
+        requestStub.calledWith(
+          Sinon.match({ method: "irn_batchSubscribe", params: { topics: [topic] } }),
+        ),
+      ).to.equal(true);
+      expect(stalledSpy.calledOnce).to.equal(true);
+    });
+
+    it("should register subscriptions when batch subscribe succeeds", async () => {
+      // #given
+      requestStub.resolves({});
+      const topic = generateRandomBytes32();
+
+      // @ts-expect-error - private property
+      subscriber.cached = [{ topic, relay: { protocol: "irn" } }];
+
+      // #when
+      // @ts-expect-error - private method
+      await subscriber.onRestart();
+
+      // #then - batch subscribe RPC was attempted
+      expect(requestStub.calledOnce).to.equal(true);
+      expect(
+        requestStub.calledWith(
+          Sinon.match({ method: "irn_batchSubscribe", params: { topics: [topic] } }),
+        ),
+      ).to.equal(true);
+      // topics should be in subscriptions/topicMap
+      expect(subscriber.subscriptions.size).to.equal(1);
+      expect(subscriber.topics.length).to.equal(1);
+      expect(await subscriber.isSubscribed(topic)).to.equal(true);
+      expect(subscriber.pending.has(topic)).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Fix silent error swallowing in `rpcBatchSubscribe` that caused the SDK to mark topics as subscribed when the RPC actually failed
- Keep failed topics in `pending` for automatic retry via heartbeat
- Add `connection_stalled` listener in the relayer to trigger `restartTransport` with exponential backoff

## Problem

When `rpcBatchSubscribe` failed (dead socket, relay error, timeout), the error was silently swallowed by a `.catch().then(resolve)` promise chain. `batchSubscribe` then unconditionally called `onBatchSubscribe`, which:
1. Added topics to `subscriptions` and `topicMap` as if they were active
2. Removed them from `pending`, preventing heartbeat-based retry
3. Made `isSubscribed(topic)` return `true` for topics never subscribed on the relay

## Solution

```mermaid
sequenceDiagram
    participant Sub as Subscriber
    participant Rel as Relayer
    participant Relay as RelayServer

    Sub->>Rel: batchSubscribe -> relayer.request()
    Rel->>Relay: irn_batchSubscribe
    Relay-->>Rel: ERROR
    Rel-->>Sub: rejects

    Note over Sub: rpcBatchSubscribe returns false
    Note over Sub: Topics added to pending (not subscriptions)

    Sub->>Rel: emit connection_stalled
    Rel->>Rel: restartTransport() with backoff
    Rel->>Relay: resetTransport (disconnect + subscriber.stop) then transportOpen
    Relay-->>Rel: connected
    Note over Rel: Backoff persists across reconnects

    Rel->>Sub: subscriber.start() -> resubscribe cached
    Note over Sub: Heartbeat also retries pending topics
```

### Changes

**`subscriber.ts`**
- `rpcBatchSubscribe` returns `Promise<boolean>` -- properly rejects on RPC failure instead of silently resolving
- `batchSubscribe` checks return value -- on failure, adds topics to `pending` for retry instead of registering them as subscribed

**`relayer.ts`**
- New `connection_stalled` event listener triggers `restartTransport()` with true exponential backoff
- Backoff: 0ms (immediate) -> 2s -> 4s -> 8s -> 16s -> 30s cap
- `stalledRestartInProgress` guard prevents concurrent restarts -- stays active until `restartTransport` completes (set in `finally` block)
- Backoff intentionally persists across successful reconnects -- resetting on connect would cause an infinite restart loop when subscriptions keep failing after socket reconnection
- Backoff resets only on explicit `transportClose` (clean lifecycle boundary)
- Cleanup in `transportClose` clears pending timeout, guard, and backoff counter
- Extracted `resetTransport()` -- shared disconnect + cleanup used by both `transportClose` and `restartTransport`, separating explicit-close state resets from internal restart path
- `restartTransport` calls `resetTransport()` (not `transportClose()`) to preserve stalled-restart backoff state across restart cycles
- `resetTransport` sets `reconnectInProgress = true` before `transportDisconnect` to prevent `onProviderDisconnect` from scheduling a competing reconnect
- `resetTransport` calls `subscriber.stop()` explicitly to cache active subscriptions and clear stale state, since the `reconnectInProgress` guard prevents `onProviderDisconnect` from doing so

## Test plan

- [x] Batch subscribe failure does NOT mark topics as subscribed
- [x] Batch subscribe failure adds topics to `pending` for retry
- [x] Batch subscribe failure emits `connection_stalled`
- [x] Batch subscribe success still registers subscriptions correctly
- [x] All tests validate `irn_batchSubscribe` RPC was actually called with correct params
- [x] First `connection_stalled` triggers immediate restart
- [x] Transport explicitly closed ignores `connection_stalled`
- [x] Rapid emissions only trigger one restart (guard)
- [x] Exponential backoff on subsequent emissions (2s delay verified)
- [x] Backoff does NOT reset on successful connection (prevents infinite loop)
- [x] Backoff resets after explicit `transportClose`
- [x] Test cleanup calls `transportClose` unconditionally to flush pending timers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches relayer transport lifecycle and reconnection behavior; incorrect backoff/guarding could cause reconnect loops, missed reconnects, or delayed message delivery under network instability.
> 
> **Overview**
> Fixes `Subscriber` batch subscribe so RPC failures are no longer silently swallowed: `rpcBatchSubscribe` now fails explicitly, and `batchSubscribe` keeps failed topics in `pending` (instead of registering them as subscribed) so heartbeat can retry.
> 
> Adds `Relayer` handling for `RELAYER_EVENTS.connection_stalled` to restart the transport with exponential backoff and a single-restart guard; transport shutdown/restart is refactored via a shared `resetTransport()` and `transportClose()` now clears stalled-restart timers/backoff. Tests are added to cover batch-subscribe failure/success behavior and the stalled-restart backoff semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41d210b1629b6e5be3c7bdb74b8a5db7b3306272. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->