### PR TITLE
🐛 [CW-27194] fix(rn): update @walletconnect/react-native-compat to 2.23.7-cbx.0 to fix symbol conflits when build ios app 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25276,7 +25276,7 @@
     "packages/pos-client": {
       "name": "@walletconnect/pos-client",
       "version": "1.0.7",
-      "license": "Apache-2.0",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@walletconnect/core": "2.23.7",
         "@walletconnect/jsonrpc-provider": "1.0.14",
@@ -25292,7 +25292,7 @@
     },
     "packages/react-native-compat": {
       "name": "@walletconnect/react-native-compat",
-      "version": "2.23.7",
+      "version": "2.23.7-cbx.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "events": "3.3.0",

--- a/packages/react-native-compat/ios/RNWalletConnectPayBridge.swift
+++ b/packages/react-native-compat/ios/RNWalletConnectPayBridge.swift
@@ -1,71 +1,48 @@
 import Foundation
-import YttriumWrapper
 
 @objc public class RNWalletConnectPayBridge: NSObject {
-    private var client: WalletConnectPayJson?
-
     @objc public override init() {
         super.init()
     }
 
     @objc public func initialize(_ sdkConfig: String) throws {
-        client = try WalletConnectPayJson(sdkConfig: sdkConfig)
+        throw NSError(
+            domain: "RNWalletConnectPay",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "RNWalletConnectPayBridge is disabled because YttriumWrapper is not enabled"]
+        )
     }
 
     @objc public func getPaymentOptions(
         _ requestJson: String,
         completion: @escaping (String?, Error?) -> Void
     ) {
-        guard let client = client else {
-            completion(nil, NSError(domain: "RNWalletConnectPay", code: 1, userInfo: [NSLocalizedDescriptionKey: "Pay client not initialized"]))
-            return
-        }
-
-        Task {
-            do {
-                let result = try await client.getPaymentOptions(requestJson: requestJson)
-                completion(result, nil)
-            } catch {
-                completion(nil, error)
-            }
-        }
+        completion(nil, NSError(
+            domain: "RNWalletConnectPay",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "RNWalletConnectPayBridge is disabled because YttriumWrapper is not enabled"]
+        ))
     }
 
     @objc public func getRequiredPaymentActions(
         _ requestJson: String,
         completion: @escaping (String?, Error?) -> Void
     ) {
-        guard let client = client else {
-            completion(nil, NSError(domain: "RNWalletConnectPay", code: 1, userInfo: [NSLocalizedDescriptionKey: "Pay client not initialized"]))
-            return
-        }
-
-        Task {
-            do {
-                let result = try await client.getRequiredPaymentActions(requestJson: requestJson)
-                completion(result, nil)
-            } catch {
-                completion(nil, error)
-            }
-        }
+        completion(nil, NSError(
+            domain: "RNWalletConnectPay",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "RNWalletConnectPayBridge is disabled because YttriumWrapper is not enabled"]
+        ))
     }
 
     @objc public func confirmPayment(
         _ requestJson: String,
         completion: @escaping (String?, Error?) -> Void
     ) {
-        guard let client = client else {
-            completion(nil, NSError(domain: "RNWalletConnectPay", code: 1, userInfo: [NSLocalizedDescriptionKey: "Pay client not initialized"]))
-            return
-        }
-
-        Task {
-            do {
-                let result = try await client.confirmPayment(requestJson: requestJson)
-                completion(result, nil)
-            } catch {
-                completion(nil, error)
-            }
-        }
+        completion(nil, NSError(
+            domain: "RNWalletConnectPay",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "RNWalletConnectPayBridge is disabled because YttriumWrapper is not enabled"]
+        ))
     }
 }

--- a/packages/react-native-compat/package.json
+++ b/packages/react-native-compat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/react-native-compat",
   "description": "Native modules and shims for WalletConnect Protocol in React Native Projects",
-  "version": "2.23.7",
+  "version": "2.23.7-cbx.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/packages/react-native-compat/react-native-compat.podspec
+++ b/packages/react-native-compat/react-native-compat.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.swift_version = "5.0"
 
   # Yttrium - WalletConnect Pay uniffi bindings
-  s.dependency "YttriumWrapper", "0.10.40"
+  # s.dependency "YttriumWrapper", "0.10.40" # Fix conflit symbol _rust_eh_personality issue
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
Fix the issue when build ios app:
```
ld: warning: ignoring duplicate libraries: '-lc++'
ld: warning: search path '/Users/brian.yeh/Library/Developer/Xcode/DerivedData/CWSApp-gepzvclqbivfmrfeguuqzlrknbxd/Build/Products/Debug-iphoneos/AFNetworking' not found
duplicate symbol '_rust_eh_personality' in:
    /Users/brian.yeh/Library/Developer/Xcode/DerivedData/CWSApp-gepzvclqbivfmrfeguuqzlrknbxd/Build/Products/Debug-iphoneos/XCFrameworkIntermediates/YttriumWrapper/libyttrium.a[167](std-094bd737aec43997.std.5350515ad8f39853-cgu.0.rcgu.o)
    /Users/brian.yeh/Library/Developer/Xcode/DerivedData/CWSApp-gepzvclqbivfmrfeguuqzlrknbxd/Build/Products/Debug-iphoneos/react-native-haskell-shelley/libreact-native-haskell-shelley.a[280](std-02e1cffd54195b35.std.ec902fb757716e69-cgu.0.rcgu.o)
ld: 1 duplicate symbols
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

slack discussion:

https://coolbitx.slack.com/archives/C02UD3WFL1X/p1772706893555859