### PR TITLE
fix(ethereum-provider): validate projectId on init

### DIFF
--- a/.changeset/ethereum-provider-projectid-validation.md
+++ b/.changeset/ethereum-provider-projectid-validation.md
@@ -1,0 +1,5 @@
+---
+@walletconnect/ethereum-provider: patch
+---
+
+Added projectId validation to EthereumProvider.init(). The provider now throws a descriptive error immediately if projectId is empty, null, or contains only whitespace, preventing silent failures at runtime when the QR modal fails to appear due to missing credentials.

--- a/providers/ethereum-provider/src/EthereumProvider.ts
+++ b/providers/ethereum-provider/src/EthereumProvider.ts
@@ -247,6 +247,11 @@ export class EthereumProvider implements IEthereumProvider {
   }
 
   static async init(opts: EthereumProviderOptions): Promise<EthereumProvider> {
+    if (!opts.projectId?.trim()) {
+      throw new Error(
+        "projectId is required and cannot be empty or whitespace. Get one at https://cloud.walletconnect.com/"
+      );
+    }
     const provider = new EthereumProvider();
     await provider.initialize(opts);
     return provider;

--- a/providers/ethereum-provider/test/index.spec.ts
+++ b/providers/ethereum-provider/test/index.spec.ts
@@ -692,4 +692,44 @@ describe("EthereumProvider", function () {
       provider.signer.session.namespaces.eip155.accounts = cachedAccounts;
     });
   });
+
+  describe("projectId validation", function () {
+    it("should throw when projectId is empty string", async () => {
+      try {
+        await EthereumProvider.init({
+          projectId: "",
+          chains: [1],
+          showQrModal: false,
+          metadata: TEST_APP_METADATA_A,
+        });
+        throw new Error("Expected EthereumProvider.init to throw");
+      } catch (error: any) {
+        expect(error.message).toContain("projectId is required");
+      }
+    });
+
+    it("should throw when projectId is whitespace only", async () => {
+      try {
+        await EthereumProvider.init({
+          projectId: "   ",
+          chains: [1],
+          showQrModal: false,
+          metadata: TEST_APP_METADATA_A,
+        });
+        throw new Error("Expected EthereumProvider.init to throw");
+      } catch (error: any) {
+        expect(error.message).toContain("projectId is required");
+      }
+    });
+
+    it("should not throw when projectId is valid", async () => {
+      const validProvider = await EthereumProvider.init({
+        projectId: "test-project-id-123",
+        chains: [1],
+        showQrModal: false,
+        metadata: TEST_APP_METADATA_A,
+      });
+      expect(validProvider).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Apps that misconfigure projectId as an empty string or whitespace fail silently. The QR modal never appears, with no error message. This PR adds early validation in EthereumProvider.init() to throw a descriptive error immediately, pointing developers to cloud.walletconnect.com to get a projectId.

## Changes

- Validate projectId in EthereumProvider.static init() — throw if empty, null, or whitespace-only
- Add test cases for empty string, whitespace, and valid projectId
- Add changeset for patch version bump

## Why

The silent failure mode is confusing to debug. A developer misconfigures the env var, the QR modal doesn't show, and they spend 30 minutes wondering why without any error in the console. This change catches the mistake at init time with clear guidance.