### PR TITLE
Feat: Change log message

### DIFF
--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -583,7 +583,7 @@ export class Relayer extends IRelayer {
   };
 
   private onConnectHandler = () => {
-    this.logger.warn({}, "Relayer connected 🛜");
+    this.logger.info({}, "Relayer connected 🛜");
     this.startPingTimeout();
     this.events.emit(RELAYER_EVENTS.connect);
   };


### PR DESCRIPTION
In React Native, using warn triggers a toast that appears at the bottom of the screen. During connect, this becomes very annoying. Changing logger.warn to logger.info will remove unnecessary noise from the screens during development.