### PR TITLE
fix: prevent infinite loop and memory exhaustion in relayer reconnection

### DIFF
--- a/.changeset/fix-relayer-reconnect-infinite-loop.md
+++ b/.changeset/fix-relayer-reconnect-infinite-loop.md
@@ -1,0 +1,13 @@
+---
+"@walletconnect/core": patch
+---
+
+fix: prevent infinite loop and memory exhaustion in relayer reconnection
+
+- Eliminate `new Promise(async executor)` antipattern in `connect()` and `subscribe()` so background tasks no longer spawn unsupervised connection attempts
+- Serialize connection attempts via `connectPromise` in both `transportOpen()` and `toEstablishConnection()` to prevent concurrent `connect()` calls
+- Keep `connectionAttemptInProgress` guard up during the entire retry loop to block `restartTransport()` from spawning parallel connections
+- Reset `reconnectInProgress` on early returns in `onProviderDisconnect()` to prevent the flag from getting permanently stuck
+- Close old WebSocket in `createProvider()` before creating a new one to prevent connection and listener leaks
+- Wrap `subscriber.stop()` in try/catch in `onProviderDisconnect()` to prevent `reconnectInProgress` from getting stuck on throw
+- Reset `stalledRestartBackoff` on successful connection so recovery latency doesn't degrade after repeated stall/recover cycles

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -426,10 +426,7 @@ export class Relayer extends IRelayer {
       }
 
       if (this.connected) {
-        this.logger.debug(
-          {},
-          `Connected to ${this.relayUrl} successfully on attempt: ${attempt}`,
-        );
+        this.logger.debug({}, `Connected to ${this.relayUrl} successfully on attempt: ${attempt}`);
         break;
       }
 

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -147,8 +147,7 @@ export class Relayer extends IRelayer {
   get connecting() {
     return (
       // @ts-expect-error
-      this.provider?.connection?.socket?.readyState === 0 ||
-      this.connectPromise !== undefined
+      this.provider?.connection?.socket?.readyState === 0 || this.connectPromise !== undefined
     );
   }
 

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -198,21 +198,25 @@ export class Relayer extends IRelayer {
         resolvePromise = resolve;
         this.subscriber.on(SUBSCRIBER_EVENTS.created, onSubCreated);
       }),
-      new Promise<void>(async (resolve, reject) => {
-        const result = await this.subscriber
+      new Promise<void>((resolve, reject) => {
+        this.subscriber
           .subscribe(topic, {
             internal: {
               throwOnFailedPublish: shouldThrowOnFailure,
             },
             ...opts,
           })
+          .then((result) => {
+            id = result || id;
+            resolve();
+          })
           .catch((error) => {
             if (shouldThrowOnFailure) {
               reject(error);
+            } else {
+              resolve();
             }
           });
-        id = result || id;
-        resolve();
       }),
     ]);
     return id;
@@ -688,11 +692,14 @@ export class Relayer extends IRelayer {
   private async onProviderDisconnect() {
     clearTimeout(this.pingTimeout);
     this.events.emit(RELAYER_EVENTS.disconnect);
-    this.connectionAttemptInProgress = false;
     if (this.reconnectInProgress) return;
 
     this.reconnectInProgress = true;
-    await this.subscriber.stop();
+    try {
+      await this.subscriber.stop();
+    } catch (e) {
+      this.logger.warn(e, "subscriber.stop() failed during disconnect");
+    }
 
     if (!this.subscriber.hasAnyTopics || this.transportExplicitlyClosed) {
       this.reconnectInProgress = false;

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -373,77 +373,72 @@ export class Relayer extends IRelayer {
     this.connectionAttemptInProgress = true;
     this.transportExplicitlyClosed = false;
     let attempt = 1;
-    try {
-      while (attempt < 6) {
-        try {
-          if (this.transportExplicitlyClosed) {
-            break;
-          }
-          this.logger.debug({}, `Connecting to ${this.relayUrl}, attempt: ${attempt}...`);
-          await this.createProvider();
-
-          // Step A: establish WebSocket connection
-          await new Promise<void>((resolve, reject) => {
-            const onDisconnect = () => {
-              reject(new Error(`Connection interrupted while trying to connect`));
-            };
-            this.provider.once(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
-            createExpiringPromise(
-              this.provider.connect(),
-              this.connectTimeout,
-              `Socket stalled when trying to connect to ${this.relayUrl}`,
-            )
-              .then(() => resolve())
-              .catch(reject)
-              .finally(() => {
-                this.provider.off(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
-                clearTimeout(this.reconnectTimeout);
-              });
-          });
-
-          // Step B: re-subscribe (only reached if Step A resolved)
-          await new Promise<void>((resolve, reject) => {
-            const onDisconnect = () => {
-              reject(new Error(`Connection interrupted while trying to subscribe`));
-            };
-            this.provider.once(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
-            this.subscriber
-              .start()
-              .then(resolve)
-              .catch(reject)
-              .finally(() => {
-                this.provider.off(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
-              });
-          });
-
-          this.hasExperiencedNetworkDisruption = false;
-        } catch (e) {
-          await this.subscriber.stop();
-          const error = e as Error;
-          this.logger.warn({}, error.message);
-          this.hasExperiencedNetworkDisruption = true;
-        }
-
-        if (this.connected) {
-          this.logger.debug(
-            {},
-            `Connected to ${this.relayUrl} successfully on attempt: ${attempt}`,
-          );
+    while (attempt < 6) {
+      try {
+        if (this.transportExplicitlyClosed) {
           break;
         }
+        this.logger.debug({}, `Connecting to ${this.relayUrl}, attempt: ${attempt}...`);
+        await this.createProvider();
 
-        await new Promise((resolve) => setTimeout(resolve, toMiliseconds(attempt * 1)));
-        attempt++;
+        // Step A: establish WebSocket connection
+        await new Promise<void>((resolve, reject) => {
+          const onDisconnect = () => {
+            reject(new Error(`Connection interrupted while trying to connect`));
+          };
+          this.provider.once(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
+          createExpiringPromise(
+            this.provider.connect(),
+            this.connectTimeout,
+            `Socket stalled when trying to connect to ${this.relayUrl}`,
+          )
+            .then(() => resolve())
+            .catch(reject)
+            .finally(() => {
+              this.provider.off(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
+              clearTimeout(this.reconnectTimeout);
+            });
+        });
+
+        // Step B: re-subscribe (only reached if Step A resolved)
+        await new Promise<void>((resolve, reject) => {
+          const onDisconnect = () => {
+            reject(new Error(`Connection interrupted while trying to subscribe`));
+          };
+          this.provider.once(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
+          this.subscriber
+            .start()
+            .then(resolve)
+            .catch(reject)
+            .finally(() => {
+              this.provider.off(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
+            });
+        });
+
+        this.hasExperiencedNetworkDisruption = false;
+      } catch (e) {
+        await this.subscriber.stop();
+        const error = e as Error;
+        this.logger.warn({}, error.message);
+        this.hasExperiencedNetworkDisruption = true;
+      } finally {
+        this.connectionAttemptInProgress = false;
       }
-    } finally {
-      this.connectionAttemptInProgress = false;
-      // Step A's finally clears reconnectTimeout, so any timeout scheduled by
-      // onProviderDisconnect during the retry loop will never fire its callback
-      // that resets reconnectInProgress. Clean up the stale state here.
-      clearTimeout(this.reconnectTimeout);
-      this.reconnectTimeout = undefined;
-      this.reconnectInProgress = false;
+
+      if (this.connected) {
+        this.logger.debug(
+          {},
+          `Connected to ${this.relayUrl} successfully on attempt: ${attempt}`,
+        );
+        break;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, toMiliseconds(attempt * 1)));
+      attempt++;
     }
+    clearTimeout(this.reconnectTimeout);
+    this.reconnectTimeout = undefined;
+    this.reconnectInProgress = false;
   }
 
   /*

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -437,6 +437,12 @@ export class Relayer extends IRelayer {
       }
     } finally {
       this.connectionAttemptInProgress = false;
+      // Step A's finally clears reconnectTimeout, so any timeout scheduled by
+      // onProviderDisconnect during the retry loop will never fire its callback
+      // that resets reconnectInProgress. Clean up the stale state here.
+      clearTimeout(this.reconnectTimeout);
+      this.reconnectTimeout = undefined;
+      this.reconnectInProgress = false;
     }
   }
 

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -722,6 +722,6 @@ export class Relayer extends IRelayer {
       await this.connectPromise;
       return;
     }
-    await this.transportOpen();
+    await this.connect();
   }
 }

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -294,13 +294,8 @@ export class Relayer extends IRelayer {
       await this.connectPromise;
       this.logger.debug({}, `Existing connection attempt resolved`);
     } else {
-      this.connectPromise = new Promise(async (resolve, reject) => {
-        await this.connect(relayUrl)
-          .then(resolve)
-          .catch(reject)
-          .finally(() => {
-            this.connectPromise = undefined;
-          });
+      this.connectPromise = this.connect(relayUrl).finally(() => {
+        this.connectPromise = undefined;
       });
       await this.connectPromise;
     }
@@ -380,68 +375,72 @@ export class Relayer extends IRelayer {
     this.connectionAttemptInProgress = true;
     this.transportExplicitlyClosed = false;
     let attempt = 1;
-    while (attempt < 6) {
-      try {
-        if (this.transportExplicitlyClosed) {
-          break;
-        }
-        this.logger.debug({}, `Connecting to ${this.relayUrl}, attempt: ${attempt}...`);
-        // Always create new socket instance when trying to connect because if the socket was dropped due to `socket hang up` exception
-        // It wont be able to reconnect
-        await this.createProvider();
+    try {
+      while (attempt < 6) {
+        try {
+          if (this.transportExplicitlyClosed) {
+            break;
+          }
+          this.logger.debug({}, `Connecting to ${this.relayUrl}, attempt: ${attempt}...`);
+          await this.createProvider();
 
-        await new Promise<void>(async (resolve, reject) => {
-          const onDisconnect = () => {
-            reject(new Error(`Connection interrupted while trying to connect`));
-          };
-          this.provider.once(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
+          // Step A: establish WebSocket connection
+          await new Promise<void>((resolve, reject) => {
+            const onDisconnect = () => {
+              reject(new Error(`Connection interrupted while trying to connect`));
+            };
+            this.provider.once(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
+            createExpiringPromise(
+              new Promise((resolve, reject) => {
+                this.provider.connect().then(resolve).catch(reject);
+              }),
+              this.connectTimeout,
+              `Socket stalled when trying to connect to ${this.relayUrl}`,
+            )
+              .then(() => resolve())
+              .catch(reject)
+              .finally(() => {
+                this.provider.off(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
+                clearTimeout(this.reconnectTimeout);
+              });
+          });
 
-          await createExpiringPromise(
-            new Promise((resolve, reject) => {
-              this.provider.connect().then(resolve).catch(reject);
-            }),
-            this.connectTimeout,
-            `Socket stalled when trying to connect to ${this.relayUrl}`,
-          )
-            .catch((e) => {
-              reject(e);
-            })
-            .finally(() => {
-              this.provider.off(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
-              clearTimeout(this.reconnectTimeout);
-            });
-          await new Promise(async (_resolve, _reject) => {
+          // Step B: re-subscribe (only reached if Step A resolved)
+          await new Promise<void>((resolve, reject) => {
             const onDisconnect = () => {
               reject(new Error(`Connection interrupted while trying to subscribe`));
             };
             this.provider.once(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
-            await this.subscriber
+            this.subscriber
               .start()
-              .then(_resolve)
-              .catch(_reject)
+              .then(resolve)
+              .catch(reject)
               .finally(() => {
                 this.provider.off(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
               });
           });
+
           this.hasExperiencedNetworkDisruption = false;
-          resolve();
-        });
-      } catch (e) {
-        await this.subscriber.stop();
-        const error = e as Error;
-        this.logger.warn({}, error.message);
-        this.hasExperiencedNetworkDisruption = true;
-      } finally {
-        this.connectionAttemptInProgress = false;
-      }
+        } catch (e) {
+          await this.subscriber.stop();
+          const error = e as Error;
+          this.logger.warn({}, error.message);
+          this.hasExperiencedNetworkDisruption = true;
+        }
 
-      if (this.connected) {
-        this.logger.debug({}, `Connected to ${this.relayUrl} successfully on attempt: ${attempt}`);
-        break;
-      }
+        if (this.connected) {
+          this.logger.debug(
+            {},
+            `Connected to ${this.relayUrl} successfully on attempt: ${attempt}`,
+          );
+          break;
+        }
 
-      await new Promise((resolve) => setTimeout(resolve, toMiliseconds(attempt * 1)));
-      attempt++;
+        await new Promise((resolve) => setTimeout(resolve, toMiliseconds(attempt * 1)));
+        attempt++;
+      }
+    } finally {
+      this.connectionAttemptInProgress = false;
     }
   }
 
@@ -485,6 +484,11 @@ export class Relayer extends IRelayer {
   private async createProvider() {
     if (this.provider.connection) {
       this.unregisterProviderListeners();
+      try {
+        await createExpiringPromise(this.provider.disconnect(), 1000, "Closing previous provider");
+      } catch {
+        // best-effort cleanup of old socket
+      }
     }
     const auth = await this.core.crypto.signJWT(this.relayUrl);
 
@@ -690,8 +694,10 @@ export class Relayer extends IRelayer {
     this.reconnectInProgress = true;
     await this.subscriber.stop();
 
-    if (!this.subscriber.hasAnyTopics) return;
-    if (this.transportExplicitlyClosed) return;
+    if (!this.subscriber.hasAnyTopics || this.transportExplicitlyClosed) {
+      this.reconnectInProgress = false;
+      return;
+    }
 
     this.reconnectTimeout = setTimeout(async () => {
       await this.transportOpen().catch((error) =>
@@ -716,6 +722,6 @@ export class Relayer extends IRelayer {
       await this.connectPromise;
       return;
     }
-    await this.connect();
+    await this.transportOpen();
   }
 }

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -370,72 +370,77 @@ export class Relayer extends IRelayer {
       await this.transportDisconnect();
     }
 
-    this.connectionAttemptInProgress = true;
     this.transportExplicitlyClosed = false;
     let attempt = 1;
-    while (attempt < 6) {
-      try {
-        if (this.transportExplicitlyClosed) {
+    try {
+      while (attempt < 6) {
+        this.connectionAttemptInProgress = true;
+        try {
+          if (this.transportExplicitlyClosed) {
+            break;
+          }
+          this.logger.debug({}, `Connecting to ${this.relayUrl}, attempt: ${attempt}...`);
+          await this.createProvider();
+
+          // Step A: establish WebSocket connection
+          await new Promise<void>((resolve, reject) => {
+            const onDisconnect = () => {
+              reject(new Error(`Connection interrupted while trying to connect`));
+            };
+            this.provider.once(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
+            createExpiringPromise(
+              this.provider.connect(),
+              this.connectTimeout,
+              `Socket stalled when trying to connect to ${this.relayUrl}`,
+            )
+              .then(() => resolve())
+              .catch(reject)
+              .finally(() => {
+                this.provider.off(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
+                clearTimeout(this.reconnectTimeout);
+              });
+          });
+
+          // Step B: re-subscribe (only reached if Step A resolved)
+          await new Promise<void>((resolve, reject) => {
+            const onDisconnect = () => {
+              reject(new Error(`Connection interrupted while trying to subscribe`));
+            };
+            this.provider.once(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
+            this.subscriber
+              .start()
+              .then(resolve)
+              .catch(reject)
+              .finally(() => {
+                this.provider.off(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
+              });
+          });
+
+          this.hasExperiencedNetworkDisruption = false;
+        } catch (e) {
+          await this.subscriber.stop();
+          const error = e as Error;
+          this.logger.warn({}, error.message);
+          this.hasExperiencedNetworkDisruption = true;
+        }
+
+        if (this.connected) {
+          this.logger.debug(
+            {},
+            `Connected to ${this.relayUrl} successfully on attempt: ${attempt}`,
+          );
           break;
         }
-        this.logger.debug({}, `Connecting to ${this.relayUrl}, attempt: ${attempt}...`);
-        await this.createProvider();
 
-        // Step A: establish WebSocket connection
-        await new Promise<void>((resolve, reject) => {
-          const onDisconnect = () => {
-            reject(new Error(`Connection interrupted while trying to connect`));
-          };
-          this.provider.once(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
-          createExpiringPromise(
-            this.provider.connect(),
-            this.connectTimeout,
-            `Socket stalled when trying to connect to ${this.relayUrl}`,
-          )
-            .then(() => resolve())
-            .catch(reject)
-            .finally(() => {
-              this.provider.off(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
-              clearTimeout(this.reconnectTimeout);
-            });
-        });
-
-        // Step B: re-subscribe (only reached if Step A resolved)
-        await new Promise<void>((resolve, reject) => {
-          const onDisconnect = () => {
-            reject(new Error(`Connection interrupted while trying to subscribe`));
-          };
-          this.provider.once(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
-          this.subscriber
-            .start()
-            .then(resolve)
-            .catch(reject)
-            .finally(() => {
-              this.provider.off(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
-            });
-        });
-
-        this.hasExperiencedNetworkDisruption = false;
-      } catch (e) {
-        await this.subscriber.stop();
-        const error = e as Error;
-        this.logger.warn({}, error.message);
-        this.hasExperiencedNetworkDisruption = true;
-      } finally {
-        this.connectionAttemptInProgress = false;
+        await new Promise((resolve) => setTimeout(resolve, toMiliseconds(attempt * 1)));
+        attempt++;
       }
-
-      if (this.connected) {
-        this.logger.debug({}, `Connected to ${this.relayUrl} successfully on attempt: ${attempt}`);
-        break;
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, toMiliseconds(attempt * 1)));
-      attempt++;
+    } finally {
+      this.connectionAttemptInProgress = false;
+      clearTimeout(this.reconnectTimeout);
+      this.reconnectTimeout = undefined;
+      this.reconnectInProgress = false;
     }
-    clearTimeout(this.reconnectTimeout);
-    this.reconnectTimeout = undefined;
-    this.reconnectInProgress = false;
   }
 
   /*
@@ -586,6 +591,7 @@ export class Relayer extends IRelayer {
   private onConnectHandler = () => {
     this.logger.warn({}, "Relayer connected 🛜");
     this.startPingTimeout();
+    this.stalledRestartBackoff = 0;
     this.events.emit(RELAYER_EVENTS.connect);
   };
 
@@ -722,6 +728,9 @@ export class Relayer extends IRelayer {
       await this.connectPromise;
       return;
     }
-    await this.connect();
+    this.connectPromise = this.connect().finally(() => {
+      this.connectPromise = undefined;
+    });
+    await this.connectPromise;
   }
 }

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -113,8 +113,8 @@ export class Relayer extends IRelayer {
     this.subscriber = new Subscriber(this, this.logger);
     this.publisher = new Publisher(this, this.logger);
 
-    this.projectId = opts?.projectId;
-    this.relayUrl = opts?.relayUrl || RELAYER_DEFAULT_RELAY_URL;
+    this.projectId = opts.projectId;
+    this.relayUrl = opts.relayUrl || RELAYER_DEFAULT_RELAY_URL;
 
     if (isAndroid()) {
       this.packageName = getAppId();
@@ -141,15 +141,14 @@ export class Relayer extends IRelayer {
 
   get connected() {
     // @ts-expect-error
-    return this.provider?.connection?.socket?.readyState === 1 || false;
+    return this.provider?.connection?.socket?.readyState === 1;
   }
 
   get connecting() {
     return (
       // @ts-expect-error
       this.provider?.connection?.socket?.readyState === 0 ||
-      this.connectPromise !== undefined ||
-      false
+      this.connectPromise !== undefined
     );
   }
 
@@ -178,11 +177,7 @@ export class Relayer extends IRelayer {
     if (!opts?.transportType || opts?.transportType === "relay") {
       await this.toEstablishConnection();
     }
-    // throw unless explicitly set to false
-    const shouldThrowOnFailure =
-      typeof opts?.internal?.throwOnFailedPublish === "undefined"
-        ? true
-        : opts?.internal?.throwOnFailedPublish;
+    const shouldThrowOnFailure = opts?.internal?.throwOnFailedPublish ?? true;
 
     let id = this.subscriber.topicMap.get(topic)?.[0] || "";
     let resolvePromise: () => void;
@@ -395,9 +390,7 @@ export class Relayer extends IRelayer {
             };
             this.provider.once(RELAYER_PROVIDER_EVENTS.disconnect, onDisconnect);
             createExpiringPromise(
-              new Promise((resolve, reject) => {
-                this.provider.connect().then(resolve).catch(reject);
-              }),
+              this.provider.connect(),
               this.connectTimeout,
               `Socket stalled when trying to connect to ${this.relayUrl}`,
             )
@@ -459,12 +452,9 @@ export class Relayer extends IRelayer {
     if (!isNode()) return;
     try {
       //@ts-expect-error - Types are divergent between the node and browser WS API
-      if (this.provider?.connection?.socket) {
-        //@ts-expect-error
-        this.provider?.connection?.socket?.on("ping", () => {
-          this.resetPingTimeout();
-        });
-      }
+      this.provider?.connection?.socket?.on("ping", () => {
+        this.resetPingTimeout();
+      });
       this.resetPingTimeout();
     } catch (e) {
       this.logger.warn(e, (e as Error)?.message);
@@ -488,10 +478,16 @@ export class Relayer extends IRelayer {
   private async createProvider() {
     if (this.provider.connection) {
       this.unregisterProviderListeners();
-      try {
-        await createExpiringPromise(this.provider.disconnect(), 1000, "Closing previous provider");
-      } catch {
-        // best-effort cleanup of old socket
+      if (this.connected) {
+        try {
+          await createExpiringPromise(
+            this.provider.disconnect(),
+            1000,
+            "Closing previous provider",
+          );
+        } catch {
+          // best-effort cleanup of old socket
+        }
       }
     }
     const auth = await this.core.crypto.signJWT(this.relayUrl);

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -609,10 +609,20 @@ describe("Relayer", () => {
         });
         await relayer.transportOpen().catch((e) => {});
         await throttle(1000);
-        console.log("first check time taken", connectReceived, errorReceived, Date.now() - timer);
         if (!connectReceived || !errorReceived) {
+          console.warn(
+            "first check time taken",
+            connectReceived,
+            errorReceived,
+            Date.now() - timer,
+          );
           await throttle(1000);
-          console.log("second check time taken", Date.now() - timer);
+          console.warn(
+            "second check time taken",
+            connectReceived,
+            errorReceived,
+            Date.now() - timer,
+          );
         }
         expect(connectReceived).to.be.true;
         expect(errorReceived).to.be.true;
@@ -739,6 +749,11 @@ describe("Relayer", () => {
       });
       await relayer.transportOpen();
     });
+    afterEach(async () => {
+      // @ts-expect-error - private property
+      clearTimeout(relayer.reconnectTimeout);
+      await disconnectSocket(relayer);
+    });
 
     it("should reset reconnectInProgress when no topics exist on disconnect", async () => {
       // #given - clear all topics so onProviderDisconnect hits the early return
@@ -813,9 +828,6 @@ describe("Relayer", () => {
 
     it("should block restartTransport during active connection attempts", async () => {
       // #given
-      const restartSpy = vi.fn();
-      const originalRestart = relayer.restartTransport.bind(relayer);
-
       await relayer.transportOpen();
       expect(relayer.connected).to.be.true;
 

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -716,6 +716,113 @@ describe("Relayer", () => {
     },
   );
 
+  describe("reconnectInProgress guard", () => {
+    beforeEach(async () => {
+      core = new Core(TEST_CORE_OPTIONS);
+      relayer = core.relayer;
+      await core.start();
+      relayer.subscriber.subscriptions.set(randomTopic, {
+        topic: randomTopic,
+        id: randomTopic,
+        relay: { protocol: "irn" },
+      });
+      await relayer.transportOpen();
+    });
+
+    it("should reset reconnectInProgress when no topics exist on disconnect", async () => {
+      // #given - clear all topics so onProviderDisconnect hits the early return
+      expect(relayer.connected).to.be.true;
+      relayer.subscriber.subscriptions.clear();
+      relayer.subscriber.topicMap.clear();
+      relayer.subscriber.pending.clear();
+
+      // #when
+      // @ts-expect-error - private method
+      await relayer.onProviderDisconnect();
+
+      // #then - flag must be reset to allow future reconnection
+      // @ts-expect-error - private property
+      expect(relayer.reconnectInProgress).to.be.false;
+    });
+
+    it("should reset reconnectInProgress when transportExplicitlyClosed on disconnect", async () => {
+      // #given
+      expect(relayer.connected).to.be.true;
+      relayer.transportExplicitlyClosed = true;
+
+      // #when
+      // @ts-expect-error - private method
+      await relayer.onProviderDisconnect();
+
+      // #then
+      // @ts-expect-error - private property
+      expect(relayer.reconnectInProgress).to.be.false;
+    });
+
+    it("should allow reconnection after early return from onProviderDisconnect", async () => {
+      // #given - trigger early return (no topics)
+      relayer.subscriber.subscriptions.clear();
+      relayer.subscriber.topicMap.clear();
+      relayer.subscriber.pending.clear();
+      // @ts-expect-error - private method
+      await relayer.onProviderDisconnect();
+      // @ts-expect-error - private property
+      expect(relayer.reconnectInProgress).to.be.false;
+
+      // #when - re-add topics and trigger another disconnect
+      relayer.subscriber.subscriptions.set(randomTopic, {
+        topic: randomTopic,
+        id: randomTopic,
+        relay: { protocol: "irn" },
+      });
+      // @ts-expect-error - private method
+      await relayer.onProviderDisconnect();
+
+      // #then - should NOT be blocked by a stuck flag — reconnect timeout should be scheduled
+      // @ts-expect-error - private property
+      expect(relayer.reconnectTimeout).to.not.be.undefined;
+      // @ts-expect-error - private property
+      expect(relayer.reconnectInProgress).to.be.true;
+
+      await relayer.transportClose();
+    });
+  });
+
+  describe("connectionAttemptInProgress guard", () => {
+    beforeEach(async () => {
+      core = new Core(TEST_CORE_OPTIONS);
+      relayer = core.relayer;
+      await core.start();
+      relayer.subscriber.subscriptions.set(randomTopic, {
+        topic: randomTopic,
+        id: randomTopic,
+        relay: { protocol: "irn" },
+      });
+    });
+
+    it("should block restartTransport during active connection attempts", async () => {
+      // #given
+      const restartSpy = vi.fn();
+      const originalRestart = relayer.restartTransport.bind(relayer);
+
+      await relayer.transportOpen();
+      expect(relayer.connected).to.be.true;
+
+      // #when - simulate connectionAttemptInProgress being true
+      // @ts-expect-error - private property
+      relayer.connectionAttemptInProgress = true;
+
+      // #then - restartTransport should return early
+      await relayer.restartTransport();
+      // If restartTransport didn't return early, it would have disconnected us
+      expect(relayer.connected).to.be.true;
+
+      // @ts-expect-error - private property
+      relayer.connectionAttemptInProgress = false;
+      await relayer.transportClose();
+    });
+  });
+
   describe("connection_stalled", () => {
     let restartStub: Sinon.SinonStub;
 

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -925,6 +925,36 @@ describe("Relayer", () => {
       expect(restartStub.callCount).to.equal(2);
     });
 
+    it("should not spawn runaway concurrent connect calls on repeated failures", async () => {
+      restartStub.restore();
+
+      // #given - stub signJWT to track how many times createProvider is called
+      const signJWTSpy = Sinon.spy(core.crypto, "signJWT");
+
+      // make provider.connect() always fail so every attempt in the retry loop fails
+      const originalCreateProvider = (relayer as any).createProvider.bind(relayer);
+      const createProviderStub = Sinon.stub(relayer as any, "createProvider").callsFake(
+        async function (this: any) {
+          await originalCreateProvider.call(this);
+          Sinon.stub(relayer.provider, "connect").rejects(new Error("simulated network failure"));
+        },
+      );
+
+      // #when - trigger a connection attempt that will fail all 5 retries
+      await relayer.transportOpen().catch(() => {});
+
+      // wait long enough for any stalled restart / heartbeat to fire
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+
+      // #then - signJWT should be called at most 5 times (one per retry attempt),
+      // NOT exponentially growing (25, 125, etc.)
+      expect(signJWTSpy.callCount).to.be.lessThanOrEqual(5);
+
+      signJWTSpy.restore();
+      createProviderStub.restore();
+      await relayer.transportClose();
+    });
+
     it("should reset backoff after explicit transportClose", async () => {
       // #given - trigger first stalled restart (immediate, backoff goes 0 → 1)
       relayer.events.emit(RELAYER_EVENTS.connection_stalled);

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -598,12 +598,23 @@ describe("Relayer", () => {
         });
 
         let errorReceived = false;
+        let connectReceived = false;
+        const timer = Date.now();
         relayer.on(RELAYER_EVENTS.error, (payload) => {
           expect(payload.message).to.include("Unauthorized: origin not allowed");
           errorReceived = true;
         });
+        relayer.on(RELAYER_EVENTS.connect, () => {
+          connectReceived = true;
+        });
         await relayer.transportOpen().catch((e) => {});
         await throttle(1000);
+        console.log("first check time taken", connectReceived, errorReceived, Date.now() - timer);
+        if (!connectReceived || !errorReceived) {
+          await throttle(1000);
+          console.log("second check time taken", Date.now() - timer);
+        }
+        expect(connectReceived).to.be.true;
         expect(errorReceived).to.be.true;
       });
 

--- a/packages/core/test/relayer.spec.ts
+++ b/packages/core/test/relayer.spec.ts
@@ -909,20 +909,20 @@ describe("Relayer", () => {
       expect(restartStub.callCount).to.equal(2);
     });
 
-    it("should NOT reset backoff on successful connection", async () => {
+    it("should reset backoff on successful connection", async () => {
       // #given - trigger first stalled restart (immediate, backoff goes 0 → 1)
       relayer.events.emit(RELAYER_EVENTS.connection_stalled);
       await new Promise((resolve) => setTimeout(resolve, 50));
       expect(restartStub.callCount).to.equal(1);
 
-      // #when - simulate successful connection
+      // #when - simulate successful connection (resets backoff to 0)
       // @ts-expect-error - private method
       relayer.onConnectHandler();
 
-      // #then - next stalled event should NOT be immediate (backoff=1 → 2s delay)
+      // #then - next stalled event should be immediate again (backoff reset to 0)
       relayer.events.emit(RELAYER_EVENTS.connection_stalled);
       await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(restartStub.callCount).to.equal(1);
+      expect(restartStub.callCount).to.equal(2);
     });
 
     it("should reset backoff after explicit transportClose", async () => {

--- a/packages/pay/src/constants/client.ts
+++ b/packages/pay/src/constants/client.ts
@@ -9,7 +9,7 @@ export const PAY_API_BASE_URL = "https://api.pay.walletconnect.com";
 export const SDK_NAME = "js-walletconnect-pay";
 
 /** SDK version (from package.json) */
-export const SDK_VERSION = `1.0.2`;
+export const SDK_VERSION = `1.0.7`;
 
 /** Client context name */
 export const CLIENT_CONTEXT = "pay";


### PR DESCRIPTION
## Summary

Fixes #7131 — Infinite loop when reconnecting causes memory exhaustion.

When the network is unreachable but `isOnline()` returns `true` (e.g. WiFi connected but broadband down, or Brave blocking the API), multiple interacting bugs in the relayer's `connect()` method combine to create **exponential growth** of concurrent connection attempts (5 → 25 → 125 → 625+), each calling the expensive `signJWT()`, until the browser tab exceeds 4GB and millions of event listeners accumulate.

### Root causes fixed

- **`new Promise(async executor)` antipattern** — After `reject()`, `.catch()` swallows the error and execution continues to `subscriber.start()`, which runs as an unsupervised background task that eventually triggers more `connect()` calls via `connection_stalled`
- **`connectionAttemptInProgress` reset inside retry loop** — The `finally` block reset the guard on every iteration instead of after the loop, allowing `restartTransport()` to spawn concurrent `connect()` calls during the sleep between retries
- **`reconnectInProgress` stuck forever** — Early returns in `onProviderDisconnect()` (no topics / transport closed) exited without resetting the flag, permanently blocking all future automatic reconnection
- **WebSocket leak in `createProvider()`** — Old provider connections were never closed before creating new ones, leaking a WebSocket + 4 event listeners per retry attempt
- **`toEstablishConnection()` bypassed serialization** — Called `connect()` directly instead of going through `transportOpen()` which has the `connectPromise` guard, enabling concurrent unserialized connections from subscriber internals

```mermaid
flowchart TD
    A[connect attempt fails] -->|"Bug 1: async executor"| B[subscriber.start runs in background]
    B --> C[subscriber request fails]
    C --> D[emits connection_stalled]
    D -->|"Bug 2: guard reset"| E[restartTransport passes guard]
    E --> F[new connect call spawned]
    F --> A
    A -->|"Bug 4: WS leak"| G[old socket leaked]
    F -->|"Bug 5: no serialization"| H[concurrent connect calls]
    
    style A fill:#ff6b6b
    style F fill:#ff6b6b
    style H fill:#ff6b6b
```

### Changes

| Fix | File | Description |
|-----|------|-------------|
| 1 | `relayer.ts` | Split nested async executor into two sequential properly-constructed promises |
| 1b | `relayer.ts` | Cleaned up `transportOpen()` — removed unnecessary `new Promise(async ...)` wrapper |
| 2 | `relayer.ts` | Moved `connectionAttemptInProgress = false` to outer `finally` after the while loop |
| 3 | `relayer.ts` | Reset `reconnectInProgress` before early returns in `onProviderDisconnect()` |
| 4 | `relayer.ts` | Close old provider connection in `createProvider()` before creating new one |
| 5 | `relayer.ts` | Route `toEstablishConnection()` through `transportOpen()` for `connectPromise` serialization |

### Tests added

- `reconnectInProgress` resets when no topics exist on disconnect
- `reconnectInProgress` resets when transport is explicitly closed
- Reconnection still works after early return from `onProviderDisconnect`
- `restartTransport` is blocked during active connection attempts

## Test plan

- [ ] Existing relayer tests pass
- [ ] New guard tests verify the concurrency fixes
- [ ] Manual test: background tab + network interruption no longer causes memory exhaustion
- [ ] Manual test: reconnection still works correctly after network recovery


Made with [Cursor](https://cursor.com)