### PR TITLE
fix: replace Node.js Buffer with browser-safe alternatives

### DIFF
--- a/.changeset/fix-buffer-not-defined-browser.md
+++ b/.changeset/fix-buffer-not-defined-browser.md
@@ -1,0 +1,8 @@
+---
+"@walletconnect/utils": patch
+---
+
+fix: replace Node.js Buffer with browser-safe alternatives to fix "Buffer is not defined" in browser environments
+
+- Replace `Buffer.from`/`Buffer.concat` with `Uint8Array`, `btoa`/`atob`, `TextEncoder`/`TextDecoder`, and `uint8arrays` helpers across `misc.ts`, `crypto.ts`, `cacao.ts`, `signatures.ts`, and `polkadot.ts`
+- Add `scripts/verify-no-buffer.mjs` to verify UMD bundles contain no unguarded Buffer usage

--- a/packages/utils/src/cacao.ts
+++ b/packages/utils/src/cacao.ts
@@ -225,11 +225,22 @@ export function getReCapActions(abilities: any[]) {
 }
 
 export function base64Encode(input: unknown): string {
-  return Buffer.from(JSON.stringify(input)).toString("base64");
+  const json = JSON.stringify(input);
+  const bytes = new TextEncoder().encode(json);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
 }
 
 export function base64Decode(encodedString: string): string {
-  return JSON.parse(Buffer.from(encodedString, "base64").toString("utf-8"));
+  const binary = atob(encodedString);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return JSON.parse(new TextDecoder().decode(bytes));
 }
 
 export function isValidRecap(recap: any) {

--- a/packages/utils/src/cacao.ts
+++ b/packages/utils/src/cacao.ts
@@ -227,11 +227,11 @@ export function getReCapActions(abilities: any[]) {
 export function base64Encode(input: unknown): string {
   const json = JSON.stringify(input);
   const bytes = new TextEncoder().encode(json);
-  let binary = "";
+  const chars = new Array<string>(bytes.length);
   for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
+    chars[i] = String.fromCharCode(bytes[i]);
   }
-  return btoa(binary);
+  return btoa(chars.join(""));
 }
 
 export function base64Decode(encodedString: string): string {

--- a/packages/utils/src/cacao.ts
+++ b/packages/utils/src/cacao.ts
@@ -235,7 +235,8 @@ export function base64Encode(input: unknown): string {
 }
 
 export function base64Decode(encodedString: string): string {
-  const binary = atob(encodedString);
+  const padded = encodedString + "=".repeat((4 - (encodedString.length % 4)) % 4);
+  const binary = atob(padded);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) {
     bytes[i] = binary.charCodeAt(i);

--- a/packages/utils/src/crypto.ts
+++ b/packages/utils/src/crypto.ts
@@ -224,42 +224,32 @@ export function isTypeTwoEnvelope(
 }
 
 export function getCryptoKeyFromKeyData(keyData: P256KeyDataType): Uint8Array {
-  const xBuffer = Buffer.from(keyData.x, "base64");
-  const yBuffer = Buffer.from(keyData.y, "base64");
+  const xBytes = fromString(fromBase64URL(keyData.x), BASE64);
+  const yBytes = fromString(fromBase64URL(keyData.y), BASE64);
 
-  // Concatenate x and y coordinates with 0x04 prefix (uncompressed point format)
-  return concat([new Uint8Array([0x04]), xBuffer, yBuffer]);
+  return concat([new Uint8Array([0x04]), xBytes, yBytes]);
 }
 
 export function verifyP256Jwt<T>(token: string, keyData: P256KeyDataType) {
   const [headerBase64Url, payloadBase64Url, signatureBase64Url] = token.split(".");
 
-  // Decode the signature
-  const signatureBuffer = Buffer.from(fromBase64URL(signatureBase64Url), "base64");
+  const signatureBytes = fromString(fromBase64URL(signatureBase64Url), BASE64);
 
-  // Check if signature length is correct (64 bytes for P-256)
-  if (signatureBuffer.length !== 64) {
+  if (signatureBytes.length !== 64) {
     throw new Error("Invalid signature length");
   }
 
-  // Extract r and s from the signature
-  const r = signatureBuffer.slice(0, 32);
-  const s = signatureBuffer.slice(32, 64);
+  const r = signatureBytes.slice(0, 32);
+  const s = signatureBytes.slice(32, 64);
 
-  // Create the signing input
   const signingInput = `${headerBase64Url}.${payloadBase64Url}`;
-
-  // Hash the signing input
   const messageHash = sha256(signingInput);
-
-  // Get the public key in uncompressed point format
   const publicKey = getCryptoKeyFromKeyData(keyData);
 
-  // Verify the signature using noble/curves p256
   const isValid = p256.verify(
-    concat([r, s]), // signature bytes
-    messageHash, // message hash
-    publicKey, // public key in uncompressed format
+    concat([r, s]),
+    messageHash,
+    publicKey,
   );
 
   if (!isValid) {

--- a/packages/utils/src/crypto.ts
+++ b/packages/utils/src/crypto.ts
@@ -246,11 +246,7 @@ export function verifyP256Jwt<T>(token: string, keyData: P256KeyDataType) {
   const messageHash = sha256(signingInput);
   const publicKey = getCryptoKeyFromKeyData(keyData);
 
-  const isValid = p256.verify(
-    concat([r, s]),
-    messageHash,
-    publicKey,
-  );
+  const isValid = p256.verify(concat([r, s]), messageHash, publicKey);
 
   if (!isValid) {
     throw new Error("Invalid signature");

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -552,11 +552,11 @@ export function isIframe() {
 
 export function toBase64(input: string, removePadding = false): string {
   const bytes = new TextEncoder().encode(input);
-  let binary = "";
+  const chars = new Array<string>(bytes.length);
   for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
+    chars[i] = String.fromCharCode(bytes[i]);
   }
-  const encoded = btoa(binary);
+  const encoded = btoa(chars.join(""));
   return removePadding ? encoded.replace(/[=]/g, "") : encoded;
 }
 

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -561,7 +561,8 @@ export function toBase64(input: string, removePadding = false): string {
 }
 
 export function fromBase64(encodedString: string): string {
-  const binary = atob(encodedString);
+  const padded = encodedString + "=".repeat((4 - (encodedString.length % 4)) % 4);
+  const binary = atob(padded);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) {
     bytes[i] = binary.charCodeAt(i);

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -551,12 +551,22 @@ export function isIframe() {
 }
 
 export function toBase64(input: string, removePadding = false): string {
-  const encoded = Buffer.from(input).toString("base64");
+  const bytes = new TextEncoder().encode(input);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  const encoded = btoa(binary);
   return removePadding ? encoded.replace(/[=]/g, "") : encoded;
 }
 
 export function fromBase64(encodedString: string): string {
-  return Buffer.from(encodedString, "base64").toString("utf-8");
+  const binary = atob(encodedString);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
 }
 
 export function sleep(ms: number) {

--- a/packages/utils/src/polkadot.ts
+++ b/packages/utils/src/polkadot.ts
@@ -1,5 +1,6 @@
 import { base58 } from "@scure/base";
 import { blake2b } from "blakejs";
+import { toString } from "uint8arrays";
 
 export function ss58AddressToPublicKey(address: string): Uint8Array {
   const decoded = base58.decode(address);
@@ -49,13 +50,7 @@ export function addSignatureToExtrinsic({
 export function deriveExtrinsicHash(signedExtrinsicHex: string): string {
   const bytes = hexToBytes(signedExtrinsicHex);
   const hash = blake2b(bytes, undefined, 32);
-  return "0x" + bytesToHex(hash);
-}
-
-function bytesToHex(bytes: Uint8Array): string {
-  return Array.from(bytes)
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
+  return "0x" + toString(hash, "base16");
 }
 
 function hexToBytes(hex: string): Uint8Array {
@@ -128,7 +123,7 @@ export function buildSignedExtrinsicHash(payload: {
 
   const publicKey = ss58AddressToPublicKey(payload.transaction.address);
   const signed = addSignatureToExtrinsic({ publicKey, signature, payload: payload.transaction });
-  const hexSigned = bytesToHex(signed);
+  const hexSigned = toString(signed, "base16");
   const hash = deriveExtrinsicHash(hexSigned);
 
   return hash;

--- a/packages/utils/src/polkadot.ts
+++ b/packages/utils/src/polkadot.ts
@@ -49,7 +49,13 @@ export function addSignatureToExtrinsic({
 export function deriveExtrinsicHash(signedExtrinsicHex: string): string {
   const bytes = hexToBytes(signedExtrinsicHex);
   const hash = blake2b(bytes, undefined, 32);
-  return "0x" + Buffer.from(hash).toString("hex");
+  return "0x" + bytesToHex(hash);
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 function hexToBytes(hex: string): Uint8Array {
@@ -118,11 +124,11 @@ export function buildSignedExtrinsicHash(payload: {
   };
   signature: string;
 }) {
-  const signature = Uint8Array.from(Buffer.from(payload.signature, "hex"));
+  const signature = hexToBytes(payload.signature);
 
   const publicKey = ss58AddressToPublicKey(payload.transaction.address);
   const signed = addSignatureToExtrinsic({ publicKey, signature, payload: payload.transaction });
-  const hexSigned = Buffer.from(signed).toString("hex");
+  const hexSigned = bytesToHex(signed);
   const hash = deriveExtrinsicHash(hexSigned);
 
   return hash;

--- a/packages/utils/src/signatures.ts
+++ b/packages/utils/src/signatures.ts
@@ -10,10 +10,36 @@ import { parseChainId } from "./caip.js";
 
 const DEFAULT_RPC_URL = "https://rpc.walletconnect.org/v1";
 
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function concatBytes(arrays: Uint8Array[]): Uint8Array {
+  const totalLength = arrays.reduce((sum, arr) => sum + arr.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const arr of arrays) {
+    result.set(arr, offset);
+    offset += arr.length;
+  }
+  return result;
+}
+
 export function hashEthereumMessage(message: string) {
   const prefix = `\x19Ethereum Signed Message:\n${message.length}`;
   const prefixedMessage = new TextEncoder().encode(prefix + message);
-  return "0x" + Buffer.from(keccak_256(prefixedMessage)).toString("hex");
+  return "0x" + bytesToHex(keccak_256(prefixedMessage));
 }
 
 export async function verifySignature(
@@ -127,43 +153,33 @@ export function extractSolanaTransactionId(solanaTransaction: string): string {
     bytes[i] = binary.charCodeAt(i);
   }
 
-  // Check signature count (first byte)
   const signatureCount = bytes[0];
   if (signatureCount === 0) {
     throw new Error("No signatures found");
   }
 
-  // Verify we have enough bytes for all signatures
-  // Each signature is 64 bytes
   const signatureEndPos = 1 + signatureCount * 64;
   if (bytes.length < signatureEndPos) {
     throw new Error("Transaction data too short for claimed signature count");
   }
 
-  // A transaction must have at least some minimum length
   if (bytes.length < 100) {
     throw new Error("Transaction too short");
   }
 
-  const transactionBuffer = Buffer.from(solanaTransaction, "base64");
-
-  const signatureBuffer = transactionBuffer.slice(1, 65);
-
-  return base58.encode(signatureBuffer);
+  const signatureBytes = bytes.slice(1, 65);
+  return base58.encode(signatureBytes);
 }
 
 export function getSuiDigest(transaction: string) {
-  const txBytes = new Uint8Array(Buffer.from(transaction, "base64"));
-
-  const typeTagBytes = Array.from(`TransactionData::`).map((e) => e.charCodeAt(0));
+  const txBytes = base64ToBytes(transaction);
+  const typeTagBytes = new TextEncoder().encode("TransactionData::");
 
   const dataWithTag = new Uint8Array(typeTagBytes.length + txBytes.length);
-
   dataWithTag.set(typeTagBytes);
   dataWithTag.set(txBytes, typeTagBytes.length);
 
   const hash = blake2b(dataWithTag, { dkLen: 32 });
-
   return base58.encode(hash);
 }
 
@@ -188,7 +204,7 @@ export function getNearUint8ArrayFromBytes(bytes: unknown) {
 }
 
 export function getAlgorandTransactionId(transaction: string) {
-  const signedTxnBytes = Buffer.from(transaction, "base64");
+  const signedTxnBytes = base64ToBytes(transaction);
 
   const decoded = msgpackDecode(signedTxnBytes) as any;
 
@@ -199,17 +215,14 @@ export function getAlgorandTransactionId(transaction: string) {
 
   const serializedUnsignedTxn = msgpackEncode(unsignedTxn);
 
-  // Prepend "TX" prefix
-  const txPrefix = Buffer.from("TX");
-  const toHash = Buffer.concat([txPrefix, Buffer.from(serializedUnsignedTxn)]);
+  const txPrefix = new TextEncoder().encode("TX");
+  const toHash = concatBytes([txPrefix, new Uint8Array(serializedUnsignedTxn)]);
 
   const hash = sha512_256(toHash);
-
-  // Encode to base32 and remove padding
   return base32.encode(hash).replace(/=+$/, "");
 }
 
-function encodeVarint(value: number | bigint): Buffer {
+function encodeVarint(value: number | bigint): Uint8Array {
   const result: number[] = [];
   let v = BigInt(value);
   while (v >= 0x80n) {
@@ -217,7 +230,7 @@ function encodeVarint(value: number | bigint): Buffer {
     v >>= 7n;
   }
   result.push(Number(v));
-  return Buffer.from(result);
+  return new Uint8Array(result);
 }
 
 export function getSignDirectHash(payload: {
@@ -235,28 +248,28 @@ export function getSignDirectHash(payload: {
     signature: string;
   };
 }) {
-  const bodyBytes = Buffer.from(payload.signed.bodyBytes, "base64");
-  const authInfoBytes = Buffer.from(payload.signed.authInfoBytes, "base64");
-  const signature = Buffer.from(payload.signature.signature, "base64");
+  const bodyBytes = base64ToBytes(payload.signed.bodyBytes);
+  const authInfoBytes = base64ToBytes(payload.signed.authInfoBytes);
+  const signature = base64ToBytes(payload.signature.signature);
 
-  const chunks: Buffer[] = [];
+  const chunks: Uint8Array[] = [];
 
-  chunks.push(Buffer.from([0x0a]));
+  chunks.push(new Uint8Array([0x0a]));
   chunks.push(encodeVarint(bodyBytes.length));
   chunks.push(bodyBytes);
 
-  chunks.push(Buffer.from([0x12]));
+  chunks.push(new Uint8Array([0x12]));
   chunks.push(encodeVarint(authInfoBytes.length));
   chunks.push(authInfoBytes);
 
-  chunks.push(Buffer.from([0x1a]));
+  chunks.push(new Uint8Array([0x1a]));
   chunks.push(encodeVarint(signature.length));
   chunks.push(signature);
 
-  const txRawBytes = Buffer.concat(chunks);
+  const txRawBytes = concatBytes(chunks);
   const hashBytes = sha256(txRawBytes);
 
-  return Buffer.from(hashBytes).toString("hex").toUpperCase();
+  return bytesToHex(hashBytes).toUpperCase();
 }
 
 export function getWalletSendCallsHashes(

--- a/packages/utils/src/signatures.ts
+++ b/packages/utils/src/signatures.ts
@@ -4,17 +4,12 @@ import { sha256, sha512_256 } from "@noble/hashes/sha2";
 import { blake2b } from "@noble/hashes/blake2";
 import { encode as msgpackEncode, decode as msgpackDecode } from "@msgpack/msgpack";
 import { base32, base58 } from "@scure/base";
+import { concat, toString } from "uint8arrays";
 import { AuthTypes } from "@walletconnect/types";
 
 import { parseChainId } from "./caip.js";
 
 const DEFAULT_RPC_URL = "https://rpc.walletconnect.org/v1";
-
-function bytesToHex(bytes: Uint8Array): string {
-  return Array.from(bytes)
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
 
 function base64ToBytes(b64: string): Uint8Array {
   const binary = atob(b64);
@@ -25,21 +20,10 @@ function base64ToBytes(b64: string): Uint8Array {
   return bytes;
 }
 
-function concatBytes(arrays: Uint8Array[]): Uint8Array {
-  const totalLength = arrays.reduce((sum, arr) => sum + arr.length, 0);
-  const result = new Uint8Array(totalLength);
-  let offset = 0;
-  for (const arr of arrays) {
-    result.set(arr, offset);
-    offset += arr.length;
-  }
-  return result;
-}
-
 export function hashEthereumMessage(message: string) {
   const prefix = `\x19Ethereum Signed Message:\n${message.length}`;
   const prefixedMessage = new TextEncoder().encode(prefix + message);
-  return "0x" + bytesToHex(keccak_256(prefixedMessage));
+  return "0x" + toString(keccak_256(prefixedMessage), "base16");
 }
 
 export async function verifySignature(
@@ -147,11 +131,7 @@ function generateJsonRpcId() {
 }
 
 export function extractSolanaTransactionId(solanaTransaction: string): string {
-  const binary = atob(solanaTransaction);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
+  const bytes = base64ToBytes(solanaTransaction);
 
   const signatureCount = bytes[0];
   if (signatureCount === 0) {
@@ -216,7 +196,7 @@ export function getAlgorandTransactionId(transaction: string) {
   const serializedUnsignedTxn = msgpackEncode(unsignedTxn);
 
   const txPrefix = new TextEncoder().encode("TX");
-  const toHash = concatBytes([txPrefix, new Uint8Array(serializedUnsignedTxn)]);
+  const toHash = concat([txPrefix, new Uint8Array(serializedUnsignedTxn)]);
 
   const hash = sha512_256(toHash);
   return base32.encode(hash).replace(/=+$/, "");
@@ -266,10 +246,10 @@ export function getSignDirectHash(payload: {
   chunks.push(encodeVarint(signature.length));
   chunks.push(signature);
 
-  const txRawBytes = concatBytes(chunks);
+  const txRawBytes = concat(chunks);
   const hashBytes = sha256(txRawBytes);
 
-  return bytesToHex(hashBytes).toUpperCase();
+  return toString(hashBytes, "base16").toUpperCase();
 }
 
 export function getWalletSendCallsHashes(

--- a/packages/utils/src/signatures.ts
+++ b/packages/utils/src/signatures.ts
@@ -12,7 +12,8 @@ import { parseChainId } from "./caip.js";
 const DEFAULT_RPC_URL = "https://rpc.walletconnect.org/v1";
 
 function base64ToBytes(b64: string): Uint8Array {
-  const binary = atob(b64);
+  const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+  const binary = atob(padded);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) {
     bytes[i] = binary.charCodeAt(i);

--- a/packages/utils/test/cacao.spec.ts
+++ b/packages/utils/test/cacao.spec.ts
@@ -12,6 +12,7 @@ import {
   isValidRecap,
   mergeRecaps,
   populateAuthPayload,
+  mergeEncodedRecaps,
 } from "../src";
 
 describe("URI", () => {
@@ -253,6 +254,72 @@ describe("URI", () => {
     expect(message).to.include("Nonce: 32891756");
     expect(message).to.include(`URI: ${request.aud}`);
   });
+  describe("encodeRecap / decodeRecap with unpadded base64", () => {
+    it("should roundtrip recap whose base64 requires padding", () => {
+      // #given - a recap whose JSON length produces base64 needing padding (length % 4 !== 0)
+      const recap = createRecap("eip155", "request", ["personal_sign"]);
+      const encoded = encodeRecap(recap);
+
+      // #when - encodeRecap strips padding per spec
+      const base64Part = encoded.replace("urn:recap:", "");
+      expect(base64Part).to.not.include("=");
+
+      // #then - decodeRecap must handle the unpadded input
+      const decoded = decodeRecap(encoded);
+      expect(decoded).to.eql(recap);
+    });
+
+    it("should decode recap with base64 length mod 4 !== 0", () => {
+      // #given - crafted recap producing unpadded base64
+      const recap = {
+        att: {
+          "https://notify.walletconnect.com": { "manage/all-apps-notifications": [{}] },
+        },
+      };
+      const encoded = encodeRecap(recap);
+      const base64Part = encoded.replace("urn:recap:", "");
+
+      // #when - verify padding was stripped and length is not divisible by 4
+      expect(base64Part.length % 4).to.not.eql(0);
+
+      // #then
+      const decoded = decodeRecap(encoded);
+      expect(decoded).to.eql(recap);
+    });
+
+    it("should mergeEncodedRecaps with unpadded base64", () => {
+      // #given
+      const recap1 = encodeRecap(
+        createRecap("eip155", "request", ["personal_sign"]),
+      );
+      const recap2 = encodeRecap(
+        createRecap("eip155", "request", ["eth_sendTransaction"]),
+      );
+
+      // #when
+      const merged = mergeEncodedRecaps(recap1, recap2);
+
+      // #then
+      const decoded = decodeRecap(merged);
+      expect(decoded.att.eip155).to.have.property("request/personal_sign");
+      expect(decoded.att.eip155).to.have.property("request/eth_sendTransaction");
+    });
+
+    it("should getMethodsFromRecap with unpadded base64", () => {
+      // #given
+      const encoded = encodeRecap(
+        createRecap("eip155", "request", ["personal_sign", "eth_chainId"]),
+      );
+
+      // #when
+      const methods = getMethodsFromRecap(encoded);
+
+      // #then
+      expect(methods).to.include("personal_sign");
+      expect(methods).to.include("eth_chainId");
+    });
+  });
+
   describe("resources", () => {
     it("should not add resources to siwe message when missing from request", () => {
       const request = {

--- a/packages/utils/test/cacao.spec.ts
+++ b/packages/utils/test/cacao.spec.ts
@@ -289,12 +289,8 @@ describe("URI", () => {
 
     it("should mergeEncodedRecaps with unpadded base64", () => {
       // #given
-      const recap1 = encodeRecap(
-        createRecap("eip155", "request", ["personal_sign"]),
-      );
-      const recap2 = encodeRecap(
-        createRecap("eip155", "request", ["eth_sendTransaction"]),
-      );
+      const recap1 = encodeRecap(createRecap("eip155", "request", ["personal_sign"]));
+      const recap2 = encodeRecap(createRecap("eip155", "request", ["eth_sendTransaction"]));
 
       // #when
       const merged = mergeEncodedRecaps(recap1, recap2);

--- a/packages/utils/test/misc.spec.ts
+++ b/packages/utils/test/misc.spec.ts
@@ -8,6 +8,7 @@ import {
   hasOverlap,
   isExpired,
   toBase64,
+  fromBase64,
   openDeeplink,
   isIframe,
   createDelayedPromise,
@@ -287,6 +288,71 @@ describe("Misc", () => {
         expect(error.code).to.eq(getInternalError("EXPIRED").code);
       }
       expect(errorReceived).to.be.true;
+    });
+  });
+
+  describe("toBase64 / fromBase64", () => {
+    it("should roundtrip with padded base64", () => {
+      // #given - input whose base64 length is a multiple of 4
+      const input = "abc";
+
+      // #when
+      const encoded = toBase64(input);
+      const decoded = fromBase64(encoded);
+
+      // #then
+      expect(decoded).to.eql(input);
+    });
+
+    it("should roundtrip with unpadded base64 (removePadding=true)", () => {
+      // #given - Telegram deeplink scenario: toBase64 strips padding
+      const input = "requestId=123&sessionTopic=randomSessionTopic";
+      const encoded = toBase64(input, true);
+
+      // #when
+      expect(encoded).to.not.include("=");
+      const decoded = fromBase64(encoded);
+
+      // #then
+      expect(decoded).to.eql(input);
+    });
+
+    it("should decode unpadded base64 where length mod 4 is 2", () => {
+      // #given - atob() throws on unpadded input with length % 4 !== 0
+      const input = "a";
+      const encoded = toBase64(input, true);
+      expect(encoded.length % 4).to.eql(2);
+
+      // #when
+      const decoded = fromBase64(encoded);
+
+      // #then
+      expect(decoded).to.eql(input);
+    });
+
+    it("should decode unpadded base64 where length mod 4 is 3", () => {
+      // #given
+      const input = "ab";
+      const encoded = toBase64(input, true);
+      expect(encoded.length % 4).to.eql(3);
+
+      // #when
+      const decoded = fromBase64(encoded);
+
+      // #then
+      expect(decoded).to.eql(input);
+    });
+
+    it("should handle unicode content", () => {
+      // #given
+      const input = "hello 🌍 wörld";
+
+      // #when
+      const encoded = toBase64(input);
+      const decoded = fromBase64(encoded);
+
+      // #then
+      expect(decoded).to.eql(input);
     });
   });
 });

--- a/scripts/verify-no-buffer.mjs
+++ b/scripts/verify-no-buffer.mjs
@@ -1,0 +1,65 @@
+/**
+ * Verifies that browser bundles (UMD) don't depend on Node.js Buffer.
+ * Run after `npm run build` to catch regressions.
+ *
+ * Usage: node scripts/verify-no-buffer.mjs
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { join, resolve } from "path";
+
+const ROOT = resolve(import.meta.dirname, "..");
+
+const UMD_BUNDLES = [
+  "packages/utils/dist/index.umd.js",
+  "packages/core/dist/index.umd.js",
+  "packages/sign-client/dist/index.umd.js",
+];
+
+let hasFailure = false;
+
+for (const bundle of UMD_BUNDLES) {
+  const fullPath = join(ROOT, bundle);
+  if (!existsSync(fullPath)) {
+    console.log(`⚠  SKIP ${bundle} (not built)`);
+    continue;
+  }
+
+  const code = readFileSync(fullPath, "utf-8");
+
+  // Strip safe guarded patterns (check Buffer existence before use)
+  const stripped = code
+    .replace(/globalThis\.Buffer\s*!=\s*null/g, "__GUARDED__")
+    .replace(/globalThis\.Buffer\s*\?\s*Buffer\./g, "__GUARDED__?__GUARDED__.")
+    .replace(/globalThis\.Buffer\./g, "__GUARDED__.");
+
+  const bufferPatterns = [
+    /(?<![A-Za-z.])Buffer\.from\b/,
+    /(?<![A-Za-z.])Buffer\.concat\b/,
+    /(?<![A-Za-z.])Buffer\.alloc\b/,
+    /\bnew Buffer\b/,
+  ];
+
+  const matches = [];
+  for (const pattern of bufferPatterns) {
+    if (pattern.test(stripped)) {
+      matches.push(pattern.source);
+    }
+  }
+
+  if (matches.length > 0) {
+    console.log(`✗  FAIL ${bundle}`);
+    console.log(`   Found Buffer usage patterns: ${matches.join(", ")}`);
+    hasFailure = true;
+  } else {
+    console.log(`✓  PASS ${bundle}`);
+  }
+}
+
+if (hasFailure) {
+  console.log("\n✗  Browser bundles contain Node.js Buffer references!");
+  console.log("   Replace with uint8arrays, TextEncoder/TextDecoder, or manual byte operations.");
+  process.exit(1);
+} else {
+  console.log("\n✓  All browser bundles are Buffer-free.");
+}

--- a/scripts/verify-no-buffer.mjs
+++ b/scripts/verify-no-buffer.mjs
@@ -11,14 +11,14 @@ import { fileURLToPath } from "url";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 
-// Provider bundles (ethereum-provider, universal-provider) are excluded because
-// they bundle large third-party trees (@reown/appkit-*) that use their own
-// guarded Buffer patterns (e.g. `globalThis.Buffer ? ... : fallback`), which
-// would cause false positives here.
+// ethereum-provider is excluded because it bundles @reown/appkit-* which uses
+// its own guarded Buffer patterns (e.g. `globalThis.Buffer ? ... : fallback`),
+// causing false positives here.
 const UMD_BUNDLES = [
   "packages/utils/dist/index.umd.js",
   "packages/core/dist/index.umd.js",
   "packages/sign-client/dist/index.umd.js",
+  "providers/universal-provider/dist/index.umd.js",
 ];
 
 let hasFailure = false;

--- a/scripts/verify-no-buffer.mjs
+++ b/scripts/verify-no-buffer.mjs
@@ -6,10 +6,15 @@
  */
 
 import { readFileSync, existsSync } from "fs";
-import { join, resolve } from "path";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
 
-const ROOT = resolve(import.meta.dirname, "..");
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 
+// Provider bundles (ethereum-provider, universal-provider) are excluded because
+// they bundle large third-party trees (@reown/appkit-*) that use their own
+// guarded Buffer patterns (e.g. `globalThis.Buffer ? ... : fallback`), which
+// would cause false positives here.
 const UMD_BUNDLES = [
   "packages/utils/dist/index.umd.js",
   "packages/core/dist/index.umd.js",


### PR DESCRIPTION
## Summary

- Replace all `Buffer` usage in `packages/utils/src` with browser-compatible alternatives (`Uint8Array`, `TextEncoder`/`TextDecoder`, `btoa`/`atob`, `uint8arrays`)
- Fixes `Buffer is not defined` error in browser environments, specifically affecting the Verify API (`verifyP256Jwt` → `getCryptoKeyFromKeyData`)
- Add `scripts/verify-no-buffer.mjs` regression guard to verify UMD bundles are Buffer-free

### Files changed

| File | Patterns replaced |
|------|------------------|
| `misc.ts` | `toBase64` / `fromBase64` → `btoa`/`atob` + `TextEncoder`/`TextDecoder` |
| `crypto.ts` | `getCryptoKeyFromKeyData` / `verifyP256Jwt` → `uint8arrays` `fromString` |
| `cacao.ts` | `base64Encode` / `base64Decode` → `btoa`/`atob` + `TextEncoder`/`TextDecoder` |
| `signatures.ts` | 6 functions → `Uint8Array` helpers (`bytesToHex`, `base64ToBytes`, `concatBytes`) |
| `polkadot.ts` | `deriveExtrinsicHash` / `buildSignedExtrinsicHash` → `bytesToHex` + `hexToBytes` |

### Verification

```
✓  PASS packages/utils/dist/index.umd.js
✓  PASS packages/core/dist/index.umd.js
✓  PASS packages/sign-client/dist/index.umd.js
✓  All browser bundles are Buffer-free.
```

Runtime test (with `Buffer` deleted from global scope):
```
toBase64/fromBase64: PASS
base64Encode/Decode: PASS
hashEthereumMessage: PASS
toBase64 no padding: PASS
getCryptoKeyFromKeyData: PASS
```

Closes #7176

## Test plan

- [x] All UMD bundles pass static Buffer usage analysis (`node scripts/verify-no-buffer.mjs`)
- [x] Runtime test: critical functions work with `Buffer` removed from global scope
- [x] Full monorepo build succeeds (`npm run build`)
- [ ] CI passes (lint, build, tests)
- [ ] Manual verification in browser environment

Made with [Cursor](https://cursor.com)