### PR TITLE
chore: deprecate authenticate method on sign-client

### DIFF
--- a/.changeset/deprecate-authenticate.md
+++ b/.changeset/deprecate-authenticate.md
@@ -1,0 +1,6 @@
+---
+"@walletconnect/sign-client": patch
+"@walletconnect/types": patch
+---
+
+Deprecate the `authenticate` method on Sign Client. It is marked `@deprecated` in the type definitions and logs a runtime warning when called. Use `connect()`'s `authentication` parameter instead to establish an authenticated session.

--- a/packages/sign-client/src/client.ts
+++ b/packages/sign-client/src/client.ts
@@ -202,8 +202,15 @@ export class SignClient extends ISignClient {
     }
   };
 
+  /**
+   * @deprecated `authenticate` is deprecated and will be removed in a future release.
+   * Use `connect()`'s `authentication` instead to establish an authenticated session.
+   */
   public authenticate: ISignClient["authenticate"] = async (params, walletUniversalLink) => {
     try {
+      console.warn(
+        "[WalletConnect] `authenticate` is deprecated and will be removed in a future release. Use `connect()`'s `authentication` instead to establish an authenticated session.",
+      );
       return await this.engine.authenticate(params, walletUniversalLink);
     } catch (error: any) {
       this.logger.error(error.message);

--- a/packages/types/src/sign-client/client.ts
+++ b/packages/types/src/sign-client/client.ts
@@ -156,6 +156,10 @@ export abstract class ISignClient {
   public abstract disconnect: IEngine["disconnect"];
   public abstract find: IEngine["find"];
   public abstract getPendingSessionRequests: IEngine["getPendingSessionRequests"];
+  /**
+   * @deprecated `authenticate` is deprecated and will be removed in a future release.
+   * Use `connect()`'s `authentication` instead to establish an authenticated session.
+   */
   public abstract authenticate: IEngine["authenticate"];
   public abstract formatAuthMessage: IEngine["formatAuthMessage"];
   public abstract approveSessionAuthenticate: IEngine["approveSessionAuthenticate"];

--- a/packages/types/src/sign-client/engine.ts
+++ b/packages/types/src/sign-client/engine.ts
@@ -483,6 +483,10 @@ export abstract class IEngine {
 
   public abstract getPendingSessionRequests: () => PendingRequestTypes.Struct[];
 
+  /**
+   * @deprecated `authenticate` is deprecated and will be removed in a future release.
+   * Use `connect()`'s `authentication` instead to establish an authenticated session.
+   */
   public abstract authenticate: (
     params: AuthTypes.SessionAuthenticateParams,
     walletUniversalLink?: string,


### PR DESCRIPTION
## Summary

Adds a deprecation notice to the `authenticate` method on Sign Client. Consumers are directed to use `connect()`'s `authentication` parameter to establish an authenticated session.

The deprecation is surfaced two ways:
- **Compile-time:** `@deprecated` JSDoc on the type definitions (`ISignClient` and `IEngine`) — IDEs render strikethrough + a tooltip.
- **Runtime:** `console.warn` emitted when `authenticate()` is called (allowed by the repo's `no-console` eslint rule).

No behavior change — the method still works exactly as before.

## Changes

- `packages/types/src/sign-client/client.ts` — `@deprecated` on `ISignClient.authenticate`
- `packages/types/src/sign-client/engine.ts` — `@deprecated` on `IEngine.authenticate`
- `packages/sign-client/src/client.ts` — runtime `console.warn` on call
- `.changeset/deprecate-authenticate.md` — patch changeset (fixed group bumps all packages)

## Deprecation path

```mermaid
flowchart LR
    A["client.authenticate(params)"] -->|deprecated| B["console.warn + @deprecated"]
    A -.migrate.-> C["client.connect({ authentication })"]
    C --> D["authenticated session"]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)