### PR TITLE
chore: use mapOf instead of HashMap for exported constants

### DIFF
--- a/packages/react-native-compat/android/src/main/java/com/walletconnect/reactnativemodule/RNWalletConnectModuleModule.kt
+++ b/packages/react-native-compat/android/src/main/java/com/walletconnect/reactnativemodule/RNWalletConnectModuleModule.kt
@@ -22,11 +22,10 @@ class RNWalletConnectModuleModule internal constructor(context: ReactApplication
       appName = "unknown"
     }
 
-    val constants: MutableMap<String, String> = HashMap()
-    constants.put("applicationId", getReactApplicationContext().getPackageName());
-    constants.put("applicationName", appName);
-    return constants
-  }
+    return mapOf(
+      "applicationId" to reactApplicationContext.packageName,
+      "applicationName" to appName
+    )
 
   @ReactMethod
   override fun isAppInstalled(packageName: String?, promise: Promise) {


### PR DESCRIPTION
Replace HashMap construction with idiomatic Kotlin mapOf() in exported constants. This simplifies the implementation and keeps behavior unchanged.