### PR TITLE
fix(core): validate event.origin in verify postMessage listener

### DIFF
--- a/packages/core/src/constants/verify.ts
+++ b/packages/core/src/constants/verify.ts
@@ -6,3 +6,6 @@ export const VERIFY_SERVER = VERIFY_SERVER_ORG;
 export const VERIFY_SERVER_V3 = `${VERIFY_SERVER}/v3`;
 
 export const TRUSTED_VERIFY_URLS = [VERIFY_SERVER_COM, VERIFY_SERVER_ORG];
+
+export const isTrustedVerifyOrigin = (origin: string): boolean =>
+  TRUSTED_VERIFY_URLS.includes(origin);

--- a/packages/core/src/controllers/verify.ts
+++ b/packages/core/src/controllers/verify.ts
@@ -13,6 +13,7 @@ import {
   VERIFY_CONTEXT,
   VERIFY_SERVER,
   VERIFY_SERVER_V3,
+  isTrustedVerifyOrigin,
 } from "../constants/index.js";
 
 type Jwk = {
@@ -85,6 +86,8 @@ export class Verify extends IVerify {
         const listener = (event: MessageEvent) => {
           if (!event.data) return;
           if (typeof event.data !== "string") return;
+          if (!isTrustedVerifyOrigin(event.origin)) return;
+
           try {
             const data = JSON.parse(event.data);
             if (data.type === "verify_attestation") {

--- a/packages/core/test/verify-origin.spec.ts
+++ b/packages/core/test/verify-origin.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { isTrustedVerifyOrigin } from "../src/constants/verify";
+
+describe("verify origin validation", () => {
+  it("accepts messages originating from the trusted verify servers", () => {
+    expect(isTrustedVerifyOrigin("https://verify.walletconnect.org")).toBe(true);
+    expect(isTrustedVerifyOrigin("https://verify.walletconnect.com")).toBe(true);
+  });
+
+  it("rejects messages from untrusted origins", () => {
+    expect(isTrustedVerifyOrigin("https://evil.example.com")).toBe(false);
+    expect(isTrustedVerifyOrigin("https://verify.walletconnect.com.evil.example")).toBe(false);
+    expect(isTrustedVerifyOrigin("http://verify.walletconnect.org")).toBe(false);
+    expect(isTrustedVerifyOrigin("null")).toBe(false);
+    expect(isTrustedVerifyOrigin("")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

The `message` event listener registered by `Verify.register` in the core package never validates `event.origin`. Any webpage can dispatch a forged `postMessage` with a `verify_attestation` payload and the listener will accept it as long as the attestation `id` matches. The `id` check is only partial mitigation (CWE-346: Origin Validation Error).

## Root cause

In `packages/core/src/controllers/verify.ts`, the `window.addEventListener("message", listener, ...)` handler in `register` inspects `event.data` and the attestation `id`, but never checks where the message came from:

```ts
const listener = (event: MessageEvent) => {
  if (!event.data) return;
  if (typeof event.data !== "string") return;
  // no event.origin validation here
  ...
};
```

## Fix

Validate the message origin against the trusted verify server origins before processing the payload. The check is factored into a small exported predicate `isTrustedVerifyOrigin` in `packages/core/src/constants/verify.ts` so it can be unit tested, and it is applied as the first gate in the listener:

```ts
const listener = (event: MessageEvent) => {
  if (!event.data) return;
  if (typeof event.data !== "string") return;
  if (!isTrustedVerifyOrigin(event.origin)) return; // only accept trusted verify origins
  ...
};
```

The origin is compared against `TRUSTED_VERIFY_URLS` (the `verify.walletconnect.org` / `verify.walletconnect.com` hosts). The comparison is deliberately against the origin host, not `VERIFY_SERVER_V3` (which includes a `/v3` path) — `MessageEvent.origin` never carries a path, so comparing against the full v3 URL would reject all legitimate messages.

## Test

Adds `packages/core/test/verify-origin.spec.ts`, a unit test for `isTrustedVerifyOrigin` that asserts the trusted verify origins are accepted and untrusted / spoofed origins (lookalike subdomains, `http`, `null`, empty) are rejected.

Run: `cd packages/core && npx vitest run test/verify-origin.spec.ts`

Fixes #7282