### PR TITLE
fix(utils): eliminate Node.js Buffer dependencies for browser compatibility (#7176)

### DIFF
--- a/packages/utils/src/cacao.ts
+++ b/packages/utils/src/cacao.ts
@@ -1,3 +1,4 @@
+import { fromString, toString } from "uint8arrays";
 import { AuthTypes } from "@walletconnect/types";
 import { getCommonValuesInArrays } from "./misc.js";
 import { verifySignature } from "./signatures.js";
@@ -225,11 +226,11 @@ export function getReCapActions(abilities: any[]) {
 }
 
 export function base64Encode(input: unknown): string {
-  return Buffer.from(JSON.stringify(input)).toString("base64");
+  return toString(fromString(JSON.stringify(input), "utf8"), "base64pad");
 }
 
 export function base64Decode(encodedString: string): string {
-  return JSON.parse(Buffer.from(encodedString, "base64").toString("utf-8"));
+  return JSON.parse(toString(fromString(encodedString, "base64pad"), "utf8"));
 }
 
 export function isValidRecap(recap: any) {

--- a/packages/utils/src/crypto.ts
+++ b/packages/utils/src/crypto.ts
@@ -224,8 +224,8 @@ export function isTypeTwoEnvelope(
 }
 
 export function getCryptoKeyFromKeyData(keyData: P256KeyDataType): Uint8Array {
-  const xBuffer = Buffer.from(keyData.x, "base64");
-  const yBuffer = Buffer.from(keyData.y, "base64");
+  const xBuffer = fromString(keyData.x, "base64url");
+  const yBuffer = fromString(keyData.y, "base64url");
 
   // Concatenate x and y coordinates with 0x04 prefix (uncompressed point format)
   return concat([new Uint8Array([0x04]), xBuffer, yBuffer]);
@@ -235,7 +235,7 @@ export function verifyP256Jwt<T>(token: string, keyData: P256KeyDataType) {
   const [headerBase64Url, payloadBase64Url, signatureBase64Url] = token.split(".");
 
   // Decode the signature
-  const signatureBuffer = Buffer.from(fromBase64URL(signatureBase64Url), "base64");
+  const signatureBuffer = fromString(fromBase64URL(signatureBase64Url), "base64pad");
 
   // Check if signature length is correct (64 bytes for P-256)
   if (signatureBuffer.length !== 64) {

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -1,3 +1,4 @@
+import { fromString, toString } from "uint8arrays";
 import { detect } from "detect-browser";
 import { FIVE_MINUTES, fromMiliseconds, toMiliseconds } from "@walletconnect/time";
 import {
@@ -551,12 +552,12 @@ export function isIframe() {
 }
 
 export function toBase64(input: string, removePadding = false): string {
-  const encoded = Buffer.from(input).toString("base64");
+  const encoded = toString(fromString(input, "utf8"), "base64pad");
   return removePadding ? encoded.replace(/[=]/g, "") : encoded;
 }
 
 export function fromBase64(encodedString: string): string {
-  return Buffer.from(encodedString, "base64").toString("utf-8");
+  return toString(fromString(encodedString, "base64pad"), "utf8");
 }
 
 export function sleep(ms: number) {

--- a/packages/utils/src/polkadot.ts
+++ b/packages/utils/src/polkadot.ts
@@ -1,3 +1,4 @@
+import { fromString, toString } from "uint8arrays";
 import { base58 } from "@scure/base";
 import { blake2b } from "blakejs";
 
@@ -49,7 +50,7 @@ export function addSignatureToExtrinsic({
 export function deriveExtrinsicHash(signedExtrinsicHex: string): string {
   const bytes = hexToBytes(signedExtrinsicHex);
   const hash = blake2b(bytes, undefined, 32);
-  return "0x" + Buffer.from(hash).toString("hex");
+  return "0x" + toString(hash, "hex");
 }
 
 function hexToBytes(hex: string): Uint8Array {
@@ -118,11 +119,11 @@ export function buildSignedExtrinsicHash(payload: {
   };
   signature: string;
 }) {
-  const signature = Uint8Array.from(Buffer.from(payload.signature, "hex"));
+  const signature = fromString(payload.signature, "hex");
 
   const publicKey = ss58AddressToPublicKey(payload.transaction.address);
   const signed = addSignatureToExtrinsic({ publicKey, signature, payload: payload.transaction });
-  const hexSigned = Buffer.from(signed).toString("hex");
+  const hexSigned = toString(signed, "hex");
   const hash = deriveExtrinsicHash(hexSigned);
 
   return hash;

--- a/packages/utils/src/signatures.ts
+++ b/packages/utils/src/signatures.ts
@@ -1,3 +1,4 @@
+import { concat, fromString, toString } from "uint8arrays";
 import { keccak_256 } from "@noble/hashes/sha3";
 import { Secp256k1, Signature } from "ox";
 import { sha256, sha512_256 } from "@noble/hashes/sha2";
@@ -13,7 +14,7 @@ const DEFAULT_RPC_URL = "https://rpc.walletconnect.org/v1";
 export function hashEthereumMessage(message: string) {
   const prefix = `\x19Ethereum Signed Message:\n${message.length}`;
   const prefixedMessage = new TextEncoder().encode(prefix + message);
-  return "0x" + Buffer.from(keccak_256(prefixedMessage)).toString("hex");
+  return "0x" + toString(keccak_256(prefixedMessage), "hex");
 }
 
 export async function verifySignature(
@@ -145,7 +146,7 @@ export function extractSolanaTransactionId(solanaTransaction: string): string {
     throw new Error("Transaction too short");
   }
 
-  const transactionBuffer = Buffer.from(solanaTransaction, "base64");
+  const transactionBuffer = fromString(solanaTransaction, "base64pad");
 
   const signatureBuffer = transactionBuffer.slice(1, 65);
 
@@ -153,7 +154,7 @@ export function extractSolanaTransactionId(solanaTransaction: string): string {
 }
 
 export function getSuiDigest(transaction: string) {
-  const txBytes = new Uint8Array(Buffer.from(transaction, "base64"));
+  const txBytes = fromString(transaction, "base64pad");
 
   const typeTagBytes = Array.from(`TransactionData::`).map((e) => e.charCodeAt(0));
 
@@ -188,7 +189,7 @@ export function getNearUint8ArrayFromBytes(bytes: unknown) {
 }
 
 export function getAlgorandTransactionId(transaction: string) {
-  const signedTxnBytes = Buffer.from(transaction, "base64");
+  const signedTxnBytes = fromString(transaction, "base64pad");
 
   const decoded = msgpackDecode(signedTxnBytes) as any;
 
@@ -200,8 +201,8 @@ export function getAlgorandTransactionId(transaction: string) {
   const serializedUnsignedTxn = msgpackEncode(unsignedTxn);
 
   // Prepend "TX" prefix
-  const txPrefix = Buffer.from("TX");
-  const toHash = Buffer.concat([txPrefix, Buffer.from(serializedUnsignedTxn)]);
+  const txPrefix = fromString("TX");
+  const toHash = concat([txPrefix, serializedUnsignedTxn]);
 
   const hash = sha512_256(toHash);
 
@@ -209,7 +210,7 @@ export function getAlgorandTransactionId(transaction: string) {
   return base32.encode(hash).replace(/=+$/, "");
 }
 
-function encodeVarint(value: number | bigint): Buffer {
+function encodeVarint(value: number | bigint): Uint8Array {
   const result: number[] = [];
   let v = BigInt(value);
   while (v >= 0x80n) {
@@ -217,7 +218,7 @@ function encodeVarint(value: number | bigint): Buffer {
     v >>= 7n;
   }
   result.push(Number(v));
-  return Buffer.from(result);
+  return new Uint8Array(result);
 }
 
 export function getSignDirectHash(payload: {
@@ -235,28 +236,28 @@ export function getSignDirectHash(payload: {
     signature: string;
   };
 }) {
-  const bodyBytes = Buffer.from(payload.signed.bodyBytes, "base64");
-  const authInfoBytes = Buffer.from(payload.signed.authInfoBytes, "base64");
-  const signature = Buffer.from(payload.signature.signature, "base64");
+  const bodyBytes = fromString(payload.signed.bodyBytes, "base64pad");
+  const authInfoBytes = fromString(payload.signed.authInfoBytes, "base64pad");
+  const signature = fromString(payload.signature.signature, "base64pad");
 
-  const chunks: Buffer[] = [];
+  const chunks: Uint8Array[] = [];
 
-  chunks.push(Buffer.from([0x0a]));
+  chunks.push(new Uint8Array([0x0a]));
   chunks.push(encodeVarint(bodyBytes.length));
   chunks.push(bodyBytes);
 
-  chunks.push(Buffer.from([0x12]));
+  chunks.push(new Uint8Array([0x12]));
   chunks.push(encodeVarint(authInfoBytes.length));
   chunks.push(authInfoBytes);
 
-  chunks.push(Buffer.from([0x1a]));
+  chunks.push(new Uint8Array([0x1a]));
   chunks.push(encodeVarint(signature.length));
   chunks.push(signature);
 
-  const txRawBytes = Buffer.concat(chunks);
+  const txRawBytes = concat(chunks);
   const hashBytes = sha256(txRawBytes);
 
-  return Buffer.from(hashBytes).toString("hex").toUpperCase();
+  return toString(hashBytes, "hex").toUpperCase();
 }
 
 export function getWalletSendCallsHashes(


### PR DESCRIPTION
This PR eliminates the usage of the Node.js `Buffer` object from `packages/utils/src` (specifically in `cacao.ts`, `misc.ts`, `crypto.ts`, `polkadot.ts`, and `signatures.ts`). This is critical for browser usage, as `Buffer` causes breaking issues (`Buffer is not defined`) in environments where it is not polyfilled (such as the Verify API context in issue #7176). 

The `Buffer` conversions have been replaced by the robust `uint8arrays` library (`fromString`, `toString`, `concat`), ensuring full browser compatibility while keeping encoding/decoding behavior consistent.