### PR TITLE
fix: strip bare TextEncoder/TextDecoder side-effect from bundles

### DIFF
--- a/.changeset/strip-bare-text-codecs.md
+++ b/.changeset/strip-bare-text-codecs.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/core": patch
+---
+
+Strip bare `new TextEncoder,new TextDecoder;` side-effect from UMD bundles that crashed React Native / Hermes on import

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,6 +29,18 @@ const browserFieldOverrides = {
   },
 };
 
+// Strip bare `new TextEncoder,new TextDecoder;` side-effect expressions that
+// originate from multiformats (transitive dep of uint8arrays) after minification.
+// These crash React Native / Hermes where TextDecoder is not a native global.
+// See: https://github.com/WalletConnect/walletconnect-monorepo/issues/7214
+const stripBareTextCodecs = {
+  name: "strip-bare-text-codecs",
+  renderChunk(code) {
+    const stripped = code.replace(/new TextEncoder,new TextDecoder;?/g, "");
+    return stripped !== code ? { code: stripped, map: null } : null;
+  },
+};
+
 export const plugins = [
   browserFieldOverrides,
   nodeResolve({ preferBuiltins: false, browser: true, exportConditions: ["browser"] }),
@@ -41,6 +53,7 @@ export const plugins = [
       ".json": "json",
     },
   }),
+  stripBareTextCodecs,
   visualizer(),
 ];
 


### PR DESCRIPTION
## Summary

- Adds a Rollup `renderChunk` plugin (`stripBareTextCodecs`) that removes bare `new TextEncoder,new TextDecoder;` side-effect expressions from built output
- These expressions originate from `multiformats` (transitive dep of `uint8arrays`) after minification and crash React Native / Hermes where `TextDecoder` is not a native global
- All functional usages like `new TextEncoder().encode(t)` are preserved — only the no-op bare constructor calls are stripped

Closes #7214

## Test plan

- [x] Rebuilt `packages/core` — zero occurrences of `new TextEncoder,new TextDecoder` in all dist files (UMD, CJS, ESM)
- [x] Rebuilt `packages/utils` — zero occurrences in all dist files
- [x] Smoke-tested CJS, ESM, and UMD builds of core — all load correctly with full exports
- [x] Verified functional `new TextEncoder().encode()` / `new TextDecoder().decode()` calls remain intact in UMD bundle


Made with [Cursor](https://cursor.com)