### PR TITLE
chore: sync pay types with yttrium crate

### DIFF
--- a/packages/pay/src/types/api.ts
+++ b/packages/pay/src/types/api.ts
@@ -8,7 +8,13 @@
 /**
  * Payment status representing the lifecycle of a payment
  */
-export type PaymentStatus = "requires_action" | "processing" | "succeeded" | "failed" | "expired";
+export type PaymentStatus =
+  | "requires_action"
+  | "processing"
+  | "succeeded"
+  | "failed"
+  | "expired"
+  | "cancelled";
 
 /**
  * Type of data collection field
@@ -155,6 +161,8 @@ export interface PaymentOption {
   amount: PayAmount;
   /** Estimated time to complete the option, in seconds */
   etaS: number;
+  /** Option expiration timestamp, in seconds since epoch */
+  expiresAt?: number;
   /** Actions required to complete the option */
   actions: Action[];
   /** Option-specific data collection requirements */

--- a/packages/pay/test/mocks/provider.ts
+++ b/packages/pay/test/mocks/provider.ts
@@ -202,6 +202,7 @@ export function createMockPaymentOptionsResponse(
           },
         },
         etaS: 5,
+        expiresAt: Math.floor(Date.now() / 1000) + 300,
         actions: [],
       },
     ],
@@ -355,6 +356,7 @@ export function createMockPaymentOptionsWithOptionCollectData(): PaymentOptionsR
           },
         },
         etaS: 5,
+        expiresAt: Math.floor(Date.now() / 1000) + 300,
         actions: [],
         collectData: {
           fields: [
@@ -388,6 +390,7 @@ export function createMockPaymentOptionsWithOptionCollectData(): PaymentOptionsR
           },
         },
         etaS: 30,
+        expiresAt: Math.floor(Date.now() / 1000) + 600,
         actions: [],
       },
     ],

--- a/packages/pay/test/pay.spec.ts
+++ b/packages/pay/test/pay.spec.ts
@@ -50,6 +50,8 @@ describe("WalletConnectPay with MockProvider", () => {
       expect(result.options[0].id).toBe("opt_1");
       expect(result.options[0].amount.unit).toContain("eip155:8453");
       expect(result.options[0].amount.display.assetSymbol).toBe("USDC");
+      expect(result.options[0].expiresAt).toBeDefined();
+      expect(typeof result.options[0].expiresAt).toBe("number");
     });
 
     it("should return payment options with payment info when requested", async () => {
@@ -115,9 +117,12 @@ describe("WalletConnectPay with MockProvider", () => {
       expect(optionWithCollect?.collectData?.fields[1].fieldType).toBe("checkbox");
       expect(optionWithCollect?.collectData?.url).toBe("https://example.com/collect");
 
+      expect(optionWithCollect?.expiresAt).toBeDefined();
+
       const optionWithoutCollect = result.options.find((o) => o.id === "opt_without_collect");
       expect(optionWithoutCollect).toBeDefined();
       expect(optionWithoutCollect?.collectData).toBeUndefined();
+      expect(optionWithoutCollect?.expiresAt).toBeDefined();
     });
 
     it("should throw error for non-existent payment", async () => {
@@ -401,6 +406,22 @@ describe("WalletConnectPay with MockProvider", () => {
       const result = await mockProvider.confirmPayment(params);
 
       expect(result.status).toBe("expired");
+      expect(result.isFinal).toBe(true);
+    });
+
+    it("should handle cancelled payment", async () => {
+      const mockResponse = createMockConfirmResponse("cancelled", true);
+      mockProvider.setConfirmResponse("pay_cancelled", "opt_1", mockResponse);
+
+      const params: ConfirmPaymentParams = {
+        paymentId: "pay_cancelled",
+        optionId: "opt_1",
+        signatures: ["0xsig1"],
+      };
+
+      const result = await mockProvider.confirmPayment(params);
+
+      expect(result.status).toBe("cancelled");
       expect(result.isFinal).toBe(true);
     });
 


### PR DESCRIPTION
## Summary

- Add missing `"cancelled"` variant to `PaymentStatus` type to match the yttrium Rust crate enum
- Add optional `expiresAt` field to `PaymentOption` interface (maps to `Option<i64>` in yttrium)
- Update mock provider to include `expiresAt` in test fixtures
- Add test coverage for cancelled payment status

## Context

The yttrium Rust crate (`crates/yttrium/src/pay/mod.rs`) has added new fields and enum variants that the JS/TS SDK types were missing. This PR brings the TypeScript types in sync.

## Test plan

- [x] All 79 pay tests pass (`npm run test --prefix=packages/pay`)
- [x] New test for `cancelled` payment status
- [x] Existing tests updated to assert `expiresAt` on payment options

Made with [Cursor](https://cursor.com)