### PR TITLE
fix: prevent Node.js crypto from leaking into browser bundles

### DIFF
--- a/.changeset/fix-browser-crypto-resolution.md
+++ b/.changeset/fix-browser-crypto-resolution.md
@@ -1,0 +1,9 @@
+---
+"@walletconnect/core": patch
+---
+
+fix: prevent Node.js crypto module from leaking into browser bundles
+
+- Fix Rollup external config to handle subpath imports (e.g. `uint8arrays/from-string`), preventing transitive bundling of `multiformats` and its Node.js `crypto` import in ESM/CJS outputs
+- Add browser field override plugin to redirect `multiformats` internal `sha2.js` to `sha2-browser.js` (Web Crypto API) in UMD bundles
+- Add build-time guard that fails the UMD build if any Node.js built-in module is referenced

--- a/providers/ethereum-provider/rollup.config.js
+++ b/providers/ethereum-provider/rollup.config.js
@@ -1,5 +1,5 @@
 import pkg from "./package.json" with { type: "json" };
-import createConfig, { input, plugins } from "../../rollup.config.js";
+import createConfig, { input, plugins, isExternal } from "../../rollup.config.js";
 import alias from "@rollup/plugin-alias";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -25,7 +25,7 @@ export default createConfig(pkg.name, externalDependencies, options, options, op
       }),
       ...plugins,
     ],
-    external: externalDependencies,
+    external: isExternal(externalDependencies),
     output: {
       file: "./dist/index.native.js",
       format: "cjs",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import { resolve, dirname } from "path";
 import esbuild from "rollup-plugin-esbuild";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
@@ -5,8 +6,32 @@ import json from "@rollup/plugin-json";
 import { visualizer } from "rollup-plugin-visualizer";
 
 export const input = "./src/index.ts";
+
+// Workaround for @rollup/plugin-node-resolve v16 not applying the package.json
+// "browser" field file-level remappings for internal relative imports within
+// transitive dependencies. Specifically, multiformats/esm/src/basics.js imports
+// "./hashes/sha2.js" (Node.js version using `import crypto from 'crypto'`)
+// instead of the browser-safe "./hashes/sha2-browser.js" (using Web Crypto API).
+// This plugin runs before nodeResolve and redirects the import.
+// Applies to multiformats <=9.x internal layout. Re-verify on upgrades.
+// The failOnNodeBuiltins guard below will catch it if this workaround stops applying.
+// See: https://github.com/WalletConnect/walletconnect-monorepo/issues/7197
+const browserFieldOverrides = {
+  name: "browser-field-overrides",
+  resolveId(source, importer) {
+    if (!importer || !source.startsWith(".")) return null;
+    if (!importer.includes("node_modules/multiformats/")) return null;
+    const resolved = resolve(dirname(importer), source);
+    if (resolved.endsWith("/hashes/sha2.js")) {
+      return resolved.replace("/hashes/sha2.js", "/hashes/sha2-browser.js");
+    }
+    return null;
+  },
+};
+
 export const plugins = [
-  nodeResolve({ preferBuiltins: false, browser: true }),
+  browserFieldOverrides,
+  nodeResolve({ preferBuiltins: false, browser: true, exportConditions: ["browser"] }),
   json(),
   commonjs(),
   esbuild({
@@ -18,6 +43,38 @@ export const plugins = [
   }),
   visualizer(),
 ];
+
+// Rollup's `external` option with a plain array only matches exact dependency names,
+// so subpath imports like "uint8arrays/from-string" are not externalized and get bundled,
+// pulling in transitive dependencies (e.g. multiformats -> Node.js crypto).
+// This function returns a matcher that also externalizes subpath imports (dep + "/...").
+export function isExternal(packageDependencies) {
+  return (id) => packageDependencies.some((dep) => id === dep || id.startsWith(dep + "/"));
+}
+
+// Fail the UMD (browser) build if Node.js built-in modules are referenced.
+// This catches regressions where transitive dependencies leak Node.js-only
+// imports (e.g. "crypto", "fs", "path") into the browser bundle.
+function failOnNodeBuiltins(warning, defaultHandler) {
+  if (warning.code === "MISSING_NODE_BUILTINS") {
+    throw new Error(warning.message);
+  }
+  if (warning.code === "UNRESOLVED_IMPORT" && warning.exporter && isNodeBuiltin(warning.exporter)) {
+    throw new Error(`Node.js built-in "${warning.exporter}" imported by ${warning.id} — not allowed in browser bundles`);
+  }
+  defaultHandler(warning);
+}
+
+const NODE_BUILTINS = new Set([
+  "assert", "buffer", "child_process", "cluster", "crypto", "dgram", "dns",
+  "events", "fs", "http", "http2", "https", "net", "os", "path", "perf_hooks",
+  "punycode", "querystring", "readline", "stream", "string_decoder", "tls",
+  "tty", "url", "util", "v8", "vm", "worker_threads", "zlib",
+]);
+
+function isNodeBuiltin(id) {
+  return NODE_BUILTINS.has(id) || NODE_BUILTINS.has(id.replace("node:", ""));
+}
 
 export default function createConfig(
   packageName,
@@ -31,6 +88,7 @@ export default function createConfig(
     {
       input,
       plugins,
+      onwarn: failOnNodeBuiltins,
       output: {
         file: "./dist/index.umd.js",
         format: "umd",
@@ -43,7 +101,7 @@ export default function createConfig(
     {
       input,
       plugins,
-      external: packageDependencies,
+      external: isExternal(packageDependencies),
       output: [
         {
           file: "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Fixes #7197 — after the Rollup v2 → v4 migration, `@rollup/plugin-node-resolve` v16 stopped properly handling browser field remappings for transitive dependencies. This caused `multiformats`' Node.js `sha2.js` (which imports `crypto`) to leak into all browser-targeted bundles (ESM, CJS, UMD) of `@walletconnect/core` and downstream packages.

### Root causes and fixes

```mermaid
graph TD
    A["@walletconnect/core"] -->|imports| B["uint8arrays/from-string"]
    B -->|subpath not externalized| C["multiformats/basics.js"]
    C -->|relative import| D["./hashes/sha2.js ❌ Node.js crypto"]
    C -.->|should resolve to| E["./hashes/sha2-browser.js ✅ Web Crypto API"]

    style D fill:#f96,stroke:#333
    style E fill:#6f9,stroke:#333
```

1. **`isExternal()` function** — Rollup's `external` option with a plain array only matches exact dependency names. Subpath imports like `uint8arrays/from-string` were not externalized, causing `multiformats` (a transitive dep) to be bundled into ESM/CJS outputs with its Node.js `crypto` import. The new function matches both exact names and subpath prefixes.

2. **`browserFieldOverrides` custom plugin** — `@rollup/plugin-node-resolve` v16 fails to apply `package.json` `browser` field file-level remappings for internal relative imports within transitive dependencies. Specifically, `multiformats/esm/src/basics.js` imports `./hashes/sha2.js` (Node.js version) instead of the browser-safe `./hashes/sha2-browser.js`. This plugin runs before `nodeResolve` and redirects the import, fixing the UMD bundle.

3. **`exportConditions: ["browser"]`** — Ensures the `browser` condition is present in exports map resolution from the very first call.

### Verified outputs

| Build | `crypto` import | Hashing API | Loads OK |
|-------|----------------|-------------|----------|
| UMD | None | `crypto.subtle` (Web Crypto) | ✅ |
| ESM | None (externalized) | N/A | ✅ |
| CJS | None (externalized) | N/A | ✅ |

## Test plan

- [x] Rebuilt `@walletconnect/core` — no crypto warnings during build
- [x] Verified UMD output has no `require("crypto")` or `createHash` references
- [x] Verified ESM/CJS outputs have no `import "crypto"` statements
- [x] All three dist outputs (`index.umd.js`, `index.js`, `index.cjs`) load and run without errors


Made with [Cursor](https://cursor.com)