### PR TITLE
refactor(utils): fix recap statement variable name

### DIFF
--- a/packages/utils/src/cacao.ts
+++ b/packages/utils/src/cacao.ts
@@ -414,8 +414,8 @@ export function formatStatementFromRecap(statement = "", recap: RecapType) {
     statementForRecap.push(abilities.join(", ").replace(".,", "."));
   });
 
-  const recapStatemet = statementForRecap.join(" ");
-  const recapStatement = `${base}${recapStatemet}`;
+  const recapStatementBody = statementForRecap.join(" ");
+  const recapStatement = `${base}${recapStatementBody}`;
   // add a space if there is a statement
   return `${statement ? statement + " " : ""}${recapStatement}`;
 }


### PR DESCRIPTION
## Description

Rename the internal `recapStatemet` variable to `recapStatementBody`. The new name fixes the spelling error and makes it clear that the value represents the Recap statement body. No exported API or runtime behavior changes.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Draft PR
- [ ] Breaking change

## How has this been tested?

- `npm run build:types --prefix=packages/utils`

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information

The renamed identifier is local to `packages/utils/src/cacao.ts`; consumers are unaffected.