### PR TITLE
chore: updates pos tests transaction hashes

### DIFF
--- a/packages/pos-client/test/pos-persistence.spec.ts
+++ b/packages/pos-client/test/pos-persistence.spec.ts
@@ -31,6 +31,7 @@ describe("Sign Integration", () => {
   });
 
   it("should reuse existing session to send multiple payments", async () => {
+    process.env.DISABLE_GLOBAL_CORE = "true";
     const databaseName = generateDatabaseName();
     const pos = await POSClient.init({
       projectId,
@@ -111,7 +112,7 @@ describe("Sign Integration", () => {
         topic: sessionRequest.topic,
         response: formatJsonRpcResult(
           sessionRequest.id,
-          "0xff16b7197277088039a45f9e23ccbb32077ebeec1e56e49b24b2f3731e1bd452",
+          "0xc9458ca3b8450ad966cc8049caf6e163b7473d03f105143f47244ec7350142d3",
         ),
       });
     };

--- a/packages/pos-client/test/pos.spec.ts
+++ b/packages/pos-client/test/pos.spec.ts
@@ -319,7 +319,7 @@ describe("Sign Integration", () => {
           topic: sessionRequest.topic,
           response: formatJsonRpcResult(
             sessionRequest.id,
-            "0xff16b7197277088039a45f9e23ccbb32077ebeec1e56e49b24b2f3731e1bd452",
+            "0xc9458ca3b8450ad966cc8049caf6e163b7473d03f105143f47244ec7350142d3",
           ),
         });
         resolve();
@@ -450,7 +450,7 @@ describe("Sign Integration", () => {
               topic: sessionRequest.topic,
               response: formatJsonRpcResult(
                 sessionRequest.id,
-                "0xff16b7197277088039a45f9e23ccbb32077ebeec1e56e49b24b2f3731e1bd452",
+                "0xc9458ca3b8450ad966cc8049caf6e163b7473d03f105143f47244ec7350142d3",
               ),
             });
           } else if (sessionRequest.params.chainId === solanaChainId) {
@@ -508,7 +508,7 @@ describe("Sign Integration", () => {
     expect(numPaymentSuccessful).to.be.equal(paymentIntents.length);
     expect(numPaymentRequested).to.be.equal(paymentIntents.length);
     expect(numPaymentBroadcasted).to.be.equal(paymentIntents.length);
-  });
+  }, 90_000);
 
   it("should set tokens", async () => {
     const networks: Record<string, POSClientTypes.Network> = {
@@ -604,7 +604,7 @@ describe("Sign Integration", () => {
             topic: sessionRequest.topic,
             response: formatJsonRpcResult(
               sessionRequest.id,
-              "0xff16b7197277088039a45f9e23ccbb32077ebeec1e56e49b24b2f3731e1bd452",
+              "0xc9458ca3b8450ad966cc8049caf6e163b7473d03f105143f47244ec7350142d3",
             ),
           });
           resolve();
@@ -731,7 +731,7 @@ describe("Sign Integration", () => {
         topic: sessionRequest.topic,
         response: formatJsonRpcResult(
           sessionRequest.id,
-          "0xff16b7197277088039a45f9e23ccbb32077ebeec1e56e49b24b2f3731e1bd452",
+          "0xc9458ca3b8450ad966cc8049caf6e163b7473d03f105143f47244ec7350142d3",
         ),
       });
     });
@@ -887,7 +887,7 @@ describe("Sign Integration", () => {
             topic: sessionRequest.topic,
             response: formatJsonRpcResult(
               sessionRequest.id,
-              "0xff16b7197277088039a45f9e23ccbb32077ebeec1e56e49b24b2f3731e1bd452",
+              "0xc9458ca3b8450ad966cc8049caf6e163b7473d03f105143f47244ec7350142d3",
             ),
           });
           resolve();


### PR DESCRIPTION
Updated `POS` tests with recent tx hashes as the previous used were 6 months old resulting in timeouts