### PR TITLE
fix(core): annotate EventEmitter fields for modern @types/node

### DIFF
--- a/.changeset/bright-events-core.md
+++ b/.changeset/bright-events-core.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/core": patch
+---
+
+Fix generated `EventEmitter` declarations so `@walletconnect/core` can be consumed with `skipLibCheck: false`.

--- a/packages/core/src/controllers/expirer.ts
+++ b/packages/core/src/controllers/expirer.ts
@@ -13,7 +13,7 @@ import {
 
 export class Expirer extends IExpirer {
   public expirations = new Map<string, ExpirerTypes.Expiration>();
-  public events = new EventEmitter();
+  public events: EventEmitter = new EventEmitter();
   public name = EXPIRER_CONTEXT;
   public version = EXPIRER_STORAGE_VERSION;
 

--- a/packages/core/src/controllers/history.ts
+++ b/packages/core/src/controllers/history.ts
@@ -14,7 +14,7 @@ import {
 
 export class JsonRpcHistory extends IJsonRpcHistory {
   public records = new Map<number, JsonRpcRecord>();
-  public events = new EventEmitter();
+  public events: EventEmitter = new EventEmitter();
   public name = HISTORY_CONTEXT;
   public version = HISTORY_STORAGE_VERSION;
 

--- a/packages/core/src/controllers/pairing.ts
+++ b/packages/core/src/controllers/pairing.ts
@@ -58,7 +58,7 @@ export class Pairing implements IPairing {
   public name = PAIRING_CONTEXT;
   public version = PAIRING_STORAGE_VERSION;
 
-  public events = new EventEmitter();
+  public events: EventEmitter = new EventEmitter();
   public pairings: IStore<string, PairingTypes.Struct>;
 
   private initialized = false;

--- a/packages/core/src/controllers/publisher.ts
+++ b/packages/core/src/controllers/publisher.ts
@@ -23,7 +23,7 @@ type IPublishType = {
 };
 
 export class Publisher extends IPublisher {
-  public events = new EventEmitter();
+  public events: EventEmitter = new EventEmitter();
   public name = PUBLISHER_CONTEXT;
   public queue = new Map<string, IPublishType>();
 

--- a/packages/core/src/controllers/relayer.ts
+++ b/packages/core/src/controllers/relayer.ts
@@ -70,7 +70,7 @@ export class Relayer extends IRelayer {
 
   public core: ICore;
   public logger: Logger;
-  public events = new EventEmitter();
+  public events: EventEmitter = new EventEmitter();
   public provider: IJsonRpcProvider;
   public messages: IMessageTracker;
   public subscriber: ISubscriber;

--- a/packages/core/src/controllers/subscriber.ts
+++ b/packages/core/src/controllers/subscriber.ts
@@ -34,7 +34,7 @@ export class Subscriber extends ISubscriber {
   public subscriptions = new Map<string, SubscriberTypes.Active>();
 
   public topicMap = new SubscriberTopicMap();
-  public events = new EventEmitter();
+  public events: EventEmitter = new EventEmitter();
   public name = SUBSCRIBER_CONTEXT;
   public version = SUBSCRIBER_STORAGE_VERSION;
   public pending = new Map<string, SubscriberTypes.Params>();

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -171,19 +171,19 @@ export class Core extends ICore {
 
   // ---------- Events ----------------------------------------------- //
 
-  public on = (name: any, listener: any) => {
+  public on = (name: any, listener: any): EventEmitter => {
     return this.events.on(name, listener);
   };
 
-  public once = (name: any, listener: any) => {
+  public once = (name: any, listener: any): EventEmitter => {
     return this.events.once(name, listener);
   };
 
-  public off = (name: any, listener: any) => {
+  public off = (name: any, listener: any): EventEmitter => {
     return this.events.off(name, listener);
   };
 
-  public removeListener = (name: any, listener: any) => {
+  public removeListener = (name: any, listener: any): EventEmitter => {
     return this.events.removeListener(name, listener);
   };
 


### PR DESCRIPTION
## Summary
- Annotate `public events: EventEmitter = new EventEmitter()` on core controllers (`relayer`, `history`, `pairing`, `publisher`, `subscriber`, `expirer`).
- Prevents shipped `.d.ts` from emitting `EventEmitter<[never]>`, which fails `TS2344` with modern `@types/node` when `skipLibCheck: false`.

Fixes #7292

## Test plan
- [ ] Build `@walletconnect/core` and confirm controller `.d.ts` files use `events: EventEmitter` (not `EventEmitter<[never]>`)
- [ ] Reproduce issue reproduction (`nodenext` + `@types/node@26` + `skipLibCheck: false`) against built types