### PR TITLE
fix(utils): annotate createRecap return type

### DIFF
--- a/.changeset/quiet-spoons-recap.md
+++ b/.changeset/quiet-spoons-recap.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/utils": patch
+---
+
+Fix the generated `createRecap` declaration so it can be consumed with `skipLibCheck: false`.

--- a/packages/utils/src/cacao.ts
+++ b/packages/utils/src/cacao.ts
@@ -290,7 +290,12 @@ export function isValidRecap(recap: any) {
   });
 }
 
-export function createRecap(resource: string, ability: string, actions: string[], limits = {}) {
+export function createRecap(
+  resource: string,
+  ability: string,
+  actions: string[],
+  limits = {},
+): RecapType {
   actions?.sort((a, b) => a.localeCompare(b));
   return {
     att: { [resource]: assignAbilityToActions(ability, actions, limits) },


### PR DESCRIPTION
> Creating a release? Please use the [Release PR Template](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/.github/pr_template_release.md) instead.

## Description

- annotate `createRecap` with the existing `RecapType`
- prevent TypeScript from emitting an invalid `[resource]` computed property in `cacao.d.ts`
- add a patch changeset for `@walletconnect/utils`

`createRecap` had no explicit return type, so TypeScript inferred an object type containing the runtime `resource` parameter as a computed property key. The declaration emitter reproduced that key as `[resource]`, which is invalid in a type literal and causes TS1170 for consumers using `skipLibCheck: false`.

Using the existing `RecapType` gives the declaration emitter a stable string-indexed return type without changing runtime behavior.


## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your configuration.

## Fixes/Resolves (Optional)

Please list any issues that are fixed by this PR in the format `#<issue number>`. If it fixes multiple issues, please put each issue in a separate line. If this Pull Request does not fix any issues, please delete this section.

## Examples/Screenshots (Optional)

Please attach a screenshot or screen recording of features/fixes you've implemented to verify your changes. Please also note any relevant details for your configuration. If your changes do not affect the UI, please delete this section.

Use this table template to show examples of your changes:

| Before       | After        |
| ------------ | ------------ |
| Content Cell | Content Cell |
| Content Cell | Content Cell |

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
