### PR TITLE
fix(utils): enforce CACAO exp/nbf in validateSignedCacao

### DIFF
--- a/packages/utils/src/cacao.ts
+++ b/packages/utils/src/cacao.ts
@@ -62,6 +62,22 @@ export async function validateSignedCacao(params: { cacao: AuthTypes.Cacao; proj
   } catch (error) {
     return false;
   }
+  // SIWE exp/nbf are reconstructed into the signed message but were never
+  // enforced here — an expired (or not-yet-valid) CACAO with a good signature
+  // still settled sessions. Fail closed when present and outside the window.
+  if (payload.exp !== undefined) {
+    const expMs = Date.parse(payload.exp);
+    if (Number.isNaN(expMs) || Date.now() >= expMs) {
+      return false;
+    }
+  }
+  if (payload.nbf !== undefined) {
+    const nbfMs = Date.parse(payload.nbf);
+    if (Number.isNaN(nbfMs) || Date.now() < nbfMs) {
+      return false;
+    }
+  }
+
   const walletAddress = getDidAddress(payload.iss) as string;
   const isValid = await verifySignature(
     walletAddress,

--- a/packages/utils/test/cacao.spec.ts
+++ b/packages/utils/test/cacao.spec.ts
@@ -304,6 +304,63 @@ describe("URI", () => {
     expect(() => formatMessage(request, iss)).to.throw("Statement must not contain line breaks");
   });
 
+  it("should return false from validateSignedCacao when exp is in the past", async () => {
+    const cacao = {
+      h: { t: "caip122" },
+      p: {
+        iss: "did:pkh:eip155:1:0x3613699A6c5D8BC97a08805876c8005543125F09",
+        domain: "app.web3inbox",
+        aud: "https://app.web3inbox.com/login",
+        version: "1",
+        nonce: "32891756",
+        iat: "2020-01-01T00:00:00.000Z",
+        exp: "2020-01-01T01:00:00.000Z",
+      },
+      s: { t: "eip191" as const, s: "0x" },
+    };
+
+    const isValid = await validateSignedCacao({ cacao });
+    expect(isValid).to.eql(false);
+  });
+
+  it("should return false from validateSignedCacao when nbf is in the future", async () => {
+    const cacao = {
+      h: { t: "caip122" },
+      p: {
+        iss: "did:pkh:eip155:1:0x3613699A6c5D8BC97a08805876c8005543125F09",
+        domain: "app.web3inbox",
+        aud: "https://app.web3inbox.com/login",
+        version: "1",
+        nonce: "32891756",
+        iat: "2020-01-01T00:00:00.000Z",
+        nbf: "2099-01-01T00:00:00.000Z",
+      },
+      s: { t: "eip191" as const, s: "0x" },
+    };
+
+    const isValid = await validateSignedCacao({ cacao });
+    expect(isValid).to.eql(false);
+  });
+
+  it("should return false from validateSignedCacao for unparseable exp", async () => {
+    const cacao = {
+      h: { t: "caip122" },
+      p: {
+        iss: "did:pkh:eip155:1:0x3613699A6c5D8BC97a08805876c8005543125F09",
+        domain: "app.web3inbox",
+        aud: "https://app.web3inbox.com/login",
+        version: "1",
+        nonce: "32891756",
+        iat: "2020-01-01T00:00:00.000Z",
+        exp: "not-a-date",
+      },
+      s: { t: "eip191" as const, s: "0x" },
+    };
+
+    const isValid = await validateSignedCacao({ cacao });
+    expect(isValid).to.eql(false);
+  });
+
   it("should return false from validateSignedCacao for statements with line breaks", async () => {
     // formatMessage throws for malformed statements; validateSignedCacao must remap that to
     // a boolean `false` rather than propagating the exception to callers.


### PR DESCRIPTION
## Why

`validateSignedCacao` reconstructs the SIWE message (including optional `Expiration Time` / `Not Before`) and verifies the signature, but never checks `payload.exp` / `payload.nbf`.

An expired (or not-yet-valid) CACAO with a good signature still returns `true`. Sign-client `Engine` uses that boolean as the auth gate before session settlement (`authenticate` / `approveSessionAuthenticate`).

Distinct from utils #279 (relay JWT `exp`), utils #280 / mono #7311 (CR/LF field hardening), and utils #281 (`isLocalhostUrl`).

## Fix

After message reconstruction, if `exp` is set and `now >= exp` (or unparseable) return `false`; if `nbf` is set and `now < nbf` (or unparseable) return `false`. Then verify the signature as before.

## Test plan

- [x] `npx vitest run --dir test test/cacao.spec.ts` in `packages/utils` (26/26)
- [ ] Expired `exp` fails closed before session settle
- [ ] Future `nbf` fails closed
- [ ] In-window CACAO with valid sig still passes


Made with [Cursor](https://cursor.com)