### PR TITLE
fix(utils): createDelayedPromise expiry uses SDKError and fixes unhandled rejection

### DIFF
--- a/packages/utils/src/errors.ts
+++ b/packages/utils/src/errors.ts
@@ -157,3 +157,7 @@ export function getSdkError(key: SdkErrorKey, context?: string | number) {
     code,
   };
 }
+
+export interface SDKError extends Error {
+  code?: number;
+}

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -11,6 +11,8 @@ import { getWindowMetadata } from "@walletconnect/window-metadata";
 import { ErrorResponse } from "@walletconnect/jsonrpc-utils";
 import { IKeyValueStorage } from "@walletconnect/keyvaluestorage";
 
+import { getInternalError, SDKError } from "./errors.js";
+
 // -- constants -----------------------------------------//
 export const REACT_NATIVE_PRODUCT = "ReactNative";
 
@@ -319,8 +321,9 @@ export function createDelayedPromise<T>(
         return promiseResolve(result);
       }
       cacheTimeout = setTimeout(() => {
-        const err = new Error(expireErrorMessage);
-        result = Promise.reject(err);
+        const expiredError = getInternalError("EXPIRED");
+        const err = new Error(expireErrorMessage || expiredError.message) as unknown as SDKError;
+        err.code = expiredError.code;
         promiseReject(err);
       }, timeout);
       cacheResolve = promiseResolve;

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -322,7 +322,7 @@ export function createDelayedPromise<T>(
       }
       cacheTimeout = setTimeout(() => {
         const expiredError = getInternalError("EXPIRED");
-        const err = new Error(expireErrorMessage || expiredError.message) as unknown as SDKError;
+        const err = new Error(expireErrorMessage || expiredError.message) as SDKError;
         err.code = expiredError.code;
         promiseReject(err);
       }, timeout);

--- a/packages/utils/test/misc.spec.ts
+++ b/packages/utils/test/misc.spec.ts
@@ -277,13 +277,16 @@ describe("Misc", () => {
   describe("createDelayedPromise", () => {
     it("should reject with an error when the promise is expired", async () => {
       const { done } = createDelayedPromise(1);
+      let errorReceived = false;
       try {
         await done();
       } catch (_error: unknown) {
+        errorReceived = true;
         const error = _error as SDKError;
         expect(error.message).to.eq(getInternalError("EXPIRED").message);
         expect(error.code).to.eq(getInternalError("EXPIRED").code);
       }
+      expect(errorReceived).to.be.true;
     });
   });
 });

--- a/packages/utils/test/misc.spec.ts
+++ b/packages/utils/test/misc.spec.ts
@@ -10,6 +10,9 @@ import {
   toBase64,
   openDeeplink,
   isIframe,
+  createDelayedPromise,
+  getInternalError,
+  SDKError,
 } from "../src";
 
 const RELAY_URL = "wss://relay.walletconnect.org";
@@ -269,6 +272,18 @@ describe("Misc", () => {
 
     it("should return false if window.top is equal to window", () => {
       expect(isIframe()).to.be.false;
+    });
+  });
+  describe("createDelayedPromise", () => {
+    it("should reject with an error when the promise is expired", async () => {
+      const { done } = createDelayedPromise(1);
+      try {
+        await done();
+      } catch (_error: unknown) {
+        const error = _error as SDKError;
+        expect(error.message).to.eq(getInternalError("EXPIRED").message);
+        expect(error.code).to.eq(getInternalError("EXPIRED").code);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
Added `code` to `createDelayedPromise` promise rejection which is mapped to the internal `expired` error with a code value of `6`

## Test plan
- [x] Existing `createDelayedPromise` expiry test passes with the assertion guard
- [x] Test correctly fails if the rejection is removed (verified locally)