### PR TITLE
fix(sign-client): bind session auth CACAO to outstanding challenge

### DIFF
--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -1118,14 +1118,35 @@ export class Engine extends IEngine {
 
       const approvedMethods: string[] = [];
       const approvedAccounts: string[] = [];
+      const expectedAuth = request.authPayload;
       for (const cacao of cacaos) {
         const isValid = await validateSignedCacao({ cacao, projectId: this.client.core.projectId });
         if (!isValid) {
           this.client.logger.error(cacao, "Signature verification failed");
-          reject(getSdkError("SESSION_SETTLEMENT_FAILED", "Signature verification failed"));
+          return reject(getSdkError("SESSION_SETTLEMENT_FAILED", "Signature verification failed"));
         }
 
         const { p: payload } = cacao;
+        // Bind CACAO challenge fields to the outstanding authenticate request.
+        // Signature validity alone is not enough: a valid CACAO for a different
+        // domain/aud/nonce must not settle this session.
+        if (
+          payload.domain !== expectedAuth.domain ||
+          payload.aud !== expectedAuth.aud ||
+          payload.nonce !== expectedAuth.nonce
+        ) {
+          this.client.logger.error(cacao, "CACAO does not match auth request");
+          return reject(
+            getSdkError("SESSION_SETTLEMENT_FAILED", "CACAO does not match auth request"),
+          );
+        }
+        const issChain = getNamespacedDidChainId(payload.iss);
+        if (!issChain || !expectedAuth.chains.includes(issChain)) {
+          this.client.logger.error(cacao, "CACAO iss chain not in auth request");
+          return reject(
+            getSdkError("SESSION_SETTLEMENT_FAILED", "CACAO iss chain not in auth request"),
+          );
+        }
         const recap = getRecapFromResources(payload.resources);
 
         const approvedChains: string[] = [getNamespacedDidChainId(payload.iss) as string];
@@ -1307,6 +1328,7 @@ export class Engine extends IEngine {
 
     const approvedMethods: string[] = [];
     const approvedAccounts: string[] = [];
+    const expectedAuth = pendingRequest.authPayload;
     for (const cacao of auths) {
       const isValid = await validateSignedCacao({ cacao, projectId: this.client.core.projectId });
       if (!isValid) {
@@ -1327,9 +1349,43 @@ export class Engine extends IEngine {
         throw new Error(invalidErr.message);
       }
 
+      const { p: payload } = cacao;
+      if (
+        payload.domain !== expectedAuth.domain ||
+        payload.aud !== expectedAuth.aud ||
+        payload.nonce !== expectedAuth.nonce
+      ) {
+        event.setError(EVENT_CLIENT_AUTHENTICATE_ERRORS.invalid_cacao);
+        const mismatchErr = getSdkError(
+          "SESSION_SETTLEMENT_FAILED",
+          "CACAO does not match auth request",
+        );
+        await this.sendError({
+          id,
+          topic: responseTopic,
+          error: mismatchErr,
+          encodeOpts,
+        });
+        throw new Error(mismatchErr.message);
+      }
+      const issChain = getNamespacedDidChainId(payload.iss);
+      if (!issChain || !expectedAuth.chains.includes(issChain)) {
+        event.setError(EVENT_CLIENT_AUTHENTICATE_ERRORS.invalid_cacao);
+        const chainErr = getSdkError(
+          "SESSION_SETTLEMENT_FAILED",
+          "CACAO iss chain not in auth request",
+        );
+        await this.sendError({
+          id,
+          topic: responseTopic,
+          error: chainErr,
+          encodeOpts,
+        });
+        throw new Error(chainErr.message);
+      }
+
       event.addTrace(EVENT_CLIENT_AUTHENTICATE_TRACES.cacaos_verified);
 
-      const { p: payload } = cacao;
       const recap = getRecapFromResources(payload.resources);
 
       const approvedChains: string[] = [getNamespacedDidChainId(payload.iss) as string];

--- a/packages/sign-client/test/sdk/auth.spec.ts
+++ b/packages/sign-client/test/sdk/auth.spec.ts
@@ -153,6 +153,70 @@ describe.concurrent("Authenticated Sessions", () => {
 
     await deleteClients({ A: dapp, B: wallet });
   });
+  // Valid CACAO signature for a different nonce must not settle the outstanding auth request
+  it("should reject authenticated session when CACAO nonce does not match request", async () => {
+    const dapp = await SignClient.init({ ...TEST_SIGN_CLIENT_OPTIONS, name: "dapp" });
+    const requestedChains = ["eip155:1"];
+    const requestedMethods = ["personal_sign"];
+    const { uri, response } = await dapp.authenticate({
+      chains: requestedChains,
+      domain: "localhost",
+      nonce: "expected-nonce",
+      uri: "aud",
+      methods: requestedMethods,
+    });
+    const wallet = await SignClient.init({
+      ...TEST_SIGN_CLIENT_OPTIONS,
+      name: "wallet",
+      metadata: TEST_APP_METADATA_B,
+    });
+    const sessionsBefore = dapp.session.getAll().length;
+    await Promise.all([
+      new Promise<void>((resolve, reject) => {
+        wallet.on("session_authenticate", async (payload) => {
+          try {
+            const authPayload = populateAuthPayload({
+              authPayload: payload.params.authPayload,
+              chains: requestedChains,
+              methods: requestedMethods,
+            });
+            // Sign a CACAO bound to a different nonce than the pending request
+            const mismatched = { ...authPayload, nonce: "attacker-nonce" };
+            const iss = `${requestedChains[0]}:${cryptoWallet.address}`;
+            const message = wallet.engine.formatAuthMessage({
+              request: mismatched,
+              iss,
+            });
+            const sig = await cryptoWallet.signMessage(message);
+            const auth = buildAuthObject(
+              mismatched,
+              {
+                t: "eip191",
+                s: sig,
+              },
+              iss,
+            );
+            await expect(
+              wallet.approveSessionAuthenticate({
+                id: payload.id,
+                auths: [auth],
+              }),
+            ).rejects.toThrow(/CACAO does not match auth request/);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        });
+      }),
+      new Promise<void>((resolve) => {
+        wallet.pair({ uri });
+        resolve();
+      }),
+      expect(response()).rejects.toThrow(),
+    ]);
+    expect(dapp.session.getAll().length).to.eq(sessionsBefore);
+    await deleteClients({ A: dapp, B: wallet });
+  });
   // this test simulates the scenario where the wallet supports subset of the requested chains and all methods
   // and replies with a single signature
   it("should establish authenticated session with single signature. Case 2", async () => {


### PR DESCRIPTION
## Summary
- After `validateSignedCacao`, bind CACAO `domain` / `aud` / `nonce` (and `iss` chain membership) to the outstanding `wc_sessionAuthenticate` request on both the dApp `onAuthenticate` path and wallet `approveSessionAuthenticate`.
- `return` after signature verification failure on the dApp path so session subscribe/set cannot run after `reject`.

## Attacker model
A compromised or malicious wallet can return a cryptographically valid CACAO for a different SIWE challenge (replayed or wrong-audience). Without challenge binding, the dApp still settles an authenticated session for the outstanding request.

## Threat-model note
The wallet already controls the signature. The gap is that signature validity was treated as sufficient for this request. Binding restores the intended challenge semantics of CACAO/SIWE.

## Test plan
- [x] Added `should reject authenticated session when CACAO nonce does not match request` in `packages/sign-client/test/sdk/auth.spec.ts`
- [ ] CI auth suite on this PR


Made with [Cursor](https://cursor.com)