### PR TITLE
fix(utils): reject CR/LF in CACAO single-line SIWE fields

### DIFF
--- a/packages/utils/src/cacao.ts
+++ b/packages/utils/src/cacao.ts
@@ -104,12 +104,25 @@ export const formatMessage = (cacao: AuthTypes.FormatMessageParams, iss: string)
     statement = formatStatementFromRecap(statement, decoded);
   }
 
-  // Per EIP-4361 the statement is a single line and must not contain line breaks.
-  // Validate the final statement (after recap formatting) so that neither a caller-supplied
-  // statement nor untrusted recap-derived text can forge other fields (URI, Nonce, etc.) in
-  // the signed message via embedded `\r`/`\n`.
-  if (statement && /\r|\n/.test(statement)) {
-    throw new Error("Statement must not contain line breaks (`\\r` or `\\n`)");
+  // Per EIP-4361 single-line fields must not contain line breaks. Reject caller-supplied
+  // domain / aud / uri / version / nonce / iat (and optional exp/nbf/requestId) as well as
+  // the final statement (after recap formatting) so embedded `\r`/`\n` cannot forge other
+  // fields in the signed message.
+  const singleLineFields: Array<[string, string | undefined]> = [
+    ["Domain", cacao.domain],
+    ["URI", cacao.aud || cacao.uri],
+    ["Version", cacao.version],
+    ["Nonce", cacao.nonce],
+    ["Issued At", cacao.iat],
+    ["Expiration Time", cacao.exp],
+    ["Not Before", cacao.nbf],
+    ["Request ID", cacao.requestId],
+    ["Statement", statement],
+  ];
+  for (const [name, value] of singleLineFields) {
+    if (value && /\r|\n/.test(value)) {
+      throw new Error(`${name} must not contain line breaks (\`\\r\` or \`\\n\`)`);
+    }
   }
 
   const message = [

--- a/packages/utils/test/cacao.spec.ts
+++ b/packages/utils/test/cacao.spec.ts
@@ -282,6 +282,34 @@ describe("URI", () => {
     );
   });
 
+  it("should reject other single-line SIWE fields containing line breaks", () => {
+    const baseRequest = {
+      type: "caip122",
+      aud: "https://app.web3inbox.com/login",
+      domain: "app.web3inbox",
+      version: "1",
+      nonce: "32891756",
+      iat: "2024-03-13T09:00:43.888Z",
+    };
+    const iss = "did:pkh:eip155:1:0x3613699A6c5D8BC97a08805876c8005543125F09";
+
+    expect(() =>
+      formatMessage({ ...baseRequest, domain: "app.web3inbox\nURI: https://evil.com" }, iss),
+    ).to.throw("Domain must not contain line breaks");
+
+    expect(() =>
+      formatMessage({ ...baseRequest, aud: "https://app.web3inbox.com/login\nNonce: forged" }, iss),
+    ).to.throw("URI must not contain line breaks");
+
+    expect(() => formatMessage({ ...baseRequest, nonce: "32891756\nVersion: 9" }, iss)).to.throw(
+      "Nonce must not contain line breaks",
+    );
+
+    expect(
+      formatMessage({ ...baseRequest, domain: "app.web3inbox", aud: "https://app.web3inbox.com" }, iss),
+    ).to.include("app.web3inbox wants you to sign in");
+  });
+
   it("should reject recap-derived statements containing line breaks", () => {
     const iss = "did:pkh:eip155:1:0x3613699A6c5D8BC97a08805876c8005543125F09";
     // recap content is untrusted: a malicious resource name with a newline must not be


### PR DESCRIPTION
## Summary
- After #7247, `formatMessage` rejects line breaks in the final statement, but other EIP-4361 single-line fields (`domain`, `aud`/`uri`, `version`, `nonce`, `iat`, optional `exp`/`nbf`/`requestId`) were still interpolated unchanged.
- A crafted `domain` like `example.com\nURI: https://evil.com` forges additional message lines (same class as statement smuggling).
- Fail closed: reject `\r`/`\n` in those fields before building the message.

## Test plan
- [x] Extended `packages/utils/test/cacao.spec.ts` for domain / aud / nonce CR/LF rejects
- [x] Existing statement + recap linebreak tests still match the shared error prefix
- [ ] CI `@walletconnect/utils` vitest


Made with [Cursor](https://cursor.com)