### PR TITLE
feat(sign-client): update default session request expiry to 15 minutes

### DIFF
--- a/.changeset/rotten-pans-shout.md
+++ b/.changeset/rotten-pans-shout.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/sign-client": patch
+---
+
+Updated the default session request expiry to 15 minutes

--- a/packages/sign-client/src/constants/engine.ts
+++ b/packages/sign-client/src/constants/engine.ts
@@ -64,12 +64,12 @@ export const ENGINE_RPC_OPTS: EngineTypes.RpcOptsMap = {
   },
   wc_sessionRequest: {
     req: {
-      ttl: FIVE_MINUTES,
+      ttl: FIVE_MINUTES * 3,
       prompt: true,
       tag: 1108,
     },
     res: {
-      ttl: FIVE_MINUTES,
+      ttl: FIVE_MINUTES * 3,
       prompt: false,
       tag: 1109,
     },

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -46,6 +46,7 @@ import {
   RELAYER_EVENTS,
 } from "@walletconnect/core";
 import { EngineTypes, RelayerTypes } from "@walletconnect/types";
+import { FIVE_MINUTES } from "@walletconnect/time";
 
 describe.sequential("Sign Client Integration", () => {
   it("init", async () => {
@@ -3589,11 +3590,11 @@ describe.sequential("session request expiry", () => {
       sessionA: { topic },
     } = await initTwoPairedClients({}, {}, { logger: "error" });
     const defaultExpiry = ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl; // FIVE_MINUTES * 3 = 900s = 15min
-    expect(defaultExpiry).to.eq(900);
+    expect(defaultExpiry).to.eq(FIVE_MINUTES * 3);
 
     const responseMessage = "test response after 14 minutes";
 
-    vi.useFakeTimers({ shouldAdvanceTime: true, shouldClearNativeTimers: true });
+    vi.useFakeTimers();
 
     await Promise.all([
       new Promise<void>((resolve) => {
@@ -3623,21 +3624,22 @@ describe.sequential("session request expiry", () => {
   });
   it("should respect dApp expiryTimestamp even when wallet uses old 5-min config", async () => {
     vi.useRealTimers();
+
+    const {
+      clients,
+      sessionA: { topic },
+    } = await initTwoPairedClients({}, {}, { logger: "error" });
+
     // should respect dApp expiryTimestamp even when wallet uses old 5-min config
     // simulate a wallet still running the old 5-min default
     const originalReqTtl = ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl;
     const originalResTtl = ENGINE_RPC_OPTS.wc_sessionRequest.res.ttl;
-    ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl = 300; // old 5-min value
-    ENGINE_RPC_OPTS.wc_sessionRequest.res.ttl = 300;
+    ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl = FIVE_MINUTES; // old 5-min value
+    ENGINE_RPC_OPTS.wc_sessionRequest.res.ttl = FIVE_MINUTES;
     try {
-      const {
-        clients,
-        sessionA: { topic },
-      } = await initTwoPairedClients({}, {}, { logger: "error" });
+      vi.useFakeTimers();
 
-      vi.useFakeTimers({ shouldAdvanceTime: true, shouldClearNativeTimers: true });
-
-      const newExpiry = 900; // 15 minutes — the new default set by the dApp
+      const newExpiry = originalReqTtl; // 15 minutes — the new default set by the dApp
       const responseMessage = "response after old expiry window";
 
       await Promise.all([

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -47,7 +47,7 @@ import {
 } from "@walletconnect/core";
 import { EngineTypes, RelayerTypes } from "@walletconnect/types";
 
-describe("Sign Client Integration", () => {
+describe.sequential("Sign Client Integration", () => {
   it("init", async () => {
     const client = await SignClient.init({
       ...TEST_SIGN_CLIENT_OPTIONS,
@@ -3309,96 +3309,6 @@ describe("Sign Client Integration", () => {
       ]);
       await deleteClients(clients);
     });
-    it("should set default request expiry to 15 minutes", async () => {
-      const {
-        clients,
-        sessionA: { topic },
-      } = await initTwoPairedClients({}, {}, { logger: "error" });
-      const defaultExpiry = ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl; // FIVE_MINUTES * 3 = 900s = 15min
-      expect(defaultExpiry).to.eq(900);
-
-      const responseMessage = "test response after 14 minutes";
-
-      vi.useFakeTimers({ shouldAdvanceTime: true });
-
-      await Promise.all([
-        new Promise<void>((resolve) => {
-          (clients.B as SignClient).once("session_request", async (payload) => {
-            expect(payload.params.request.expiryTimestamp).to.be.approximately(
-              calcExpiry(defaultExpiry),
-              5,
-            );
-            // advance clock by 14 minutes — still within the 15-min default expiry
-            await vi.advanceTimersByTimeAsync(14 * 60 * 1000);
-            await clients.B.respond({
-              topic,
-              response: formatJsonRpcResult(payload.id, responseMessage),
-            });
-            resolve();
-          });
-        }),
-        new Promise<void>(async (resolve) => {
-          // no expiry param — should use the default 15min
-          const result = await clients.A.request({ ...TEST_REQUEST_PARAMS, topic });
-          expect(result).to.eq(responseMessage);
-          resolve();
-        }),
-      ]);
-      vi.useRealTimers();
-      await deleteClients(clients);
-    });
-    it("should respect dApp expiryTimestamp even when wallet uses old 5-min config", async () => {
-      // simulate a wallet still running the old 5-min default
-      const originalReqTtl = ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl;
-      const originalResTtl = ENGINE_RPC_OPTS.wc_sessionRequest.res.ttl;
-      ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl = 300; // old 5-min value
-      ENGINE_RPC_OPTS.wc_sessionRequest.res.ttl = 300;
-      try {
-        const {
-          clients,
-          sessionA: { topic },
-        } = await initTwoPairedClients({}, {}, { logger: "error" });
-
-        vi.useFakeTimers({ shouldAdvanceTime: true });
-
-        const newExpiry = 900; // 15 minutes — the new default set by the dApp
-        const responseMessage = "response after old expiry window";
-
-        await Promise.all([
-          new Promise<void>((resolve) => {
-            (clients.B as SignClient).once("session_request", async (payload) => {
-              // wallet receives expiryTimestamp set by dApp (~15 min), not the wallet's local 5-min config
-              expect(payload.params.request.expiryTimestamp).to.be.approximately(
-                calcExpiry(newExpiry),
-                5,
-              );
-              // advance past old 5-min window but within new 15-min window
-              await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
-              await clients.B.respond({
-                topic,
-                response: formatJsonRpcResult(payload.id, responseMessage),
-              });
-              resolve();
-            });
-          }),
-          new Promise<void>(async (resolve) => {
-            // dApp explicitly passes the new 15-min expiry
-            const result = await clients.A.request({
-              ...TEST_REQUEST_PARAMS,
-              topic,
-              expiry: newExpiry,
-            });
-            expect(result).to.eq(responseMessage);
-            resolve();
-          }),
-        ]);
-        vi.useRealTimers();
-        await deleteClients(clients);
-      } finally {
-        ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl = originalReqTtl;
-        ENGINE_RPC_OPTS.wc_sessionRequest.res.ttl = originalResTtl;
-      }
-    });
     it("should send request on optional namespace", async () => {
       const {
         clients,
@@ -3595,7 +3505,7 @@ describe("Sign Client Integration", () => {
   });
 });
 // don't use concurrency here as these tests change timeclock
-describe("extend", () => {
+describe.sequential("extend", () => {
   it("updates session expiry state initiated by client A", async () => {
     const {
       clients,
@@ -3669,5 +3579,98 @@ describe("extend", () => {
     vi.useRealTimers();
 
     await deleteClients(clients);
+  });
+});
+describe.sequential("session request expiry", () => {
+  it("should set default request expiry to 15 minutes and respect dApp expiryTimestamp", async () => {
+    const {
+      clients,
+      sessionA: { topic },
+    } = await initTwoPairedClients({}, {}, { logger: "error" });
+    const defaultExpiry = ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl; // FIVE_MINUTES * 3 = 900s = 15min
+    expect(defaultExpiry).to.eq(900);
+
+    const responseMessage = "test response after 14 minutes";
+
+    vi.useFakeTimers({ shouldAdvanceTime: true, shouldClearNativeTimers: true });
+
+    await Promise.all([
+      new Promise<void>((resolve) => {
+        (clients.B as SignClient).once("session_request", async (payload) => {
+          expect(payload.params.request.expiryTimestamp).to.be.approximately(
+            calcExpiry(defaultExpiry),
+            5,
+          );
+          // advance clock by 14 minutes — still within the 15-min default expiry
+          await vi.advanceTimersByTimeAsync(14 * 60 * 1000);
+          await clients.B.respond({
+            topic,
+            response: formatJsonRpcResult(payload.id, responseMessage),
+          });
+          resolve();
+        });
+      }),
+      new Promise<void>(async (resolve) => {
+        // no expiry param — should use the default 15min
+        const result = await clients.A.request({ ...TEST_REQUEST_PARAMS, topic });
+        expect(result).to.eq(responseMessage);
+        resolve();
+      }),
+    ]);
+    vi.useRealTimers();
+    await deleteClients(clients);
+  });
+  it("should respect dApp expiryTimestamp even when wallet uses old 5-min config", async () => {
+    // should respect dApp expiryTimestamp even when wallet uses old 5-min config
+    // simulate a wallet still running the old 5-min default
+    const originalReqTtl = ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl;
+    const originalResTtl = ENGINE_RPC_OPTS.wc_sessionRequest.res.ttl;
+    ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl = 300; // old 5-min value
+    ENGINE_RPC_OPTS.wc_sessionRequest.res.ttl = 300;
+    try {
+      const {
+        clients,
+        sessionA: { topic },
+      } = await initTwoPairedClients({}, {}, { logger: "error" });
+
+      vi.useFakeTimers({ shouldAdvanceTime: true, shouldClearNativeTimers: true });
+
+      const newExpiry = 900; // 15 minutes — the new default set by the dApp
+      const responseMessage = "response after old expiry window";
+
+      await Promise.all([
+        new Promise<void>((resolve) => {
+          (clients.B as SignClient).once("session_request", async (payload) => {
+            // wallet receives expiryTimestamp set by dApp (~15 min), not the wallet's local 5-min config
+            expect(payload.params.request.expiryTimestamp).to.be.approximately(
+              calcExpiry(newExpiry),
+              5,
+            );
+            // advance past old 5-min window but within new 15-min window
+            await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
+            await clients.B.respond({
+              topic,
+              response: formatJsonRpcResult(payload.id, responseMessage),
+            });
+            resolve();
+          });
+        }),
+        new Promise<void>(async (resolve) => {
+          // dApp explicitly passes the new 15-min expiry
+          const result = await clients.A.request({
+            ...TEST_REQUEST_PARAMS,
+            topic,
+            expiry: newExpiry,
+          });
+          expect(result).to.eq(responseMessage);
+          resolve();
+        }),
+      ]);
+      vi.useRealTimers();
+      await deleteClients(clients);
+    } finally {
+      ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl = originalReqTtl;
+      ENGINE_RPC_OPTS.wc_sessionRequest.res.ttl = originalResTtl;
+    }
   });
 });

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -3310,7 +3310,6 @@ describe("Sign Client Integration", () => {
       await deleteClients(clients);
     });
     it("should set default request expiry to 15 minutes", async () => {
-      vi.useFakeTimers({ shouldAdvanceTime: true });
       try {
         const {
           clients,
@@ -3320,6 +3319,8 @@ describe("Sign Client Integration", () => {
         expect(defaultExpiry).to.eq(900);
 
         const responseMessage = "test response after 14 minutes";
+
+        vi.useFakeTimers({ shouldAdvanceTime: true });
 
         await Promise.all([
           new Promise<void>((resolve) => {
@@ -3350,7 +3351,6 @@ describe("Sign Client Integration", () => {
       }
     });
     it("should respect dApp expiryTimestamp even when wallet uses old 5-min config", async () => {
-      vi.useFakeTimers({ shouldAdvanceTime: true });
       // simulate a wallet still running the old 5-min default
       const originalReqTtl = ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl;
       const originalResTtl = ENGINE_RPC_OPTS.wc_sessionRequest.res.ttl;
@@ -3361,6 +3361,9 @@ describe("Sign Client Integration", () => {
           clients,
           sessionA: { topic },
         } = await initTwoPairedClients({}, {}, { logger: "error" });
+
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+
         const newExpiry = 900; // 15 minutes — the new default set by the dApp
         const responseMessage = "response after old expiry window";
 

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -3309,6 +3309,46 @@ describe.concurrent("Sign Client Integration", () => {
       ]);
       await deleteClients(clients);
     });
+    it("should set default request expiry to 15 minutes", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        const {
+          clients,
+          sessionA: { topic },
+        } = await initTwoPairedClients({}, {}, { logger: "error" });
+        const defaultExpiry = ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl; // FIVE_MINUTES * 3 = 900s = 15min
+        expect(defaultExpiry).to.eq(900);
+
+        const responseMessage = "test response after 14 minutes";
+
+        await Promise.all([
+          new Promise<void>((resolve) => {
+            (clients.B as SignClient).once("session_request", async (payload) => {
+              expect(payload.params.request.expiryTimestamp).to.be.approximately(
+                calcExpiry(defaultExpiry),
+                5,
+              );
+              // advance clock by 14 minutes — still within the 15-min default expiry
+              await vi.advanceTimersByTimeAsync(14 * 60 * 1000);
+              await clients.B.respond({
+                topic,
+                response: formatJsonRpcResult(payload.id, responseMessage),
+              });
+              resolve();
+            });
+          }),
+          new Promise<void>(async (resolve) => {
+            // no expiry param — should use the default 15min
+            const result = await clients.A.request({ ...TEST_REQUEST_PARAMS, topic });
+            expect(result).to.eq(responseMessage);
+            resolve();
+          }),
+        ]);
+        await deleteClients(clients);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
     it("should send request on optional namespace", async () => {
       const {
         clients,

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -3583,6 +3583,7 @@ describe.sequential("extend", () => {
 });
 describe.sequential("session request expiry", () => {
   it("should set default request expiry to 15 minutes and respect dApp expiryTimestamp", async () => {
+    vi.useRealTimers();
     const {
       clients,
       sessionA: { topic },
@@ -3621,6 +3622,7 @@ describe.sequential("session request expiry", () => {
     await deleteClients(clients);
   });
   it("should respect dApp expiryTimestamp even when wallet uses old 5-min config", async () => {
+    vi.useRealTimers();
     // should respect dApp expiryTimestamp even when wallet uses old 5-min config
     // simulate a wallet still running the old 5-min default
     const originalReqTtl = ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl;

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -3594,9 +3594,9 @@ describe.sequential("session request expiry", () => {
 
     const responseMessage = "test response after 14 minutes";
 
-    // Only fake setTimeout/clearTimeout — leave Date.now() real so WebSocket
-    // operations don't send far-future timestamps that the relay rejects.
-    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    // Use shouldAdvanceTime so real timers keep working (relay/WebSocket)
+    // while allowing vi.setSystemTime to shift Date.now() for expiry checks.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
 
     await Promise.all([
       new Promise<void>((resolve) => {
@@ -3605,8 +3605,8 @@ describe.sequential("session request expiry", () => {
             calcExpiry(defaultExpiry),
             5,
           );
-          // advance clock by 14 minutes — still within the 15-min default expiry
-          await vi.advanceTimersByTimeAsync(14 * 60 * 1000);
+          // shift Date.now() by 14 minutes — still within the 15-min default expiry
+          vi.setSystemTime(Date.now() + 14 * 60 * 1000);
           await clients.B.respond({
             topic,
             response: formatJsonRpcResult(payload.id, responseMessage),
@@ -3615,7 +3615,6 @@ describe.sequential("session request expiry", () => {
         });
       }),
       new Promise<void>(async (resolve) => {
-        // no expiry param — should use the default 15min
         const result = await clients.A.request({ ...TEST_REQUEST_PARAMS, topic });
         expect(result).to.eq(responseMessage);
         resolve();
@@ -3632,16 +3631,14 @@ describe.sequential("session request expiry", () => {
       sessionA: { topic },
     } = await initTwoPairedClients({}, {}, { logger: "error" });
 
-    // should respect dApp expiryTimestamp even when wallet uses old 5-min config
-    // simulate a wallet still running the old 5-min default
     const originalReqTtl = ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl;
     const originalResTtl = ENGINE_RPC_OPTS.wc_sessionRequest.res.ttl;
     ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl = FIVE_MINUTES; // old 5-min value
     ENGINE_RPC_OPTS.wc_sessionRequest.res.ttl = FIVE_MINUTES;
     try {
-      // Only fake setTimeout/clearTimeout — leave Date.now() real so WebSocket
-      // operations don't send far-future timestamps that the relay rejects.
-      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      // Use shouldAdvanceTime so real timers keep working (relay/WebSocket)
+      // while allowing vi.setSystemTime to shift Date.now() for expiry checks.
+      vi.useFakeTimers({ shouldAdvanceTime: true });
 
       const newExpiry = originalReqTtl; // 15 minutes — the new default set by the dApp
       const responseMessage = "response after old expiry window";
@@ -3649,13 +3646,12 @@ describe.sequential("session request expiry", () => {
       await Promise.all([
         new Promise<void>((resolve) => {
           (clients.B as SignClient).once("session_request", async (payload) => {
-            // wallet receives expiryTimestamp set by dApp (~15 min), not the wallet's local 5-min config
             expect(payload.params.request.expiryTimestamp).to.be.approximately(
               calcExpiry(newExpiry),
               5,
             );
-            // advance past old 5-min window but within new 15-min window
-            await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
+            // shift Date.now() past old 5-min window but within new 15-min window
+            vi.setSystemTime(Date.now() + 6 * 60 * 1000);
             await clients.B.respond({
               topic,
               response: formatJsonRpcResult(payload.id, responseMessage),
@@ -3664,7 +3660,6 @@ describe.sequential("session request expiry", () => {
           });
         }),
         new Promise<void>(async (resolve) => {
-          // dApp explicitly passes the new 15-min expiry
           const result = await clients.A.request({
             ...TEST_REQUEST_PARAMS,
             topic,

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -3280,7 +3280,7 @@ describe.concurrent("Sign Client Integration", () => {
     });
   });
 
-  describe.concurrent("session requests", () => {
+  describe("session requests", () => {
     it("should set custom request expiry", async () => {
       const {
         clients,
@@ -3346,6 +3346,56 @@ describe.concurrent("Sign Client Integration", () => {
         ]);
         await deleteClients(clients);
       } finally {
+        vi.useRealTimers();
+      }
+    });
+    it("should respect dApp expiryTimestamp even when wallet uses old 5-min config", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      // simulate a wallet still running the old 5-min default
+      const originalReqTtl = ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl;
+      const originalResTtl = ENGINE_RPC_OPTS.wc_sessionRequest.res.ttl;
+      ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl = 300; // old 5-min value
+      ENGINE_RPC_OPTS.wc_sessionRequest.res.ttl = 300;
+      try {
+        const {
+          clients,
+          sessionA: { topic },
+        } = await initTwoPairedClients({}, {}, { logger: "error" });
+        const newExpiry = 900; // 15 minutes — the new default set by the dApp
+        const responseMessage = "response after old expiry window";
+
+        await Promise.all([
+          new Promise<void>((resolve) => {
+            (clients.B as SignClient).once("session_request", async (payload) => {
+              // wallet receives expiryTimestamp set by dApp (~15 min), not the wallet's local 5-min config
+              expect(payload.params.request.expiryTimestamp).to.be.approximately(
+                calcExpiry(newExpiry),
+                5,
+              );
+              // advance past old 5-min window but within new 15-min window
+              await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
+              await clients.B.respond({
+                topic,
+                response: formatJsonRpcResult(payload.id, responseMessage),
+              });
+              resolve();
+            });
+          }),
+          new Promise<void>(async (resolve) => {
+            // dApp explicitly passes the new 15-min expiry
+            const result = await clients.A.request({
+              ...TEST_REQUEST_PARAMS,
+              topic,
+              expiry: newExpiry,
+            });
+            expect(result).to.eq(responseMessage);
+            resolve();
+          }),
+        ]);
+        await deleteClients(clients);
+      } finally {
+        ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl = originalReqTtl;
+        ENGINE_RPC_OPTS.wc_sessionRequest.res.ttl = originalResTtl;
         vi.useRealTimers();
       }
     });

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -47,7 +47,7 @@ import {
 } from "@walletconnect/core";
 import { EngineTypes, RelayerTypes } from "@walletconnect/types";
 
-describe.concurrent("Sign Client Integration", () => {
+describe("Sign Client Integration", () => {
   it("init", async () => {
     const client = await SignClient.init({
       ...TEST_SIGN_CLIENT_OPTIONS,

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -3310,45 +3310,42 @@ describe("Sign Client Integration", () => {
       await deleteClients(clients);
     });
     it("should set default request expiry to 15 minutes", async () => {
-      try {
-        const {
-          clients,
-          sessionA: { topic },
-        } = await initTwoPairedClients({}, {}, { logger: "error" });
-        const defaultExpiry = ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl; // FIVE_MINUTES * 3 = 900s = 15min
-        expect(defaultExpiry).to.eq(900);
+      const {
+        clients,
+        sessionA: { topic },
+      } = await initTwoPairedClients({}, {}, { logger: "error" });
+      const defaultExpiry = ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl; // FIVE_MINUTES * 3 = 900s = 15min
+      expect(defaultExpiry).to.eq(900);
 
-        const responseMessage = "test response after 14 minutes";
+      const responseMessage = "test response after 14 minutes";
 
-        vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.useFakeTimers({ shouldAdvanceTime: true });
 
-        await Promise.all([
-          new Promise<void>((resolve) => {
-            (clients.B as SignClient).once("session_request", async (payload) => {
-              expect(payload.params.request.expiryTimestamp).to.be.approximately(
-                calcExpiry(defaultExpiry),
-                5,
-              );
-              // advance clock by 14 minutes — still within the 15-min default expiry
-              await vi.advanceTimersByTimeAsync(14 * 60 * 1000);
-              await clients.B.respond({
-                topic,
-                response: formatJsonRpcResult(payload.id, responseMessage),
-              });
-              resolve();
+      await Promise.all([
+        new Promise<void>((resolve) => {
+          (clients.B as SignClient).once("session_request", async (payload) => {
+            expect(payload.params.request.expiryTimestamp).to.be.approximately(
+              calcExpiry(defaultExpiry),
+              5,
+            );
+            // advance clock by 14 minutes — still within the 15-min default expiry
+            await vi.advanceTimersByTimeAsync(14 * 60 * 1000);
+            await clients.B.respond({
+              topic,
+              response: formatJsonRpcResult(payload.id, responseMessage),
             });
-          }),
-          new Promise<void>(async (resolve) => {
-            // no expiry param — should use the default 15min
-            const result = await clients.A.request({ ...TEST_REQUEST_PARAMS, topic });
-            expect(result).to.eq(responseMessage);
             resolve();
-          }),
-        ]);
-        await deleteClients(clients);
-      } finally {
-        vi.useRealTimers();
-      }
+          });
+        }),
+        new Promise<void>(async (resolve) => {
+          // no expiry param — should use the default 15min
+          const result = await clients.A.request({ ...TEST_REQUEST_PARAMS, topic });
+          expect(result).to.eq(responseMessage);
+          resolve();
+        }),
+      ]);
+      vi.useRealTimers();
+      await deleteClients(clients);
     });
     it("should respect dApp expiryTimestamp even when wallet uses old 5-min config", async () => {
       // simulate a wallet still running the old 5-min default
@@ -3395,11 +3392,11 @@ describe("Sign Client Integration", () => {
             resolve();
           }),
         ]);
+        vi.useRealTimers();
         await deleteClients(clients);
       } finally {
         ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl = originalReqTtl;
         ENGINE_RPC_OPTS.wc_sessionRequest.res.ttl = originalResTtl;
-        vi.useRealTimers();
       }
     });
     it("should send request on optional namespace", async () => {

--- a/packages/sign-client/test/sdk/client.spec.ts
+++ b/packages/sign-client/test/sdk/client.spec.ts
@@ -3594,7 +3594,9 @@ describe.sequential("session request expiry", () => {
 
     const responseMessage = "test response after 14 minutes";
 
-    vi.useFakeTimers();
+    // Only fake setTimeout/clearTimeout — leave Date.now() real so WebSocket
+    // operations don't send far-future timestamps that the relay rejects.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
 
     await Promise.all([
       new Promise<void>((resolve) => {
@@ -3637,7 +3639,9 @@ describe.sequential("session request expiry", () => {
     ENGINE_RPC_OPTS.wc_sessionRequest.req.ttl = FIVE_MINUTES; // old 5-min value
     ENGINE_RPC_OPTS.wc_sessionRequest.res.ttl = FIVE_MINUTES;
     try {
-      vi.useFakeTimers();
+      // Only fake setTimeout/clearTimeout — leave Date.now() real so WebSocket
+      // operations don't send far-future timestamps that the relay rejects.
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
 
       const newExpiry = originalReqTtl; // 15 minutes — the new default set by the dApp
       const responseMessage = "response after old expiry window";


### PR DESCRIPTION
## Summary
- Increase the default `wc_sessionRequest` TTL from 5 minutes to 15 minutes (`FIVE_MINUTES * 3 = 900s`) for both request and response
- Add integration test that uses vitest fake timers to advance the clock by 14 minutes and confirms the request still resolves successfully within the 15-minute window

## Test plan
- [x] Existing tests pass (`npm run test --prefix=packages/sign-client`)
- [x] New test `"should set default request expiry to 15 minutes"` validates the default TTL constant equals 900s
- [x] New test confirms `expiryTimestamp` is set correctly when no custom expiry is provided
- [x] New test advances fake timers by 14 minutes and verifies the response still resolves (not expired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small constant change plus test updates; main behavioral impact is longer-lived session requests by default, which could affect timeout expectations but is straightforward and covered by new tests.
> 
> **Overview**
> Updates the default `wc_sessionRequest` request/response TTL from 5 minutes to 15 minutes (`FIVE_MINUTES * 3`) via `ENGINE_RPC_OPTS`, affecting the default expiry used when dApps do not pass an explicit `expiry`.
> 
> Adds/adjusts integration tests to validate the new default `expiryTimestamp`, ensure requests still succeed near the end of the 15-minute window using fake timers, and verify wallets with an old 5-minute config still honor the dApp-provided `expiryTimestamp` (also switching some suites to `describe.sequential` to avoid timer/concurrency flakiness).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da45d0291cd650f72a31522438d2e0f46e718b62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->