### PR TITLE
chore: add changeset for createDelayedPromise expiry error fix

### DIFF
--- a/.changeset/fix-delayed-promise-expiry-error.md
+++ b/.changeset/fix-delayed-promise-expiry-error.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/utils": patch
+---
+
+Updated `createDelayedPromise` expiry rejection to also contain a proper error code from `getInternalError("EXPIRED")` with a value of `6`


### PR DESCRIPTION
## Summary
- Adds a changeset for PR #7173 which added expired error `code` to the delayed promise rejection

## Test plan
- No code changes, changeset only

Made with [Cursor](https://cursor.com)