### PR TITLE
fix: lazy TextDecoder/TextEncoder init in yttrium.js for React Native debug builds

### DIFF
--- a/.changeset/fix-pay-wasm-react-native-textdecoder.md
+++ b/.changeset/fix-pay-wasm-react-native-textdecoder.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/pay": patch
+---
+
+fix: lazy TextDecoder/TextEncoder initialization in WASM provider for React Native debug builds

--- a/.github/workflows/update_pay_wasm.yml
+++ b/.github/workflows/update_pay_wasm.yml
@@ -250,6 +250,10 @@ jobs:
           echo "Updated files in $DEST_DIR:"
           ls -lh "$DEST_DIR/"
 
+      - name: Patch yttrium.js for React Native compatibility
+        if: steps.compare.outputs.wasm_needs_update == 'true'
+        run: node scripts/patch_yttrium_lazy_init.js
+
       - name: Update podspec with Swift version
         if: steps.compare.outputs.swift_needs_update == 'true'
         run: |

--- a/packages/pay/src/client.ts
+++ b/packages/pay/src/client.ts
@@ -35,7 +35,7 @@ export class WalletConnectPay {
   public readonly baseUrl: string;
 
   private readonly logger: Logger;
-  private readonly provider: PayProvider;
+  private readonly providerPromise: Promise<PayProvider>;
 
   /**
    * Initialize a new Pay client
@@ -68,9 +68,10 @@ export class WalletConnectPay {
       bundleId: getAppId() ?? "",
     };
 
-    // Create provider (auto-detects available provider)
-    this.provider = createProvider(providerConfig);
-    this.logger.debug(`${LOGGER_CONTEXT} provider initialized`);
+    this.providerPromise = createProvider(providerConfig);
+    this.providerPromise.then(() => {
+      this.logger.debug(`${LOGGER_CONTEXT} provider initialized`);
+    });
   }
 
   /**
@@ -101,7 +102,8 @@ export class WalletConnectPay {
     );
 
     try {
-      const response = await this.provider.getPaymentOptions(params);
+      const provider = await this.providerPromise;
+      const response = await provider.getPaymentOptions(params);
 
       this.logger.debug(
         { paymentId: response.paymentId, optionsCount: response.options.length },
@@ -131,7 +133,8 @@ export class WalletConnectPay {
     );
 
     try {
-      const actions = await this.provider.getRequiredPaymentActions(params);
+      const provider = await this.providerPromise;
+      const actions = await provider.getRequiredPaymentActions(params);
 
       this.logger.debug(
         { actionsCount: actions.length },
@@ -168,7 +171,8 @@ export class WalletConnectPay {
     );
 
     try {
-      const response = await this.provider.confirmPayment(params);
+      const provider = await this.providerPromise;
+      const response = await provider.confirmPayment(params);
 
       this.logger.debug(
         { status: response.status, isFinal: response.isFinal },

--- a/packages/pay/src/client.ts
+++ b/packages/pay/src/client.ts
@@ -35,7 +35,7 @@ export class WalletConnectPay {
   public readonly baseUrl: string;
 
   private readonly logger: Logger;
-  private readonly providerPromise: Promise<PayProvider>;
+  private readonly provider: PayProvider;
 
   /**
    * Initialize a new Pay client
@@ -68,10 +68,8 @@ export class WalletConnectPay {
       bundleId: getAppId() ?? "",
     };
 
-    this.providerPromise = createProvider(providerConfig);
-    this.providerPromise.then(() => {
-      this.logger.debug(`${LOGGER_CONTEXT} provider initialized`);
-    });
+    this.provider = createProvider(providerConfig);
+    this.logger.debug(`${LOGGER_CONTEXT} provider initialized`);
   }
 
   /**
@@ -102,8 +100,7 @@ export class WalletConnectPay {
     );
 
     try {
-      const provider = await this.providerPromise;
-      const response = await provider.getPaymentOptions(params);
+      const response = await this.provider.getPaymentOptions(params);
 
       this.logger.debug(
         { paymentId: response.paymentId, optionsCount: response.options.length },
@@ -133,8 +130,7 @@ export class WalletConnectPay {
     );
 
     try {
-      const provider = await this.providerPromise;
-      const actions = await provider.getRequiredPaymentActions(params);
+      const actions = await this.provider.getRequiredPaymentActions(params);
 
       this.logger.debug(
         { actionsCount: actions.length },
@@ -171,8 +167,7 @@ export class WalletConnectPay {
     );
 
     try {
-      const provider = await this.providerPromise;
-      const response = await provider.confirmPayment(params);
+      const response = await this.provider.confirmPayment(params);
 
       this.logger.debug(
         { status: response.status, isFinal: response.isFinal },

--- a/packages/pay/src/providers/index.ts
+++ b/packages/pay/src/providers/index.ts
@@ -1,25 +1,36 @@
 /**
  * Provider exports for WalletConnect Pay SDK
+ *
+ * WASM provider is loaded dynamically to avoid pulling in TextDecoder-dependent
+ * code in React Native debug builds where TextDecoder is unavailable.
  */
 
+import { isReactNative } from "@walletconnect/utils";
 import type { PayProvider, PayProviderConfig, PayProviderType } from "../types/index.js";
 import { createNativeProvider, isNativeProviderAvailable } from "./native.js";
-import { createWasmProvider, isWasmProviderAvailable } from "./wasm.js";
 
 export * from "./native.js";
-export * from "./wasm.js";
+
+function isWasmProviderAvailable(): boolean {
+  return !isReactNative() && typeof WebAssembly !== "undefined";
+}
+
+export { isWasmProviderAvailable };
+
+async function loadWasmProvider(config: PayProviderConfig): Promise<PayProvider> {
+  const { createWasmProvider } = await import("./wasm.js");
+  return createWasmProvider(config);
+}
 
 /**
  * Detect the best available provider type for the current environment
  * Priority: Native (React Native) > WASM (Browser/Node.js)
  */
 export function detectProviderType(): PayProviderType | null {
-  // Check for native module (React Native) - preferred for mobile
   if (isNativeProviderAvailable()) {
     return "native";
   }
 
-  // Check for WASM support (Browser/Node.js)
   if (isWasmProviderAvailable()) {
     return "wasm";
   }
@@ -28,26 +39,33 @@ export function detectProviderType(): PayProviderType | null {
 }
 
 /**
- * Create a provider based on auto-detection
- * @param config - Provider configuration
+ * Create a provider based on auto-detection.
+ * Returns a Promise because the WASM provider is loaded dynamically.
  */
-export function createProvider(config: PayProviderConfig): PayProvider {
-  const providerType = detectProviderType();
+export function createProvider(config: PayProviderConfig): Promise<PayProvider> {
+  return new Promise((resolve, reject) => {
+    const providerType = detectProviderType();
 
-  if (!providerType) {
-    throw new Error(
-      "No Pay provider available. Make sure you are running in React Native with the native module installed, or in a browser/Node.js environment with WebAssembly support.",
-    );
-  }
+    if (!providerType) {
+      reject(
+        new Error(
+          "No Pay provider available. Make sure you are running in React Native with the native module installed, or in a browser/Node.js environment with WebAssembly support.",
+        ),
+      );
+      return;
+    }
 
-  switch (providerType) {
-    case "native":
-      return createNativeProvider(config);
-    case "wasm":
-      return createWasmProvider(config);
-    default:
-      throw new Error(`Unknown provider type: ${providerType}`);
-  }
+    switch (providerType) {
+      case "native":
+        resolve(createNativeProvider(config));
+        break;
+      case "wasm":
+        resolve(loadWasmProvider(config));
+        break;
+      default:
+        reject(new Error(`Unknown provider type: ${providerType}`));
+    }
+  });
 }
 
 /**

--- a/packages/pay/src/providers/index.ts
+++ b/packages/pay/src/providers/index.ts
@@ -1,26 +1,14 @@
 /**
  * Provider exports for WalletConnect Pay SDK
- *
- * WASM provider is loaded dynamically to avoid pulling in TextDecoder-dependent
- * code in React Native debug builds where TextDecoder is unavailable.
  */
 
 import { isReactNative } from "@walletconnect/utils";
 import type { PayProvider, PayProviderConfig, PayProviderType } from "../types/index.js";
 import { createNativeProvider, isNativeProviderAvailable } from "./native.js";
+import { createWasmProvider, isWasmProviderAvailable } from "./wasm.js";
 
 export * from "./native.js";
-
-function isWasmProviderAvailable(): boolean {
-  return !isReactNative() && typeof WebAssembly !== "undefined";
-}
-
-export { isWasmProviderAvailable };
-
-async function loadWasmProvider(config: PayProviderConfig): Promise<PayProvider> {
-  const { createWasmProvider } = await import("./wasm.js");
-  return createWasmProvider(config);
-}
+export * from "./wasm.js";
 
 /**
  * Detect the best available provider type for the current environment
@@ -31,7 +19,7 @@ export function detectProviderType(): PayProviderType | null {
     return "native";
   }
 
-  if (isWasmProviderAvailable()) {
+  if (!isReactNative() && isWasmProviderAvailable()) {
     return "wasm";
   }
 
@@ -39,33 +27,26 @@ export function detectProviderType(): PayProviderType | null {
 }
 
 /**
- * Create a provider based on auto-detection.
- * Returns a Promise because the WASM provider is loaded dynamically.
+ * Create a provider based on auto-detection
+ * @param config - Provider configuration
  */
-export function createProvider(config: PayProviderConfig): Promise<PayProvider> {
-  return new Promise((resolve, reject) => {
-    const providerType = detectProviderType();
+export function createProvider(config: PayProviderConfig): PayProvider {
+  const providerType = detectProviderType();
 
-    if (!providerType) {
-      reject(
-        new Error(
-          "No Pay provider available. Make sure you are running in React Native with the native module installed, or in a browser/Node.js environment with WebAssembly support.",
-        ),
-      );
-      return;
-    }
+  if (!providerType) {
+    throw new Error(
+      "No Pay provider available. Make sure you are running in React Native with the native module installed, or in a browser/Node.js environment with WebAssembly support.",
+    );
+  }
 
-    switch (providerType) {
-      case "native":
-        resolve(createNativeProvider(config));
-        break;
-      case "wasm":
-        resolve(loadWasmProvider(config));
-        break;
-      default:
-        reject(new Error(`Unknown provider type: ${providerType}`));
-    }
-  });
+  switch (providerType) {
+    case "native":
+      return createNativeProvider(config);
+    case "wasm":
+      return createWasmProvider(config);
+    default:
+      throw new Error(`Unknown provider type: ${providerType}`);
+  }
 }
 
 /**

--- a/packages/pay/src/providers/wasm/yttrium.js
+++ b/packages/pay/src/providers/wasm/yttrium.js
@@ -8,17 +8,17 @@ function getObject(idx) {
   return heap[idx];
 }
 
-const cachedTextDecoder =
-  typeof TextDecoder !== "undefined"
-    ? new TextDecoder("utf-8", { ignoreBOM: true, fatal: true })
-    : {
-        decode: () => {
-          throw Error("TextDecoder not available");
-        },
-      };
+let cachedTextDecoder = null;
 
-if (typeof TextDecoder !== "undefined") {
-  cachedTextDecoder.decode();
+function getTextDecoder() {
+  if (!cachedTextDecoder) {
+    if (typeof TextDecoder === "undefined") {
+      throw Error("TextDecoder not available");
+    }
+    cachedTextDecoder = new TextDecoder("utf-8", { ignoreBOM: true, fatal: true });
+    cachedTextDecoder.decode();
+  }
+  return cachedTextDecoder;
 }
 
 let cachedUint8ArrayMemory0 = null;
@@ -32,7 +32,7 @@ function getUint8ArrayMemory0() {
 
 function getStringFromWasm0(ptr, len) {
   ptr = ptr >>> 0;
-  return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+  return getTextDecoder().decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
 }
 
 let heap_next = heap.length;
@@ -77,32 +77,34 @@ function getArrayU8FromWasm0(ptr, len) {
 
 let WASM_VECTOR_LEN = 0;
 
-const cachedTextEncoder =
-  typeof TextEncoder !== "undefined"
-    ? new TextEncoder("utf-8")
-    : {
-        encode: () => {
-          throw Error("TextEncoder not available");
-        },
-      };
+let cachedTextEncoder = null;
 
-const encodeString =
-  typeof cachedTextEncoder.encodeInto === "function"
-    ? function (arg, view) {
-        return cachedTextEncoder.encodeInto(arg, view);
-      }
-    : function (arg, view) {
-        const buf = cachedTextEncoder.encode(arg);
-        view.set(buf);
-        return {
-          read: arg.length,
-          written: buf.length,
-        };
-      };
+function getTextEncoder() {
+  if (!cachedTextEncoder) {
+    if (typeof TextEncoder === "undefined") {
+      throw Error("TextEncoder not available");
+    }
+    cachedTextEncoder = new TextEncoder("utf-8");
+  }
+  return cachedTextEncoder;
+}
+
+function encodeString(arg, view) {
+  const encoder = getTextEncoder();
+  if (typeof encoder.encodeInto === "function") {
+    return encoder.encodeInto(arg, view);
+  }
+  const buf = encoder.encode(arg);
+  view.set(buf);
+  return {
+    read: arg.length,
+    written: buf.length,
+  };
+}
 
 function passStringToWasm0(arg, malloc, realloc) {
   if (realloc === undefined) {
-    const buf = cachedTextEncoder.encode(arg);
+    const buf = getTextEncoder().encode(arg);
     const ptr = malloc(buf.length, 1) >>> 0;
     getUint8ArrayMemory0()
       .subarray(ptr, ptr + buf.length)

--- a/packages/pay/test/patch-yttrium.spec.ts
+++ b/packages/pay/test/patch-yttrium.spec.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect } from "vitest";
+import { patchYttriumSource } from "../../../scripts/patch_yttrium_lazy_init.js";
+
+const ORIGINAL_TEXT_DECODER = `const cachedTextDecoder =
+  typeof TextDecoder !== "undefined"
+    ? new TextDecoder("utf-8", { ignoreBOM: true, fatal: true })
+    : {
+        decode: () => {
+          throw Error("TextDecoder not available");
+        },
+      };
+
+if (typeof TextDecoder !== "undefined") {
+  cachedTextDecoder.decode();
+}`;
+
+const ORIGINAL_TEXT_ENCODER = `const cachedTextEncoder =
+  typeof TextEncoder !== "undefined"
+    ? new TextEncoder("utf-8")
+    : {
+        encode: () => {
+          throw Error("TextEncoder not available");
+        },
+      };
+
+const encodeString =
+  typeof cachedTextEncoder.encodeInto === "function"
+    ? function (arg, view) {
+        return cachedTextEncoder.encodeInto(arg, view);
+      }
+    : function (arg, view) {
+        const buf = cachedTextEncoder.encode(arg);
+        view.set(buf);
+        return {
+          read: arg.length,
+          written: buf.length,
+        };
+      };`;
+
+const DECODER_USAGE = `function getStringFromWasm0(ptr, len) {
+  ptr = ptr >>> 0;
+  return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+}`;
+
+const ENCODER_USAGE = `function passStringToWasm0(arg, malloc, realloc) {
+  if (realloc === undefined) {
+    const buf = cachedTextEncoder.encode(arg);
+    const ptr = malloc(buf.length, 1) >>> 0;
+    getUint8ArrayMemory0()
+      .subarray(ptr, ptr + buf.length)
+      .set(buf);
+    WASM_VECTOR_LEN = buf.length;
+    return ptr;
+  }
+}`;
+
+const UNRELATED_CODE = `let wasm;
+
+const heap = new Array(128).fill(undefined);
+
+heap.push(undefined, null, true, false);
+
+function getObject(idx) {
+  return heap[idx];
+}`;
+
+function buildFullInput(): string {
+  return [
+    UNRELATED_CODE,
+    ORIGINAL_TEXT_DECODER,
+    DECODER_USAGE,
+    ORIGINAL_TEXT_ENCODER,
+    ENCODER_USAGE,
+  ].join("\n\n");
+}
+
+describe("patch_yttrium_lazy_init", () => {
+  describe("TextDecoder patching", () => {
+    it("should replace eager TextDecoder init with lazy getter", () => {
+      // #given
+      const input = buildFullInput();
+
+      // #when
+      const { code } = patchYttriumSource(input);
+
+      // #then
+      expect(code).toContain("let cachedTextDecoder = null;");
+      expect(code).toContain("function getTextDecoder()");
+      expect(code).not.toContain("const cachedTextDecoder =");
+    });
+
+    it("should replace cachedTextDecoder usage with getTextDecoder()", () => {
+      // #given
+      const input = buildFullInput();
+
+      // #when
+      const { code } = patchYttriumSource(input);
+
+      // #then
+      expect(code).toContain("return getTextDecoder().decode(getUint8ArrayMemory0()");
+    });
+
+    it("should preserve the warmup call inside getTextDecoder as cachedTextDecoder.decode()", () => {
+      // #given
+      const input = buildFullInput();
+
+      // #when
+      const { code } = patchYttriumSource(input);
+
+      // #then
+      const getterMatch = code.match(
+        /function getTextDecoder\(\) \{[\s\S]*?return cachedTextDecoder;\s*\}/,
+      );
+      expect(getterMatch).not.toBeNull();
+      expect(getterMatch![0]).toContain("cachedTextDecoder.decode();");
+      expect(getterMatch![0]).not.toContain("getTextDecoder().decode()");
+    });
+
+    it("should report textDecoder as patched", () => {
+      // #given
+      const input = buildFullInput();
+
+      // #when
+      const { results } = patchYttriumSource(input);
+
+      // #then
+      expect(results.textDecoder).toBe(true);
+    });
+  });
+
+  describe("TextEncoder patching", () => {
+    it("should replace eager TextEncoder init with lazy getter", () => {
+      // #given
+      const input = buildFullInput();
+
+      // #when
+      const { code } = patchYttriumSource(input);
+
+      // #then
+      expect(code).toContain("let cachedTextEncoder = null;");
+      expect(code).toContain("function getTextEncoder()");
+      expect(code).not.toContain("const cachedTextEncoder =");
+    });
+
+    it("should replace encodeString const with a function", () => {
+      // #given
+      const input = buildFullInput();
+
+      // #when
+      const { code } = patchYttriumSource(input);
+
+      // #then
+      expect(code).toContain("function encodeString(arg, view)");
+      expect(code).not.toContain("const encodeString =");
+    });
+
+    it("should replace cachedTextEncoder.encode usage with getTextEncoder().encode", () => {
+      // #given
+      const input = buildFullInput();
+
+      // #when
+      const { code } = patchYttriumSource(input);
+
+      // #then
+      expect(code).toContain("const buf = getTextEncoder().encode(arg);");
+      expect(code).not.toContain("cachedTextEncoder.encode(arg)");
+    });
+
+    it("should report textEncoder as patched", () => {
+      // #given
+      const input = buildFullInput();
+
+      // #when
+      const { results } = patchYttriumSource(input);
+
+      // #then
+      expect(results.textEncoder).toBe(true);
+    });
+  });
+
+  describe("unrelated code preservation", () => {
+    it("should not modify code outside the TextDecoder/TextEncoder patterns", () => {
+      // #given
+      const input = buildFullInput();
+
+      // #when
+      const { code } = patchYttriumSource(input);
+
+      // #then
+      expect(code).toContain(UNRELATED_CODE);
+    });
+
+    it("should preserve getStringFromWasm0 function structure", () => {
+      // #given
+      const input = buildFullInput();
+
+      // #when
+      const { code } = patchYttriumSource(input);
+
+      // #then
+      expect(code).toContain("function getStringFromWasm0(ptr, len)");
+      expect(code).toContain("ptr = ptr >>> 0;");
+    });
+
+    it("should preserve passStringToWasm0 function structure", () => {
+      // #given
+      const input = buildFullInput();
+
+      // #when
+      const { code } = patchYttriumSource(input);
+
+      // #then
+      expect(code).toContain("function passStringToWasm0(arg, malloc, realloc)");
+      expect(code).toContain("const ptr = malloc(buf.length, 1) >>> 0;");
+    });
+  });
+
+  describe("idempotency", () => {
+    it("should not modify an already-patched file", () => {
+      // #given
+      const input = buildFullInput();
+      const { code: firstPass } = patchYttriumSource(input);
+
+      // #when
+      const { code: secondPass, changed } = patchYttriumSource(firstPass);
+
+      // #then
+      expect(changed).toBe(false);
+      expect(secondPass).toBe(firstPass);
+    });
+
+    it("should report no patterns found on already-patched code", () => {
+      // #given
+      const input = buildFullInput();
+      const { code: patched } = patchYttriumSource(input);
+
+      // #when
+      const { results } = patchYttriumSource(patched);
+
+      // #then
+      expect(results.textDecoder).toBe(false);
+      expect(results.textEncoder).toBe(false);
+    });
+  });
+
+  describe("partial patching", () => {
+    it("should patch only TextDecoder when TextEncoder is absent", () => {
+      // #given
+      const input = [UNRELATED_CODE, ORIGINAL_TEXT_DECODER, DECODER_USAGE].join("\n\n");
+
+      // #when
+      const { code, changed, results } = patchYttriumSource(input);
+
+      // #then
+      expect(changed).toBe(true);
+      expect(results.textDecoder).toBe(true);
+      expect(results.textEncoder).toBe(false);
+      expect(code).toContain("function getTextDecoder()");
+    });
+
+    it("should patch only TextEncoder when TextDecoder is absent", () => {
+      // #given
+      const input = [UNRELATED_CODE, ORIGINAL_TEXT_ENCODER, ENCODER_USAGE].join("\n\n");
+
+      // #when
+      const { code, changed, results } = patchYttriumSource(input);
+
+      // #then
+      expect(changed).toBe(true);
+      expect(results.textDecoder).toBe(false);
+      expect(results.textEncoder).toBe(true);
+      expect(code).toContain("function getTextEncoder()");
+    });
+  });
+
+  describe("no matching patterns", () => {
+    it("should return unchanged code when no patterns match", () => {
+      // #given
+      const input = UNRELATED_CODE;
+
+      // #when
+      const { code, changed, results } = patchYttriumSource(input);
+
+      // #then
+      expect(changed).toBe(false);
+      expect(code).toBe(input);
+      expect(results.textDecoder).toBe(false);
+      expect(results.textEncoder).toBe(false);
+    });
+  });
+
+  describe("patched output validity", () => {
+    it("should produce syntactically valid JavaScript", () => {
+      // #given
+      const input = buildFullInput();
+
+      // #when
+      const { code } = patchYttriumSource(input);
+
+      // #then — parsing as a function body to avoid strict-mode issues with let re-declarations
+      expect(() => new Function(code)).not.toThrow();
+    });
+
+    it("should have no remaining direct cachedTextDecoder references outside the getter", () => {
+      // #given
+      const input = buildFullInput();
+
+      // #when
+      const { code } = patchYttriumSource(input);
+
+      // #then
+      const matches = code.match(/cachedTextDecoder\.decode\(/g) || [];
+      expect(matches).toHaveLength(1);
+
+      const getterBlock = code.match(
+        /function getTextDecoder\(\) \{[\s\S]*?return cachedTextDecoder;\s*\}/,
+      );
+      expect(getterBlock).not.toBeNull();
+      expect(getterBlock![0]).toContain("cachedTextDecoder.decode(");
+    });
+
+    it("should have no remaining direct cachedTextEncoder.encode references", () => {
+      // #given
+      const input = buildFullInput();
+
+      // #when
+      const { code } = patchYttriumSource(input);
+
+      // #then
+      expect(code).not.toMatch(/cachedTextEncoder\.encode\(/);
+    });
+  });
+});

--- a/packages/pay/test/provider-detection.spec.ts
+++ b/packages/pay/test/provider-detection.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { isReactNative } from "@walletconnect/utils";
+import { detectProviderType, createProvider, isProviderAvailable } from "../src/providers/index.js";
+import type { PayProviderConfig } from "../src/types/index.js";
+
+vi.mock("@walletconnect/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@walletconnect/utils")>();
+  return {
+    ...actual,
+    isReactNative: vi.fn(() => false),
+  };
+});
+
+const mockedIsReactNative = vi.mocked(isReactNative);
+
+const TEST_CONFIG: PayProviderConfig = {
+  baseUrl: "https://pay.walletconnect.com",
+  projectId: "test-project-id",
+  sdkName: "@walletconnect/pay",
+  sdkVersion: "1.0.0",
+  sdkPlatform: "test",
+  bundleId: "com.test.app",
+};
+
+describe("Provider detection", () => {
+  beforeEach(() => {
+    mockedIsReactNative.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("when in React Native environment", () => {
+    beforeEach(() => {
+      mockedIsReactNative.mockReturnValue(true);
+    });
+
+    it("should not detect wasm as provider type", () => {
+      // #given - React Native environment, no native module
+
+      // #when
+      const providerType = detectProviderType();
+
+      // #then
+      expect(providerType).not.toBe("wasm");
+    });
+
+    it("should report no provider available when native module is absent", () => {
+      // #given - React Native environment, no native module
+
+      // #when
+      const available = isProviderAvailable();
+
+      // #then
+      expect(available).toBe(false);
+    });
+
+    it("should throw when creating provider without native module", () => {
+      // #given - React Native environment, no native module
+
+      // #when / #then
+      expect(() => createProvider(TEST_CONFIG)).toThrow("No Pay provider available");
+    });
+  });
+
+  describe("when in browser/Node.js environment", () => {
+    beforeEach(() => {
+      mockedIsReactNative.mockReturnValue(false);
+    });
+
+    it("should detect wasm as provider type", () => {
+      // #given - non-RN environment with WebAssembly
+
+      // #when
+      const providerType = detectProviderType();
+
+      // #then
+      expect(providerType).toBe("wasm");
+    });
+
+    it("should report provider available", () => {
+      // #given - non-RN environment
+
+      // #when
+      const available = isProviderAvailable();
+
+      // #then
+      expect(available).toBe(true);
+    });
+
+    it("should create wasm provider successfully", () => {
+      // #given - non-RN environment
+
+      // #when
+      const provider = createProvider(TEST_CONFIG);
+
+      // #then
+      expect(provider).toBeDefined();
+      expect(typeof provider.getPaymentOptions).toBe("function");
+    });
+  });
+});

--- a/scripts/patch_yttrium_lazy_init.js
+++ b/scripts/patch_yttrium_lazy_init.js
@@ -17,24 +17,12 @@
 const fs = require("fs");
 const path = require("path");
 
-const filePath =
-  process.argv[2] ||
-  path.join(__dirname, "../packages/pay/src/providers/wasm/yttrium.js");
+// --- Patterns ---
 
-if (!fs.existsSync(filePath)) {
-  console.error(`File not found: ${filePath}`);
-  process.exit(1);
-}
-
-let code = fs.readFileSync(filePath, "utf-8");
-const original = code;
-
-// --- TextDecoder: eager init → lazy getter ---
-
-const textDecoderEager =
+const TEXT_DECODER_EAGER =
   /const cachedTextDecoder =\s*typeof TextDecoder !== "undefined"\s*\? new TextDecoder\("utf-8", \{ ignoreBOM: true, fatal: true \}\)\s*: \{\s*decode: \(\) => \{\s*throw Error\("TextDecoder not available"\);\s*\},?\s*\};\s*if \(typeof TextDecoder !== "undefined"\) \{\s*cachedTextDecoder\.decode\(\);\s*\}/;
 
-const textDecoderLazy = `let cachedTextDecoder = null;
+const TEXT_DECODER_LAZY = `let cachedTextDecoder = null;
 
 function getTextDecoder() {
   if (!cachedTextDecoder) {
@@ -47,24 +35,10 @@ function getTextDecoder() {
   return cachedTextDecoder;
 }`;
 
-if (!textDecoderEager.test(code)) {
-  console.error("WARNING: Could not find TextDecoder eager init pattern — skipping.");
-} else {
-  code = code.replace(textDecoderEager, textDecoderLazy);
-  // Replace usage sites but protect the warmup call inside getTextDecoder()
-  // by temporarily swapping it with a placeholder
-  code = code.replace("cachedTextDecoder.decode();\n  }\n  return cachedTextDecoder;", "__WARMUP_PLACEHOLDER__");
-  code = code.replace(/cachedTextDecoder\.decode\(/g, "getTextDecoder().decode(");
-  code = code.replace("__WARMUP_PLACEHOLDER__", "cachedTextDecoder.decode();\n  }\n  return cachedTextDecoder;");
-  console.log("Patched TextDecoder to lazy initialization.");
-}
-
-// --- TextEncoder: eager init + encodeString → lazy getter + function ---
-
-const textEncoderEager =
+const TEXT_ENCODER_EAGER =
   /const cachedTextEncoder =\s*typeof TextEncoder !== "undefined"\s*\? new TextEncoder\("utf-8"\)\s*: \{\s*encode: \(\) => \{\s*throw Error\("TextEncoder not available"\);\s*\},?\s*\};\s*const encodeString =\s*typeof cachedTextEncoder\.encodeInto === "function"\s*\? function \(arg, view\) \{\s*return cachedTextEncoder\.encodeInto\(arg, view\);\s*\}\s*: function \(arg, view\) \{\s*const buf = cachedTextEncoder\.encode\(arg\);\s*view\.set\(buf\);\s*return \{\s*read: arg\.length,\s*written: buf\.length,?\s*\};\s*\};/;
 
-const textEncoderLazy = `let cachedTextEncoder = null;
+const TEXT_ENCODER_LAZY = `let cachedTextEncoder = null;
 
 function getTextEncoder() {
   if (!cachedTextEncoder) {
@@ -89,17 +63,71 @@ function encodeString(arg, view) {
   };
 }`;
 
-if (!textEncoderEager.test(code)) {
-  console.error("WARNING: Could not find TextEncoder eager init pattern — skipping.");
-} else {
-  code = code.replace(textEncoderEager, textEncoderLazy);
-  code = code.replace(/cachedTextEncoder\.encode\(/g, "getTextEncoder().encode(");
-  console.log("Patched TextEncoder to lazy initialization.");
+const WARMUP_PLACEHOLDER = "__WARMUP_PLACEHOLDER__";
+const WARMUP_ORIGINAL = "cachedTextDecoder.decode();\n  }\n  return cachedTextDecoder;";
+
+// --- Core transform ---
+
+function patchYttriumSource(code) {
+  let patched = code;
+  const results = { textDecoder: false, textEncoder: false };
+
+  if (TEXT_DECODER_EAGER.test(patched)) {
+    patched = patched.replace(TEXT_DECODER_EAGER, TEXT_DECODER_LAZY);
+    patched = patched.replace(WARMUP_ORIGINAL, WARMUP_PLACEHOLDER);
+    patched = patched.replace(/cachedTextDecoder\.decode\(/g, "getTextDecoder().decode(");
+    patched = patched.replace(WARMUP_PLACEHOLDER, WARMUP_ORIGINAL);
+    results.textDecoder = true;
+  }
+
+  if (TEXT_ENCODER_EAGER.test(patched)) {
+    patched = patched.replace(TEXT_ENCODER_EAGER, TEXT_ENCODER_LAZY);
+    patched = patched.replace(/cachedTextEncoder\.encode\(/g, "getTextEncoder().encode(");
+    results.textEncoder = true;
+  }
+
+  return { code: patched, changed: patched !== code, results };
 }
 
-if (code === original) {
-  console.log("No changes needed — file already patched or patterns not found.");
-} else {
-  fs.writeFileSync(filePath, code, "utf-8");
-  console.log(`Wrote patched file: ${filePath}`);
+// --- Exports for testing ---
+
+module.exports = {
+  patchYttriumSource,
+  TEXT_DECODER_EAGER,
+  TEXT_ENCODER_EAGER,
+};
+
+// --- CLI entry point ---
+
+if (require.main === module) {
+  const filePath =
+    process.argv[2] ||
+    path.join(__dirname, "../packages/pay/src/providers/wasm/yttrium.js");
+
+  if (!fs.existsSync(filePath)) {
+    console.error(`File not found: ${filePath}`);
+    process.exit(1);
+  }
+
+  const code = fs.readFileSync(filePath, "utf-8");
+  const { code: patched, changed, results } = patchYttriumSource(code);
+
+  if (!results.textDecoder) {
+    console.error("WARNING: Could not find TextDecoder eager init pattern — skipping.");
+  } else {
+    console.log("Patched TextDecoder to lazy initialization.");
+  }
+
+  if (!results.textEncoder) {
+    console.error("WARNING: Could not find TextEncoder eager init pattern — skipping.");
+  } else {
+    console.log("Patched TextEncoder to lazy initialization.");
+  }
+
+  if (!changed) {
+    console.log("No changes needed — file already patched or patterns not found.");
+  } else {
+    fs.writeFileSync(filePath, patched, "utf-8");
+    console.log(`Wrote patched file: ${filePath}`);
+  }
 }

--- a/scripts/patch_yttrium_lazy_init.js
+++ b/scripts/patch_yttrium_lazy_init.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+/**
+ * Patches yttrium.js to use lazy TextDecoder/TextEncoder initialization.
+ *
+ * The wasm-bindgen generated code creates TextDecoder/TextEncoder at module scope,
+ * which crashes in React Native debug builds where these globals aren't available
+ * at parse time (the fast-text-encoding polyfill from react-native-compat loads later).
+ *
+ * This script converts the eager initialization to lazy getters so the instances
+ * are created on first use, by which point the polyfills are available.
+ *
+ * Usage: node scripts/patch_yttrium_lazy_init.js [path-to-yttrium.js]
+ *   Default path: packages/pay/src/providers/wasm/yttrium.js
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const filePath =
+  process.argv[2] ||
+  path.join(__dirname, "../packages/pay/src/providers/wasm/yttrium.js");
+
+if (!fs.existsSync(filePath)) {
+  console.error(`File not found: ${filePath}`);
+  process.exit(1);
+}
+
+let code = fs.readFileSync(filePath, "utf-8");
+const original = code;
+
+// --- TextDecoder: eager init → lazy getter ---
+
+const textDecoderEager =
+  /const cachedTextDecoder =\s*typeof TextDecoder !== "undefined"\s*\? new TextDecoder\("utf-8", \{ ignoreBOM: true, fatal: true \}\)\s*: \{\s*decode: \(\) => \{\s*throw Error\("TextDecoder not available"\);\s*\},?\s*\};\s*if \(typeof TextDecoder !== "undefined"\) \{\s*cachedTextDecoder\.decode\(\);\s*\}/;
+
+const textDecoderLazy = `let cachedTextDecoder = null;
+
+function getTextDecoder() {
+  if (!cachedTextDecoder) {
+    if (typeof TextDecoder === "undefined") {
+      throw Error("TextDecoder not available");
+    }
+    cachedTextDecoder = new TextDecoder("utf-8", { ignoreBOM: true, fatal: true });
+    cachedTextDecoder.decode();
+  }
+  return cachedTextDecoder;
+}`;
+
+if (!textDecoderEager.test(code)) {
+  console.error("WARNING: Could not find TextDecoder eager init pattern — skipping.");
+} else {
+  code = code.replace(textDecoderEager, textDecoderLazy);
+  // Replace usage sites but protect the warmup call inside getTextDecoder()
+  // by temporarily swapping it with a placeholder
+  code = code.replace("cachedTextDecoder.decode();\n  }\n  return cachedTextDecoder;", "__WARMUP_PLACEHOLDER__");
+  code = code.replace(/cachedTextDecoder\.decode\(/g, "getTextDecoder().decode(");
+  code = code.replace("__WARMUP_PLACEHOLDER__", "cachedTextDecoder.decode();\n  }\n  return cachedTextDecoder;");
+  console.log("Patched TextDecoder to lazy initialization.");
+}
+
+// --- TextEncoder: eager init + encodeString → lazy getter + function ---
+
+const textEncoderEager =
+  /const cachedTextEncoder =\s*typeof TextEncoder !== "undefined"\s*\? new TextEncoder\("utf-8"\)\s*: \{\s*encode: \(\) => \{\s*throw Error\("TextEncoder not available"\);\s*\},?\s*\};\s*const encodeString =\s*typeof cachedTextEncoder\.encodeInto === "function"\s*\? function \(arg, view\) \{\s*return cachedTextEncoder\.encodeInto\(arg, view\);\s*\}\s*: function \(arg, view\) \{\s*const buf = cachedTextEncoder\.encode\(arg\);\s*view\.set\(buf\);\s*return \{\s*read: arg\.length,\s*written: buf\.length,?\s*\};\s*\};/;
+
+const textEncoderLazy = `let cachedTextEncoder = null;
+
+function getTextEncoder() {
+  if (!cachedTextEncoder) {
+    if (typeof TextEncoder === "undefined") {
+      throw Error("TextEncoder not available");
+    }
+    cachedTextEncoder = new TextEncoder("utf-8");
+  }
+  return cachedTextEncoder;
+}
+
+function encodeString(arg, view) {
+  const encoder = getTextEncoder();
+  if (typeof encoder.encodeInto === "function") {
+    return encoder.encodeInto(arg, view);
+  }
+  const buf = encoder.encode(arg);
+  view.set(buf);
+  return {
+    read: arg.length,
+    written: buf.length,
+  };
+}`;
+
+if (!textEncoderEager.test(code)) {
+  console.error("WARNING: Could not find TextEncoder eager init pattern — skipping.");
+} else {
+  code = code.replace(textEncoderEager, textEncoderLazy);
+  code = code.replace(/cachedTextEncoder\.encode\(/g, "getTextEncoder().encode(");
+  console.log("Patched TextEncoder to lazy initialization.");
+}
+
+if (code === original) {
+  console.log("No changes needed — file already patched or patterns not found.");
+} else {
+  fs.writeFileSync(filePath, code, "utf-8");
+  console.log(`Wrote patched file: ${filePath}`);
+}


### PR DESCRIPTION
## Summary

- Patched `yttrium.js` (wasm-bindgen generated) to use lazy `TextDecoder`/`TextEncoder` initialization instead of eager module-scope instantiation, which crashes in React Native debug builds where these globals aren't available until the `fast-text-encoding` polyfill loads
- Added `isReactNative()` guard in `detectProviderType()` to prevent WASM provider selection on React Native (native provider is always preferred)
- Created `scripts/patch_yttrium_lazy_init.js` to automatically apply this patch on future yttrium WASM updates, with a new step in the `update_pay_wasm.yml` CI workflow

```mermaid
flowchart TD
    A[yttrium.js loaded] --> B{TextDecoder/TextEncoder<br/>available?}
    B -->|No - RN debug build| C[Module loads safely<br/>lazy getters defer creation]
    B -->|Yes - Browser/Node| C
    C --> D[First WASM call]
    D --> E[getTextDecoder/getTextEncoder<br/>creates instance on demand]
    E --> F[Polyfills ready by now<br/>works in all environments]
```

## Changes

| File | Change |
|---|---|
| `packages/pay/src/providers/wasm/yttrium.js` | Lazy `TextDecoder`/`TextEncoder` init via getter functions |
| `packages/pay/src/providers/index.ts` | `isReactNative()` guard in provider detection |
| `scripts/patch_yttrium_lazy_init.js` | Automated patch script (exports `patchYttriumSource` for testing) |
| `.github/workflows/update_pay_wasm.yml` | Runs patch script after yttrium WASM updates |
| `packages/pay/test/provider-detection.spec.ts` | Tests: WASM skipped on RN, selected on browser/Node |
| `packages/pay/test/patch-yttrium.spec.ts` | Tests: patch correctness, idempotency, partial patching, output validity |

## Test plan

- [x] `npm run build` passes (UMD, CJS, ESM)
- [x] All 77 tests pass (`npm run test --prefix=packages/pay`)
- [x] Patch script produces byte-identical output to committed file when run on original
- [x] Patch script is idempotent (no-op on already-patched file)
- [ ] Verify React Native debug build no longer crashes on `TextDecoder`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Pay provider selection and the generated WASM glue code path; mistakes could cause initialization failures or wrong provider selection across environments, though changes are scoped and test-covered.
> 
> **Overview**
> Fixes React Native debug build crashes when loading the Pay WASM bundle by switching `packages/pay/src/providers/wasm/yttrium.js` from module-scope `TextDecoder`/`TextEncoder` creation to **lazy getter-based initialization**.
> 
> Updates provider auto-detection to **never select the WASM provider on React Native** (`detectProviderType` now checks `isReactNative()`), adds a CI step in `update_pay_wasm.yml` to automatically re-apply the yttrium patch after upstream WASM updates, and introduces a reusable `scripts/patch_yttrium_lazy_init.js` plus Vitest coverage for both the patching behavior and provider selection. A patch changeset is included for `@walletconnect/pay`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9567ffd39b3806f2e04bce1c35b5d634f09d2cf7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->