### PR TITLE
feat(tvf): collect transaction hashes for stellar_signXDR and stellar_signAndSubmitXDR

### DIFF
--- a/.changeset/stellar-tvf-tx-hashes.md
+++ b/.changeset/stellar-tvf-tx-hashes.md
@@ -1,6 +1,0 @@
----
-"@walletconnect/utils": patch
-"@walletconnect/sign-client": patch
----
-
-Add TVF transaction hash collection for Stellar (`stellar_signXDR`, `stellar_signAndSubmitXDR`). For `stellar_signXDR` the hash is computed dependency-free from the signed TransactionEnvelope XDR as `sha256(network_id || envelope_type || transaction_body)`, supporting V0, V1 and fee-bump envelopes.

--- a/.changeset/stellar-tvf-tx-hashes.md
+++ b/.changeset/stellar-tvf-tx-hashes.md
@@ -1,0 +1,6 @@
+---
+"@walletconnect/utils": patch
+"@walletconnect/sign-client": patch
+---
+
+Add TVF transaction hash collection for Stellar (`stellar_signXDR`, `stellar_signAndSubmitXDR`). For `stellar_signXDR` the hash is computed dependency-free from the signed TransactionEnvelope XDR as `sha256(network_id || envelope_type || transaction_body)`, supporting V0, V1 and fee-bump envelopes.

--- a/packages/sign-client/src/constants/engine.ts
+++ b/packages/sign-client/src/constants/engine.ts
@@ -235,4 +235,12 @@ export const TVF_METHODS = {
   canton_prepareSignExecute: {
     key: "",
   },
+
+  // stellar
+  stellar_signXDR: {
+    key: "",
+  },
+  stellar_signAndSubmitXDR: {
+    key: "tx_hash",
+  },
 };

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -104,6 +104,7 @@ import {
   getAlgorandTransactionId,
   buildSignedExtrinsicHash,
   getSignDirectHash,
+  getStellarTransactionHash,
   LimitedSet,
   getWalletSendCallsHashes,
   getCantonTransactionHashes,
@@ -3563,6 +3564,10 @@ export class Engine extends IEngine {
 
       if (method === "cosmos_signDirect") {
         return [getSignDirectHash(result)];
+      }
+
+      if (method === "stellar_signXDR") {
+        return [getStellarTransactionHash(result.signedXDR, request.params?.chain)];
       }
 
       if (method === "wallet_sendCalls") {

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -3497,6 +3497,14 @@ export class Engine extends IEngine {
     try {
       const txHashes = this.extractTxHashesFromResult(params.request, result);
       tvf.txHashes = txHashes;
+      // TEMP QA logging (draft PR): surface collected Stellar tx hashes for explorer lookup
+      if (result && params.request.method.startsWith("stellar_")) {
+        // eslint-disable-next-line no-console
+        console.log(
+          `[TVF] ${params.request.method} (${params.chainId}) collected txHashes:`,
+          txHashes,
+        );
+      }
       tvf.contractAddresses = this.isValidContractData(params.request.params)
         ? [params.request.params?.[0]?.to]
         : [];

--- a/packages/sign-client/src/controllers/engine.ts
+++ b/packages/sign-client/src/controllers/engine.ts
@@ -3497,14 +3497,6 @@ export class Engine extends IEngine {
     try {
       const txHashes = this.extractTxHashesFromResult(params.request, result);
       tvf.txHashes = txHashes;
-      // TEMP QA logging (draft PR): surface collected Stellar tx hashes for explorer lookup
-      if (result && params.request.method.startsWith("stellar_")) {
-        // eslint-disable-next-line no-console
-        console.log(
-          `[TVF] ${params.request.method} (${params.chainId}) collected txHashes:`,
-          txHashes,
-        );
-      }
       tvf.contractAddresses = this.isValidContractData(params.request.params)
         ? [params.request.params?.[0]?.to]
         : [];

--- a/packages/utils/src/signatures.ts
+++ b/packages/utils/src/signatures.ts
@@ -353,9 +353,7 @@ export function getStellarTransactionHash(signedXDR: string, chain?: string): st
       bodyStart = 4;
       break;
     default:
-      throw new Error(
-        `getStellarTransactionHash: unsupported envelope type: ${discriminant}`,
-      );
+      throw new Error(`getStellarTransactionHash: unsupported envelope type: ${discriminant}`);
   }
 
   const signatureArrayOffset = findStellarSignatureArrayOffset(bytes);

--- a/packages/utils/src/signatures.ts
+++ b/packages/utils/src/signatures.ts
@@ -288,13 +288,16 @@ function readUint32BE(bytes: Uint8Array, offset: number): number {
  * WalletConnect Stellar RPC spec mandates wallets emit.
  */
 function findStellarSignatureArrayOffset(bytes: Uint8Array): number {
+  // Scan from the maximum count downward: a real multi-signature array must be
+  // found before the vacuously-matching zero count, which would otherwise win
+  // whenever a signature happens to end in four zero bytes.
   for (
-    let signatureCount = 0;
-    signatureCount <= STELLAR_MAX_ENVELOPE_SIGNATURES;
-    signatureCount++
+    let signatureCount = STELLAR_MAX_ENVELOPE_SIGNATURES;
+    signatureCount >= 0;
+    signatureCount--
   ) {
     const offset = bytes.length - 4 - STELLAR_DECORATED_SIGNATURE_LENGTH * signatureCount;
-    if (offset < 4) break;
+    if (offset < 4) continue;
     if (readUint32BE(bytes, offset) !== signatureCount) continue;
     let isValid = true;
     for (let i = 0; i < signatureCount; i++) {

--- a/packages/utils/src/signatures.ts
+++ b/packages/utils/src/signatures.ts
@@ -253,6 +253,117 @@ export function getSignDirectHash(payload: {
   return toString(hashBytes, "base16").toUpperCase();
 }
 
+const STELLAR_NETWORK_PASSPHRASES: Record<string, string> = {
+  pubnet: "Public Global Stellar Network ; September 2015",
+  testnet: "Test SDF Network ; September 2015",
+};
+
+// XDR EnvelopeType discriminants (https://developers.stellar.org/docs/learn/encyclopedia/data-format/xdr)
+const STELLAR_ENVELOPE_TYPE_TX_V0 = 0;
+const STELLAR_ENVELOPE_TYPE_TX = 2;
+const STELLAR_ENVELOPE_TYPE_TX_FEE_BUMP = 5;
+// DecoratedSignature with an ed25519 signature: hint (4 bytes) + length (4 bytes, =64) + signature (64 bytes)
+const STELLAR_DECORATED_SIGNATURE_LENGTH = 72;
+const STELLAR_ED25519_SIGNATURE_LENGTH = 64;
+const STELLAR_MAX_ENVELOPE_SIGNATURES = 20;
+
+function readUint32BE(bytes: Uint8Array, offset: number): number {
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(offset, false);
+}
+
+/**
+ * Locates the start of the trailing `DecoratedSignature signatures<20>` XDR array
+ * of a Stellar TransactionEnvelope without parsing the transaction body.
+ * Assumes ed25519 signatures (fixed 72-byte entries), which is what the
+ * WalletConnect Stellar RPC spec mandates wallets emit.
+ */
+function findStellarSignatureArrayOffset(bytes: Uint8Array): number {
+  for (
+    let signatureCount = 0;
+    signatureCount <= STELLAR_MAX_ENVELOPE_SIGNATURES;
+    signatureCount++
+  ) {
+    const offset = bytes.length - 4 - STELLAR_DECORATED_SIGNATURE_LENGTH * signatureCount;
+    if (offset < 4) break;
+    if (readUint32BE(bytes, offset) !== signatureCount) continue;
+    let isValid = true;
+    for (let i = 0; i < signatureCount; i++) {
+      const entryOffset = offset + 4 + STELLAR_DECORATED_SIGNATURE_LENGTH * i;
+      // each entry's signature length field must be exactly 64 (ed25519)
+      if (readUint32BE(bytes, entryOffset + 4) !== STELLAR_ED25519_SIGNATURE_LENGTH) {
+        isValid = false;
+        break;
+      }
+    }
+    if (isValid) return offset;
+  }
+  throw new Error("getStellarTransactionHash: could not locate envelope signature array");
+}
+
+/**
+ * Computes the Stellar transaction hash from a base64-encoded, signed
+ * TransactionEnvelope XDR, as `sha256(network_id || envelope_type || transaction_body)`.
+ * The hash is deterministic from the envelope — signatures are computed over it,
+ * so they are stripped rather than hashed.
+ *
+ * For fee-bump envelopes this yields the canonical fee-bump hash. For plain
+ * transactions wrapped by a relayer later, this yields the inner hash, which
+ * Horizon also resolves.
+ *
+ * @param signedXDR base64-encoded TransactionEnvelope XDR (V0, V1 or fee-bump)
+ * @param chain CAIP-2 chain id (`stellar:pubnet` / `stellar:testnet`), defaults to pubnet
+ * @returns lowercase hex transaction hash (64 chars)
+ */
+export function getStellarTransactionHash(signedXDR: string, chain?: string): string {
+  const bytes = base64ToBytes(signedXDR);
+  if (bytes.length < 8) {
+    throw new Error("getStellarTransactionHash: envelope too short");
+  }
+
+  const discriminant = readUint32BE(bytes, 0);
+  let envelopeType: number;
+  let bodyStart: number;
+  switch (discriminant) {
+    case STELLAR_ENVELOPE_TYPE_TX_V0:
+      // V0 transactions are hashed as ENVELOPE_TYPE_TX over the envelope bytes
+      // INCLUDING the leading 4 zero bytes — they double as the legacy
+      // AccountID key-type tag of the pre-protocol-13 Transaction struct.
+      envelopeType = STELLAR_ENVELOPE_TYPE_TX;
+      bodyStart = 0;
+      break;
+    case STELLAR_ENVELOPE_TYPE_TX:
+      envelopeType = STELLAR_ENVELOPE_TYPE_TX;
+      bodyStart = 4;
+      break;
+    case STELLAR_ENVELOPE_TYPE_TX_FEE_BUMP:
+      envelopeType = STELLAR_ENVELOPE_TYPE_TX_FEE_BUMP;
+      bodyStart = 4;
+      break;
+    default:
+      throw new Error(
+        `getStellarTransactionHash: unsupported envelope type: ${discriminant}`,
+      );
+  }
+
+  const signatureArrayOffset = findStellarSignatureArrayOffset(bytes);
+
+  const networkReference = chain?.split(":").pop() ?? "pubnet";
+  const passphrase = STELLAR_NETWORK_PASSPHRASES[networkReference];
+  if (!passphrase) {
+    throw new Error(`getStellarTransactionHash: unknown Stellar network: ${networkReference}`);
+  }
+  const networkId = sha256(new TextEncoder().encode(passphrase));
+
+  const envelopeTypeBytes = new Uint8Array([0, 0, 0, envelopeType]);
+  const payload = concat([
+    networkId,
+    envelopeTypeBytes,
+    bytes.slice(bodyStart, signatureArrayOffset),
+  ]);
+
+  return toString(sha256(payload), "base16");
+}
+
 export function getWalletSendCallsHashes(
   result: string | { id: string; capabilities: { caip345: { transactionHashes: string[] } } },
 ) {

--- a/packages/utils/test/signatures.spec.ts
+++ b/packages/utils/test/signatures.spec.ts
@@ -635,6 +635,18 @@ Issued At: 2022-10-10T23:03:35.700Z`;
       expect(getStellarTransactionHash(signedXDR, "stellar:pubnet")).toBe(expectedHash);
     });
 
+    it("should compute the correct stellar hash when a signature ends in four zero bytes", () => {
+      // Adversarial: the last 4 bytes of the (structurally valid) signature are
+      // 0x00000000, which an ascending signature-array scan mistakes for a
+      // zero-length signature array, hashing the signatures into the payload.
+      // Hash cross-checked against @stellar/stellar-sdk's Transaction.hash().
+      const signedXDR =
+        "AAAAAgAAAABuW7RrrxcrA5UP8IX0wR/DVsdakYMxqY7Ug5ycd5KzgQAAAGQAAAAASZYC0wAAAAEAAAAAAAAAAAAAAABw29iAAAAAAAAAAAEAAAAAAAAAAQAAAABuW7RrrxcrA5UP8IX0wR/DVsdakYMxqY7Ug5ycd5KzgQAAAAAAAAAAAJiWgAAAAAAAAAABd5KzgQAAAEDGLpyx0gomLUe6OHNM90dIb/J8FPe2mR/+9m8suCVKNCF3UH6jhJthgRaiYAchg4uS+yAghMuqqTVHvyAAAAAA";
+      const expectedHash = "17e5f1f36ff6edc099fc190d24da41e48ab9dd9f0b0be6c6d68d9eba028ed8d3";
+
+      expect(getStellarTransactionHash(signedXDR, "stellar:pubnet")).toBe(expectedHash);
+    });
+
     it("should fail to compute a stellar transaction hash for an unknown network", () => {
       const signedXDR =
         "AAAAAgAAAAAEJr/kOejtZoeowwp8zwNy2Q5PJ4BGTWfjsi8nOzNmrwABOIQDtAXqAA5+nQAAAAEAAAAAAAAAAAAAAABqgtc9AAAAAAAAAAQAAAAAAAAADAAAAAFVU0RDAAAAADuZETgO/piLoKiQDrHP5E82b32+lGvtB3JA9/Yk3xXFAAAAAXlYTE0AAAAAIjbXcP4NPgFSGXXVz3rEhCtwldaxqddo0+mmMumZBr4AAAAAWC0vBxJeEy11BinxAAAAAG57ynoAAAAAAAAADAAAAAFVU0RDAAAAADuZETgO/piLoKiQDrHP5E82b32+lGvtB3JA9/Yk3xXFAAAAAXlYTE0AAAAAIjbXcP4NPgFSGXXVz3rEhCtwldaxqddo0+mmMumZBr4AAAACy0F4AAGqIxIKms6JAAAAAG57nJcAAAAAAAAAAwAAAAF5WExNAAAAACI213D+DT4BUhl11c96xIQrcJXWsanXaNPppjLpmQa+AAAAAVVTREMAAAAAO5kROA7+mIugqJAOsc/kTzZvfb6Ua+0HckD39iTfFcUAAAAAstBeAA36DJRYpIptAAAAAG52hUIAAAAAAAAAAwAAAAF5WExNAAAAACI213D+DT4BUhl11c96xIQrcJXWsanXaNPppjLpmQa+AAAAAVVTREMAAAAAO5kROA7+mIugqJAOsc/kTzZvfb6Ua+0HckD39iTfFcUAAAACy0F4AA0hty1TaHPUAAAAAG56kgAAAAAAAAAAATszZq8AAABAxLKQz2a6NY74WUVxGbWvafiKXhExlAIu2WM2MKUNOidwRDZb3EDY/JP2TbM5rWXlmwZGKHE8iLYs19u/n2LgAA==";

--- a/packages/utils/test/signatures.spec.ts
+++ b/packages/utils/test/signatures.spec.ts
@@ -6,6 +6,7 @@ import {
   getAlgorandTransactionId,
   getNearTransactionIdFromSignedTransaction,
   getSignDirectHash,
+  getStellarTransactionHash,
   getSuiDigest,
   isValidEip1271Signature,
   isValidEip191Signature,
@@ -531,6 +532,50 @@ Expiration Time: 2022-10-11T23:03:35.700Z`;
       const hash = getSignDirectHash(result);
       console.log("hash", hash);
       expect(hash).toBe(expectedHash);
+    });
+
+    // Stellar test vectors are real transactions fetched from Horizon
+    // (hash == the `hash` field of `GET /transactions/{hash}`).
+    it("should compute the transaction hash from a signed stellar V1 envelope (pubnet)", () => {
+      const signedXDR =
+        "AAAAAgAAAAAEJr/kOejtZoeowwp8zwNy2Q5PJ4BGTWfjsi8nOzNmrwABOIQDtAXqAA5+nQAAAAEAAAAAAAAAAAAAAABqgtc9AAAAAAAAAAQAAAAAAAAADAAAAAFVU0RDAAAAADuZETgO/piLoKiQDrHP5E82b32+lGvtB3JA9/Yk3xXFAAAAAXlYTE0AAAAAIjbXcP4NPgFSGXXVz3rEhCtwldaxqddo0+mmMumZBr4AAAAAWC0vBxJeEy11BinxAAAAAG57ynoAAAAAAAAADAAAAAFVU0RDAAAAADuZETgO/piLoKiQDrHP5E82b32+lGvtB3JA9/Yk3xXFAAAAAXlYTE0AAAAAIjbXcP4NPgFSGXXVz3rEhCtwldaxqddo0+mmMumZBr4AAAACy0F4AAGqIxIKms6JAAAAAG57nJcAAAAAAAAAAwAAAAF5WExNAAAAACI213D+DT4BUhl11c96xIQrcJXWsanXaNPppjLpmQa+AAAAAVVTREMAAAAAO5kROA7+mIugqJAOsc/kTzZvfb6Ua+0HckD39iTfFcUAAAAAstBeAA36DJRYpIptAAAAAG52hUIAAAAAAAAAAwAAAAF5WExNAAAAACI213D+DT4BUhl11c96xIQrcJXWsanXaNPppjLpmQa+AAAAAVVTREMAAAAAO5kROA7+mIugqJAOsc/kTzZvfb6Ua+0HckD39iTfFcUAAAACy0F4AA0hty1TaHPUAAAAAG56kgAAAAAAAAAAATszZq8AAABAxLKQz2a6NY74WUVxGbWvafiKXhExlAIu2WM2MKUNOidwRDZb3EDY/JP2TbM5rWXlmwZGKHE8iLYs19u/n2LgAA==";
+      const expectedHash = "f988eec2a159fa6031ef519bf4730dd50e86eb61f692334292d2d2b40d1465f1";
+
+      expect(getStellarTransactionHash(signedXDR, "stellar:pubnet")).toBe(expectedHash);
+      // pubnet is the default network
+      expect(getStellarTransactionHash(signedXDR)).toBe(expectedHash);
+    });
+
+    it("should compute the canonical fee-bump hash from a signed stellar fee-bump envelope (pubnet)", () => {
+      const signedXDR =
+        "AAAABQAAAAA0mMHF8QGzwsMRBhe9i8PSIqxjNjKyQMyXZODBAdhAUwAAAAAAA5+BAAAAAgAAAAA6Hd6p+AA5GTO2bJqKN/hbBfWcOh2Ow8cnTY3iIFFVPAADnrgDoCvmAAAZVgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAADod3qn4ADkZM7Zsmoo3+FsF9Zw6HY7DxydNjeIgUVU8AAAAGAAAAAAAAAAB1/5EvQrxHWArEJHy9KH03yEtRE0DIeoyrbPMHLurCgQAAAAEd29yawAAAAMAAAASAAAAAAAAAAA6Hd6p+AA5GTO2bJqKN/hbBfWcOh2Ow8cnTY3iIFFVPAAAAA0AAAAgAAAAjpSFVoEyx/Ev5d2V/desEr+GEqMyXKvrs5wXFqwAAAAFAAAAAAIrSjwAAAAAAAAAAQAAAAAAAAABAAAAB9ssFCkNSWTjgF8lJ90TKTm6X7P8ysVrML+rj9CRARYnAAAAAwAAAAYAAAAB1/5EvQrxHWArEJHy9KH03yEtRE0DIeoyrbPMHLurCgQAAAAQAAAAAQAAAAIAAAAPAAAABUJsb2NrAAAAAAAAAwACsj8AAAAAAAAABgAAAAHX/kS9CvEdYCsQkfL0ofTfIS1ETQMh6jKts8wcu6sKBAAAABAAAAABAAAAAwAAAA8AAAAEUGFpbAAAABIAAAAAAAAAADod3qn4ADkZM7Zsmoo3+FsF9Zw6HY7DxydNjeIgUVU8AAAAAwACsj8AAAAAAAAABgAAAAHX/kS9CvEdYCsQkfL0ofTfIS1ETQMh6jKts8wcu6sKBAAAABQAAAABABvFygAAAAAAAAXIAAAAAAADnrgAAAABIFFVPAAAAEBbcalx54eMMHwWJz7tzgOoxIVmMl4pexbgwTLzxnyMtAhZ2nZlsF18jIMDBaubSNSNPi4YRHkSajpyOcdZOzsCAAAAAAAAAAEB2EBTAAAAQDOlpIeUB73BImAZJCSAt0cuKZXHlKG+TJ+j+fCeFe9bDc5wHzMlDjU6YlB6geCuxRi7QwTq4RgxrOIJ9HICfg8=";
+      // this is H_fb (the hash explorers index), not the inner tx hash
+      const expectedHash = "5906453d5a367b4a8a1af9bbbc934904841718ec1ca1345874904e15f97bf83b";
+
+      expect(getStellarTransactionHash(signedXDR, "stellar:pubnet")).toBe(expectedHash);
+    });
+
+    it("should compute the transaction hash from a signed stellar V1 envelope (testnet)", () => {
+      const signedXDR =
+        "AAAAAgAAAAAJDqKNhO2/XZAvmR1Wynm2lxfIUQwB6TDzqNVOlQgQTgAAm74AJGh0ABKiOwAAAAEAAAAAAAAAAAAAAABqgthtAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABmtIg9IzJFxPz3yuidCMj3LiE2SB3XYOl8DvtohHRPVAAAAAJc2V0X3ByaWNlAAAAAAAAAwAAABIAAAAAAAAAAAkOoo2E7b9dkC+ZHVbKebaXF8hRDAHpMPOo1U6VCBBOAAAADwAAAAZFVEhVU0QAAAAAAAoAAAAAAAAAAAAAAARomVswAAAAAQAAAAAAAAAAAAAAAZrSIPSMyRcT898ronQjI9y4hNkgd12DpfA77aIR0T1QAAAACXNldF9wcmljZQAAAAAAAAMAAAASAAAAAAAAAAAJDqKNhO2/XZAvmR1Wynm2lxfIUQwB6TDzqNVOlQgQTgAAAA8AAAAGRVRIVVNEAAAAAAAKAAAAAAAAAAAAAAAEaJlbMAAAAAAAAAABAAAAAAAAAAQAAAAGAAAAAcbgeSm1T8h+V5r+/0u+qUVZIopr5hDeGKj1+u37faSgAAAAEAAAAAEAAAADAAAADwAAAAdIYXNSb2xlAAAAABIAAAAAAAAAAAkOoo2E7b9dkC+ZHVbKebaXF8hRDAHpMPOo1U6VCBBOAAAADwAAAAZPUkFDTEUAAAAAAAEAAAAGAAAAAcbgeSm1T8h+V5r+/0u+qUVZIopr5hDeGKj1+u37faSgAAAAFAAAAAEAAAAHve3Sc2JfmD0Hu+w96oFCzEX1XxFR0uE/NeSf2Vqmia8AAAAH4IWMslKp5yCKjCiGPIRV6yV0LdrLOEfRrCRSwjur0G8AAAABAAAABgAAAAGa0iD0jMkXE/PfK6J0IyPcuITZIHddg6XwO+2iEdE9UAAAABQAAAABADikCAAAAAAAAAJUAAAAAAAATa0AAAABlQgQTgAAAEDSMm2vdKNsB2TCk+Pbb6vSYgq6Zd5F0E4H5BfMi4lwWEcYFAq2Mp+e12wr1qU+Ni7+2BTqZUkb+uK7lVM8PqkN";
+      const expectedHash = "c9b2d35ab15c055acb422872a8f1680a84ad6b8ad0d56271cfb74c083edf2007";
+
+      expect(getStellarTransactionHash(signedXDR, "stellar:testnet")).toBe(expectedHash);
+    });
+
+    it("should fail to compute a stellar transaction hash for an unknown network", () => {
+      const signedXDR =
+        "AAAAAgAAAAAEJr/kOejtZoeowwp8zwNy2Q5PJ4BGTWfjsi8nOzNmrwABOIQDtAXqAA5+nQAAAAEAAAAAAAAAAAAAAABqgtc9AAAAAAAAAAQAAAAAAAAADAAAAAFVU0RDAAAAADuZETgO/piLoKiQDrHP5E82b32+lGvtB3JA9/Yk3xXFAAAAAXlYTE0AAAAAIjbXcP4NPgFSGXXVz3rEhCtwldaxqddo0+mmMumZBr4AAAAAWC0vBxJeEy11BinxAAAAAG57ynoAAAAAAAAADAAAAAFVU0RDAAAAADuZETgO/piLoKiQDrHP5E82b32+lGvtB3JA9/Yk3xXFAAAAAXlYTE0AAAAAIjbXcP4NPgFSGXXVz3rEhCtwldaxqddo0+mmMumZBr4AAAACy0F4AAGqIxIKms6JAAAAAG57nJcAAAAAAAAAAwAAAAF5WExNAAAAACI213D+DT4BUhl11c96xIQrcJXWsanXaNPppjLpmQa+AAAAAVVTREMAAAAAO5kROA7+mIugqJAOsc/kTzZvfb6Ua+0HckD39iTfFcUAAAAAstBeAA36DJRYpIptAAAAAG52hUIAAAAAAAAAAwAAAAF5WExNAAAAACI213D+DT4BUhl11c96xIQrcJXWsanXaNPppjLpmQa+AAAAAVVTREMAAAAAO5kROA7+mIugqJAOsc/kTzZvfb6Ua+0HckD39iTfFcUAAAACy0F4AA0hty1TaHPUAAAAAG56kgAAAAAAAAAAATszZq8AAABAxLKQz2a6NY74WUVxGbWvafiKXhExlAIu2WM2MKUNOidwRDZb3EDY/JP2TbM5rWXlmwZGKHE8iLYs19u/n2LgAA==";
+      expect(() => getStellarTransactionHash(signedXDR, "stellar:futurenet")).to.throw();
+    });
+
+    it("should fail to compute a stellar transaction hash from a malformed envelope", () => {
+      // too short
+      expect(() => getStellarTransactionHash("AAAA")).to.throw();
+      // valid base64 but not a TransactionEnvelope (unknown discriminant, no signature array)
+      expect(() =>
+        getStellarTransactionHash("q83vASNFZ4mrze8BI0VniavN7wEjRWeJq83vAQ==", "stellar:pubnet"),
+      ).to.throw();
     });
   });
 });

--- a/packages/utils/test/signatures.spec.ts
+++ b/packages/utils/test/signatures.spec.ts
@@ -563,6 +563,16 @@ Expiration Time: 2022-10-11T23:03:35.700Z`;
       expect(getStellarTransactionHash(signedXDR, "stellar:testnet")).toBe(expectedHash);
     });
 
+    it("should compute the transaction hash from a signed stellar V0 envelope (pubnet)", () => {
+      // ENVELOPE_TYPE_TX_V0 (discriminant 0) — exercises the include-leading-zeros path.
+      // Hash cross-checked against @stellar/stellar-sdk's Transaction.hash().
+      const signedXDR =
+        "AAAAAG5btGuvFysDlQ/whfTBH8NWx1qRgzGpjtSDnJx3krOBAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAsAAAAAAAAAZAAAAAAAAAABd5KzgQAAAEAu0xW2vwIqtuAu4/FFLWHBooGpvqn/N6iHgEX45savBk7SyoFGKIlyhG7ETZQ93tbF1OC/5ym6SdXmwIhIPQUD";
+      const expectedHash = "5b709eff53cb92c20d2c79e007f6b53ba9be04d6073119d142ffa70d7ea5c7cb";
+
+      expect(getStellarTransactionHash(signedXDR, "stellar:pubnet")).toBe(expectedHash);
+    });
+
     it("should fail to compute a stellar transaction hash for an unknown network", () => {
       const signedXDR =
         "AAAAAgAAAAAEJr/kOejtZoeowwp8zwNy2Q5PJ4BGTWfjsi8nOzNmrwABOIQDtAXqAA5+nQAAAAEAAAAAAAAAAAAAAABqgtc9AAAAAAAAAAQAAAAAAAAADAAAAAFVU0RDAAAAADuZETgO/piLoKiQDrHP5E82b32+lGvtB3JA9/Yk3xXFAAAAAXlYTE0AAAAAIjbXcP4NPgFSGXXVz3rEhCtwldaxqddo0+mmMumZBr4AAAAAWC0vBxJeEy11BinxAAAAAG57ynoAAAAAAAAADAAAAAFVU0RDAAAAADuZETgO/piLoKiQDrHP5E82b32+lGvtB3JA9/Yk3xXFAAAAAXlYTE0AAAAAIjbXcP4NPgFSGXXVz3rEhCtwldaxqddo0+mmMumZBr4AAAACy0F4AAGqIxIKms6JAAAAAG57nJcAAAAAAAAAAwAAAAF5WExNAAAAACI213D+DT4BUhl11c96xIQrcJXWsanXaNPppjLpmQa+AAAAAVVTREMAAAAAO5kROA7+mIugqJAOsc/kTzZvfb6Ua+0HckD39iTfFcUAAAAAstBeAA36DJRYpIptAAAAAG52hUIAAAAAAAAAAwAAAAF5WExNAAAAACI213D+DT4BUhl11c96xIQrcJXWsanXaNPppjLpmQa+AAAAAVVTREMAAAAAO5kROA7+mIugqJAOsc/kTzZvfb6Ua+0HckD39iTfFcUAAAACy0F4AA0hty1TaHPUAAAAAG56kgAAAAAAAAAAATszZq8AAABAxLKQz2a6NY74WUVxGbWvafiKXhExlAIu2WM2MKUNOidwRDZb3EDY/JP2TbM5rWXlmwZGKHE8iLYs19u/n2LgAA==";


### PR DESCRIPTION
## Description

Adds Stellar to TVF transaction-hash collection, covering the two transaction methods of the [Stellar RPC proposal](https://github.com/WalletConnectFoundation/docs/pull/154):

| Method | Strategy |
|---|---|
| `stellar_signAndSubmitXDR` | Response contains the hash — extracted via the generic `TVF_METHODS` key mapping (`tx_hash`) |
| `stellar_signXDR` | Response contains only `signedXDR` — hash computed client-side as `sha256(network_id ‖ envelope_type ‖ transaction_body)` |

### How `stellar_signXDR` hash computation works (`getStellarTransactionHash` in `@walletconnect/utils`)

The Stellar tx hash is deterministic from the signed envelope (signatures are computed *over* the hash, so they're stripped, not hashed):

1. base64-decode the `TransactionEnvelope` XDR
2. read the 4-byte envelope discriminant — `0` (V0), `2` (V1), `5` (fee-bump) all supported
3. locate the trailing `DecoratedSignature<20>` array with a validated scan (fixed 72-byte ed25519 entries — count field and per-entry length fields must all check out), avoiding a full parse of the Stellar transaction schema
4. `sha256(sha256(network_passphrase) ‖ envelope_type ‖ body)`, lowercase hex

**No new dependencies** — uses `@noble/hashes` sha256 already in `@walletconnect/utils`, same pattern as the existing Cosmos (hand-rolled protobuf) and Sui (client-side digest) TVF helpers.

The network passphrase is selected from the request's CAIP-2 `chain` param (`stellar:pubnet` / `stellar:testnet`), defaulting to pubnet.

### Fee-bump semantics

- If the wallet signs a **fee-bump envelope**, the computed hash is the canonical fee-bump hash explorers index.
- If the wallet signs a **plain tx** that a relayer later wraps in a `FeeBumpTransaction` (fee-abstraction flow), the computed hash is the inner hash — Horizon resolves it to the same record via dual-hash lookup, but it 404s until the wrapped tx is submitted.

## Tests

Test vectors are **real pubnet/testnet transactions fetched from Horizon**, asserting byte-for-byte equality with the network-reported `hash` field:

- V1 pubnet envelope (multi-op path payments, 1 signature)
- Fee-bump pubnet envelope with Soroban data in the inner tx → canonical H_fb
- V1 testnet Soroban invocation (passphrase selection)
- Default-to-pubnet when `chain` omitted
- Failure cases: unknown network, malformed/truncated envelopes

`vitest run test/signatures.spec.ts` → 5/5 new tests pass (2 pre-existing EIP-1271 failures are unrelated — they require `TEST_PROJECT_ID` + network and fail identically on `v2.0`).

## Notes for QA

- Wallet-side: respond to a `stellar_signXDR` request and confirm the relay publish carries `txHashes` matching the hash your Stellar tooling computes (`TransactionBuilder.fromXDR(signedXDR, Networks.PUBLIC).hash().toString("hex")`).
- `stellar_signAndSubmitXDR` publish should carry the response's `tx_hash` verbatim.
- Kotlin/Swift/Flutter ports follow once this is validated (RN inherits this JS implementation via `@reown/walletkit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)