### PR TITLE
chore: fix incorrect license references across packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ sudo xcode-select --reset
 
 ## License
 
-Apache 2.0
+WalletConnect Community License

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,4 +4,4 @@ Core for WalletConnect Protocol
 
 ## License
 
-Apache 2.0
+WalletConnect Community License

--- a/packages/pay/README.md
+++ b/packages/pay/README.md
@@ -278,4 +278,4 @@ try {
 
 ## License
 
-Apache-2.0
+WalletConnect Community License

--- a/packages/pos-client/package.json
+++ b/packages/pos-client/package.json
@@ -5,7 +5,7 @@
   "private": false,
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
-  "license": "Apache-2.0",
+  "license": "SEE LICENSE IN LICENSE.md",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "unpkg": "dist/index.umd.js",

--- a/packages/sign-client/README.md
+++ b/packages/sign-client/README.md
@@ -14,4 +14,4 @@ Also available quick start for [Dapps](https://docs.reown.com/api/sign/dapp-usag
 
 ## License
 
-Apache 2.0
+WalletConnect Community License


### PR DESCRIPTION
## Summary

- Updated 4 README files (`README.md`, `packages/core/README.md`, `packages/sign-client/README.md`, `packages/pay/README.md`) from "Apache 2.0" to "WalletConnect Community License"
- Updated `packages/pos-client/package.json` license field from `"Apache-2.0"` to `"SEE LICENSE IN LICENSE.md"` to match all other packages

## Test plan

- [x] Verified all other `package.json` files already use `"SEE LICENSE IN LICENSE.md"`
- [x] Verified `LICENSE.md` contains the WalletConnect Community License Agreement
- [x] No code changes, documentation only


Made with [Cursor](https://cursor.com)