### PR TITLE
fix: sync pay API types with yttrium crate

### DIFF
--- a/.changeset/sync-pay-types-yttrium.md
+++ b/.changeset/sync-pay-types-yttrium.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/pay": patch
+---
+
+fix: sync pay API types with yttrium crate

--- a/packages/pay/src/types/api.ts
+++ b/packages/pay/src/types/api.ts
@@ -13,7 +13,7 @@ export type PaymentStatus = "requires_action" | "processing" | "succeeded" | "fa
 /**
  * Type of data collection field
  */
-export type CollectDataFieldType = "text" | "date";
+export type CollectDataFieldType = "text" | "date" | "checkbox";
 
 // ==================== Display Types ====================
 
@@ -113,6 +113,8 @@ export interface CollectDataField {
  */
 export interface CollectDataAction {
   fields: CollectDataField[];
+  url?: string;
+  schema?: string;
 }
 
 /**
@@ -212,6 +214,14 @@ export interface PaymentOptionsResponse {
 }
 
 /**
+ * Transaction result info returned after payment confirmation
+ */
+export interface PaymentResultInfo {
+  txId: string;
+  optionAmount: PayAmount;
+}
+
+/**
  * Response from confirm payment
  */
 export interface ConfirmPaymentResponse {
@@ -221,4 +231,6 @@ export interface ConfirmPaymentResponse {
   isFinal: boolean;
   /** Time to poll for payment status, in milliseconds */
   pollInMs?: number;
+  /** Transaction result info, present when payment succeeds */
+  info?: PaymentResultInfo;
 }


### PR DESCRIPTION
## Summary

- Sync `packages/pay` TypeScript types with the latest Rust type definitions from the `yttrium` pay crate
- Add missing `"checkbox"` variant to `CollectDataFieldType`
- Add missing `url` and `schema` optional fields to `CollectDataAction`
- Add new `PaymentResultInfo` type and wire it into `ConfirmPaymentResponse`

## Test plan

- [ ] Verify `npm run build` passes for `packages/pay`
- [ ] Verify existing pay tests still pass
- [ ] Confirm types align with yttrium WASM output at runtime


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only updates to the Pay SDK API surface; main risk is downstream TypeScript compile breaks for consumers that narrow on `CollectDataFieldType` or expect `ConfirmPaymentResponse` without `info`.
> 
> **Overview**
> Syncs `@walletconnect/pay` TypeScript API types with the latest `yttrium` definitions.
> 
> Expands data-collection typing by adding a `"checkbox"` `CollectDataFieldType` and optional `url`/`schema` fields on `CollectDataAction`. Extends `ConfirmPaymentResponse` with optional transaction details via new `PaymentResultInfo` (`txId`, `optionAmount`). Adds a changeset to publish a patch release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1674f2bfbeb55845ad7786b031a95c2ff8cc844. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->