### PR TITLE
chore: pin brotli to exact version in @walletconnect/pay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21966,7 +21966,7 @@
         "@walletconnect/logger": "3.0.2",
         "@walletconnect/types": "2.23.9",
         "@walletconnect/utils": "2.23.9",
-        "brotli": "^1.3.3"
+        "brotli": "1.3.3"
       },
       "devDependencies": {
         "@types/brotli": "^1.3.4",

--- a/packages/pay/package.json
+++ b/packages/pay/package.json
@@ -44,7 +44,7 @@
     "@walletconnect/logger": "3.0.2",
     "@walletconnect/types": "2.23.9",
     "@walletconnect/utils": "2.23.9",
-    "brotli": "^1.3.3"
+    "brotli": "1.3.3"
   },
   "peerDependencies": {
     "react-native": ">=0.64.0"


### PR DESCRIPTION
## Summary

Pins the only floating **production** dependency in the monorepo to an exact version, in line with the exact-version policy.

- `packages/pay` → `brotli`: `"^1.3.3"` → `"1.3.3"`

The lockfile already resolves `brotli` to `1.3.3`, so this is a no-op at install time and requires no reinstall.

## Scope

Per the request, only **production** dependencies were pinned. The following were intentionally left as-is:

- **devDependencies** (build/test only, not shipped): `hardhat ^3.1.4`, `@rollup/plugin-alias ^6.0.0`, `@types/brotli ^1.3.4`
- **peerDependencies** (ranges by design): `react-native >=0.64.0` and the `*` peers in `react-native-compat` — pinning these would force exact versions on consumers and break installs.

## Test plan

- [ ] CI lint + build + test pass
- No runtime behavior change expected (resolved version unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)