### PR TITLE
fix: reject SIWE statements containing line breaks per EIP-4361

### DIFF
--- a/.changeset/reject-statement-line-breaks.md
+++ b/.changeset/reject-statement-line-breaks.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/utils": patch
+---
+
+Reject SIWE/CAIP-122 statements containing line breaks in `formatMessage`. Per EIP-4361 the statement is a single line, and embedded `\r`/`\n` could forge other fields (URI, Nonce, etc.) in the signed message.

--- a/.changeset/reject-statement-line-breaks.md
+++ b/.changeset/reject-statement-line-breaks.md
@@ -2,4 +2,4 @@
 "@walletconnect/utils": patch
 ---
 
-Reject SIWE/CAIP-122 statements containing line breaks in `formatMessage`. Per EIP-4361 the statement is a single line, and embedded `\r`/`\n` could forge other fields (URI, Nonce, etc.) in the signed message.
+Reject SIWE/CAIP-122 statements containing line breaks in `formatMessage`. Per EIP-4361 the statement is a single line, and embedded `\r`/`\n` (from a caller-supplied statement or untrusted recap-derived text) could forge other fields (URI, Nonce, etc.) in the signed message. The check runs on the final statement after recap formatting, and `validateSignedCacao` now returns `false` for such malformed payloads instead of throwing.

--- a/packages/utils/src/cacao.ts
+++ b/packages/utils/src/cacao.ts
@@ -53,7 +53,15 @@ export const getDidAddress = (iss: string) => {
 export async function validateSignedCacao(params: { cacao: AuthTypes.Cacao; projectId?: string }) {
   const { cacao, projectId } = params;
   const { s: signature, p: payload } = cacao;
-  const reconstructed = formatMessage(payload, payload.iss);
+  let reconstructed: string;
+  try {
+    // A malformed payload (e.g. a statement with line breaks) makes the message
+    // impossible to reconstruct — treat it as invalid rather than throwing, since
+    // the public contract of `validateSignedCacao` is a boolean validity check.
+    reconstructed = formatMessage(payload, payload.iss);
+  } catch (error) {
+    return false;
+  }
   const walletAddress = getDidAddress(payload.iss) as string;
   const isValid = await verifySignature(
     walletAddress,
@@ -79,11 +87,6 @@ export const formatMessage = (cacao: AuthTypes.FormatMessageParams, iss: string)
   }
 
   let statement = cacao.statement || undefined;
-  // Per EIP-4361 the statement is a single line and must not contain line breaks.
-  // Reject embedded newlines to prevent forging other fields (URI, Nonce, etc.) in the signed message.
-  if (statement && /\r|\n/.test(statement)) {
-    throw new Error("Statement must not contain line breaks (`\\r` or `\\n`)");
-  }
   const uri = `URI: ${cacao.aud || cacao.uri}`;
   const version = `Version: ${cacao.version}`;
   const chainId = `Chain ID: ${getDidChainId(iss)}`;
@@ -99,6 +102,14 @@ export const formatMessage = (cacao: AuthTypes.FormatMessageParams, iss: string)
   if (recap) {
     const decoded = decodeRecap(recap);
     statement = formatStatementFromRecap(statement, decoded);
+  }
+
+  // Per EIP-4361 the statement is a single line and must not contain line breaks.
+  // Validate the final statement (after recap formatting) so that neither a caller-supplied
+  // statement nor untrusted recap-derived text can forge other fields (URI, Nonce, etc.) in
+  // the signed message via embedded `\r`/`\n`.
+  if (statement && /\r|\n/.test(statement)) {
+    throw new Error("Statement must not contain line breaks (`\\r` or `\\n`)");
   }
 
   const message = [

--- a/packages/utils/src/cacao.ts
+++ b/packages/utils/src/cacao.ts
@@ -79,6 +79,11 @@ export const formatMessage = (cacao: AuthTypes.FormatMessageParams, iss: string)
   }
 
   let statement = cacao.statement || undefined;
+  // Per EIP-4361 the statement is a single line and must not contain line breaks.
+  // Reject embedded newlines to prevent forging other fields (URI, Nonce, etc.) in the signed message.
+  if (statement && /\r|\n/.test(statement)) {
+    throw new Error("Statement must not contain line breaks (`\\r` or `\\n`)");
+  }
   const uri = `URI: ${cacao.aud || cacao.uri}`;
   const version = `Version: ${cacao.version}`;
   const chainId = `Chain ID: ${getDidChainId(iss)}`;

--- a/packages/utils/test/cacao.spec.ts
+++ b/packages/utils/test/cacao.spec.ts
@@ -13,6 +13,7 @@ import {
   mergeRecaps,
   populateAuthPayload,
   mergeEncodedRecaps,
+  validateSignedCacao,
 } from "../src";
 
 describe("URI", () => {
@@ -279,6 +280,49 @@ describe("URI", () => {
     expect(formatMessage({ ...baseRequest, statement: "I accept the terms" }, iss)).to.include(
       "I accept the terms",
     );
+  });
+
+  it("should reject recap-derived statements containing line breaks", () => {
+    const iss = "did:pkh:eip155:1:0x3613699A6c5D8BC97a08805876c8005543125F09";
+    // recap content is untrusted: a malicious resource name with a newline must not be
+    // able to smuggle forged fields into the statement via formatStatementFromRecap.
+    const maliciousRecap = {
+      att: {
+        "eip155\nURI: https://evil.com": { "request/personal_sign": [{}] },
+      },
+    };
+    const request = {
+      type: "caip122",
+      aud: "https://app.web3inbox.com/login",
+      domain: "app.web3inbox",
+      version: "1",
+      nonce: "32891756",
+      iat: "2024-03-13T09:00:43.888Z",
+      resources: [encodeRecap(maliciousRecap)],
+    };
+
+    expect(() => formatMessage(request, iss)).to.throw("Statement must not contain line breaks");
+  });
+
+  it("should return false from validateSignedCacao for statements with line breaks", async () => {
+    // formatMessage throws for malformed statements; validateSignedCacao must remap that to
+    // a boolean `false` rather than propagating the exception to callers.
+    const cacao = {
+      h: { t: "caip122" },
+      p: {
+        iss: "did:pkh:eip155:1:0x3613699A6c5D8BC97a08805876c8005543125F09",
+        domain: "app.web3inbox",
+        aud: "https://app.web3inbox.com/login",
+        version: "1",
+        nonce: "32891756",
+        iat: "2024-03-13T09:00:43.888Z",
+        statement: "I accept\nURI: https://evil.com",
+      },
+      s: { t: "eip191" as const, s: "0x" },
+    };
+
+    const isValid = await validateSignedCacao({ cacao });
+    expect(isValid).to.eql(false);
   });
 
   describe("encodeRecap / decodeRecap with unpadded base64", () => {

--- a/packages/utils/test/cacao.spec.ts
+++ b/packages/utils/test/cacao.spec.ts
@@ -254,6 +254,33 @@ describe("URI", () => {
     expect(message).to.include("Nonce: 32891756");
     expect(message).to.include(`URI: ${request.aud}`);
   });
+
+  it("should reject statements containing line breaks (EIP-4361)", () => {
+    const baseRequest = {
+      type: "caip122",
+      aud: "https://app.web3inbox.com/login",
+      domain: "app.web3inbox",
+      version: "1",
+      nonce: "32891756",
+      iat: "2024-03-13T09:00:43.888Z",
+    };
+    const iss = "did:pkh:eip155:1:0x3613699A6c5D8BC97a08805876c8005543125F09";
+
+    // a statement smuggling extra SIWE fields via newlines must be rejected
+    expect(() =>
+      formatMessage({ ...baseRequest, statement: "I accept\nURI: https://evil.com" }, iss),
+    ).to.throw("Statement must not contain line breaks");
+
+    expect(() =>
+      formatMessage({ ...baseRequest, statement: "I accept\r\nthe terms" }, iss),
+    ).to.throw("Statement must not contain line breaks");
+
+    // a well-formed single-line statement is still accepted
+    expect(formatMessage({ ...baseRequest, statement: "I accept the terms" }, iss)).to.include(
+      "I accept the terms",
+    );
+  });
+
   describe("encodeRecap / decodeRecap with unpadded base64", () => {
     it("should roundtrip recap whose base64 requires padding", () => {
       // #given - a recap whose JSON length produces base64 needing padding (length % 4 !== 0)


### PR DESCRIPTION
## Summary

`formatMessage` in `packages/utils/src/cacao.ts` builds the SIWE/CAIP-122 message by placing the `statement` between the wallet-address block and the `URI:`/`Version:`/`Chain ID:`/`Nonce:`/… fields, then joining the whole array with `\n`. Per [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) the `statement` is a single line (ABNF: `reserved / unreserved / " "`), but `cacao.statement` was never validated for line breaks.

A statement containing `\r`/`\n` could therefore **forge additional SIWE fields** in the message that gets signed/verified.

### The vector

```
statement: "I accept\nURI: https://evil.com\nNonce: attacker"
```

…would inject forged `URI:`/`Nonce:` lines directly into the signed message.

### Fix

Guard added right after reading `cacao.statement`, before any field assembly — throws if the statement contains `\r` or `\n`.

```mermaid
flowchart TD
    A[cacao.statement] --> B{contains \r or \n?}
    B -- yes --> C[throw Error]
    B -- no --> D[assemble message lines]
    D --> E[join with \n -> signed message]
```

## Changes
- `packages/utils/src/cacao.ts` — reject line breaks in statement
- `packages/utils/test/cacao.spec.ts` — tests for `\n`, `\r\n` injection + valid single-line statement
- changeset (`@walletconnect/utils` patch)

## Test plan
- [x] `npx vitest run --dir test cacao` in `packages/utils` — 21/21 pass

## Note for reviewers
`validateSignedCacao` reconstructs the message via `formatMessage` to verify signatures, so an already-stored cacao with a newline statement will now **throw** during verification rather than returning `false`. That's the safe outcome (such a cacao should never have been signed), but happy to wrap the call site to fail gracefully instead if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)