### PR TITLE
fix(utils): hash plaintext SIWE messages whose domain starts with 0x in isValidEip1271Signature

### DIFF
--- a/.changeset/strict-eip1271-hash-detection.md
+++ b/.changeset/strict-eip1271-hash-detection.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/utils": patch
+---
+
+Fix `isValidEip1271Signature` treating any message that starts with `0x` as an already-hashed digest. A plaintext SIWE/CACAO message whose domain begins with `0x` (e.g. `0xsplits.xyz`) was spliced unhashed into the `eth_call` calldata, so EIP-1271 verification for smart-contract wallets deterministically failed against such dApps. Only a 32-byte hex string is now treated as pre-hashed; everything else is hashed per EIP-191.

--- a/packages/utils/src/signatures.ts
+++ b/packages/utils/src/signatures.ts
@@ -21,6 +21,16 @@ function base64ToBytes(b64: string): Uint8Array {
   return bytes;
 }
 
+// EIP-1271 `isValidSignature(bytes32 _hash, bytes _signature)` takes a 32-byte digest, so only a
+// `0x`-prefixed 64-character hex string can be an already-hashed message. Anything else — notably a
+// plaintext SIWE/CACAO message whose domain happens to start with `0x` (e.g. `0xsplits.xyz`) — must
+// still be hashed per EIP-191 before being spliced into the calldata.
+const BYTES32_HEX_REGEX = /^0x[0-9a-fA-F]{64}$/;
+
+function isBytes32Hex(value: string): boolean {
+  return BYTES32_HEX_REGEX.test(value);
+}
+
 export function hashEthereumMessage(message: string) {
   const prefix = `\x19Ethereum Signed Message:\n${message.length}`;
   const prefixedMessage = new TextEncoder().encode(prefix + message);
@@ -89,7 +99,7 @@ export async function isValidEip1271Signature(
     const nonPrefixedSignature = signature.substring(2);
     const dynamicTypeLength = (nonPrefixedSignature.length / 2).toString(16).padStart(64, "0");
     const nonPrefixedHashedMessage = (
-      reconstructedMessage.startsWith("0x")
+      isBytes32Hex(reconstructedMessage)
         ? reconstructedMessage
         : hashEthereumMessage(reconstructedMessage)
     ).substring(2);

--- a/packages/utils/test/cacao.spec.ts
+++ b/packages/utils/test/cacao.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createEncodedRecap,
   createRecap,
@@ -9,6 +9,7 @@ import {
   getCommonValuesInArrays,
   getDecodedRecapFromResources,
   getMethodsFromRecap,
+  hashEthereumMessage,
   isValidRecap,
   mergeRecaps,
   populateAuthPayload,
@@ -323,6 +324,45 @@ describe("URI", () => {
 
     const isValid = await validateSignedCacao({ cacao });
     expect(isValid).to.eql(false);
+  });
+
+  it("should hash a plaintext SIWE message whose domain starts with `0x` for eip1271 cacaos", async () => {
+    // Regression: `isValidEip1271Signature` detected a pre-hashed message via `startsWith("0x")`,
+    // so a domain such as `0xsplits.xyz` made the reconstructed plaintext message get spliced
+    // into the `eth_call` calldata unhashed, yielding invalid hex and a deterministic `false`.
+    const address = "0x3613699A6c5D8BC97a08805876c8005543125F09";
+    const cacao = {
+      h: { t: "caip122" },
+      p: {
+        iss: `did:pkh:eip155:1:${address}`,
+        domain: "0xsplits.xyz",
+        aud: "https://0xsplits.xyz/login",
+        version: "1",
+        nonce: "32891756",
+        iat: "2024-03-13T09:00:43.888Z",
+        statement: "Sign in to 0xsplits",
+      },
+      s: {
+        t: "eip1271" as const,
+        s: "0xc1505719b2504095116db01baaf276361efd3a73c28cf8cc28dabefa945b8d536011289ac0a3b048600c1e692ff173ca944246cf7ceb319ac2262d27b395c82b1c",
+      },
+    };
+    const eip1271MagicValue = "0x1626ba7e";
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      json: () => Promise.resolve({ result: eip1271MagicValue.padEnd(66, "0") }),
+    } as unknown as Response);
+    try {
+      const isValid = await validateSignedCacao({ cacao, projectId: "test-project-id" });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+      const data: string = body.params[0].data;
+      expect(data).toMatch(/^0x[0-9a-f]+$/i);
+      const expectedHash = hashEthereumMessage(formatMessage(cacao.p, cacao.p.iss));
+      expect(data.slice(10, 74)).to.eql(expectedHash.slice(2));
+      expect(isValid).to.eql(true);
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   describe("encodeRecap / decodeRecap with unpadded base64", () => {

--- a/packages/utils/test/signatures.spec.ts
+++ b/packages/utils/test/signatures.spec.ts
@@ -1,5 +1,5 @@
 import { AuthTypes } from "@walletconnect/types";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildSignedExtrinsicHash,
   extractSolanaTransactionId,
@@ -7,6 +7,7 @@ import {
   getNearTransactionIdFromSignedTransaction,
   getSignDirectHash,
   getSuiDigest,
+  hashEthereumMessage,
   isValidEip1271Signature,
   isValidEip191Signature,
   verifySignature,
@@ -113,6 +114,67 @@ Expiration Time: 2022-10-11T23:03:35.700Z`;
         projectId,
       );
       expect(isValid).toBe(true);
+    });
+  });
+  describe("EIP-1271 message hashing", () => {
+    const chainId = "eip155:1";
+    const projectId = "test-project-id";
+    const address = "0x2faf83c542b68f1b4cdc0e770e8cb9f567b08f71";
+    const signature =
+      "0xc1505719b2504095116db01baaf276361efd3a73c28cf8cc28dabefa945b8d536011289ac0a3b048600c1e692ff173ca944246cf7ceb319ac2262d27b395c82b1c";
+    const eip1271MagicValue = "0x1626ba7e";
+
+    // Captures the `eth_call` calldata `isValidEip1271Signature` would send, without touching
+    // the network. The stubbed RPC answers with the magic value so the call is treated as valid.
+    const captureCalldata = async (message: string) => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        json: () => Promise.resolve({ result: eip1271MagicValue.padEnd(66, "0") }),
+      } as unknown as Response);
+      try {
+        const isValid = await isValidEip1271Signature(
+          address,
+          message,
+          signature,
+          chainId,
+          projectId,
+        );
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+        return { isValid, data: body.params[0].data as string };
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    };
+
+    it("hashes a plaintext SIWE message whose domain starts with `0x`", async () => {
+      // Regression: a `startsWith("0x")` check treated this plaintext message as a pre-hashed
+      // digest, splicing it unhashed into the calldata and producing invalid hex.
+      const message = `0xsplits.xyz wants you to sign in with your Ethereum account:
+${address}
+
+URI: https://0xsplits.xyz
+Version: 1
+Chain ID: 1
+Nonce: 1665443015700
+Issued At: 2022-10-10T23:03:35.700Z`;
+      const { isValid, data } = await captureCalldata(message);
+      expect(data).toMatch(/^0x[0-9a-f]+$/i);
+      expect(data.slice(0, 10)).toBe(eip1271MagicValue);
+      expect(data.slice(10, 74)).toBe(hashEthereumMessage(message).slice(2));
+      expect(isValid).toBe(true);
+    });
+
+    it("passes a pre-hashed 32-byte message through unchanged", async () => {
+      const hash = "0xb48c43838346726a55fe0023cd2fc14b26144b6a9d36284a436b62e934bf382d";
+      const { data } = await captureCalldata(hash);
+      expect(data.slice(10, 74)).toBe(hash.slice(2));
+    });
+
+    it("hashes a `0x`-prefixed message that is not a 32-byte hash", async () => {
+      // A short hex string (e.g. an address) cannot be an EIP-1271 `bytes32` digest.
+      const message = "0xdeadbeef";
+      const { data } = await captureCalldata(message);
+      expect(data.slice(10, 74)).toBe(hashEthereumMessage(message).slice(2));
     });
   });
   describe("EIP-191 signatures", () => {


### PR DESCRIPTION
## Description

`isValidEip1271Signature` decided whether its `reconstructedMessage` was already a 32-byte digest by checking `reconstructedMessage.startsWith("0x")`. A reconstructed CACAO/SIWE message begins with the dApp `domain` (`formatMessage()` header: `<domain> wants you to sign in with your … account:`), so any dApp whose domain starts with `0x` (e.g. `0xsplits.xyz`) made the check return `true`. EIP-191 hashing was skipped, the plaintext was spliced into the `eth_call` calldata, the RPC rejected the request as invalid hex, and verification returned `false` — a deterministic `wc_sessionAuthenticate` failure for every EIP-1271 (smart-contract) wallet against such dApps, on both the wallet (`approveSessionAuthenticate`) and dApp (`onAuthenticate`) side.

The fix only treats a `0x`-prefixed **64-character hex string** as pre-hashed, since that is the only thing that can be an EIP-1271 `isValidSignature(bytes32, bytes)` digest. Everything else is hashed per EIP-191. The pre-hashed path (added for multi-sig callers in c8c722488) is preserved, so there is no public-API change for `@walletconnect/utils` consumers.

```mermaid
flowchart LR
    A[validateSignedCacao] --> B["formatMessage()<br/>'0xsplits.xyz wants you to sign in…'"]
    B --> C{isValidEip1271Signature}
    C -- "before: startsWith('0x') → true" --> D[plaintext spliced into calldata]
    D --> E["RPC -32602 invalid hex → false"]
    C -- "after: /^0x[0-9a-fA-F]{64}$/ → false" --> F[hashEthereumMessage]
    F --> G["valid bytes32 calldata → eth_call reaches isValidSignature"]
    H["0xb48c…(32-byte digest)"] -. "both before & after: passed through unchanged" .-> C
```

Impact assessment: availability/correctness only. A SIWE message can never be valid hex, so the malformed calldata always errored to `false` — there is no path to a forged signature being accepted, and only a dApp's own domain triggers it.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

- New fetch-stubbed regression tests (no network / project ID needed):
  - `packages/utils/test/signatures.spec.ts` › `EIP-1271 message hashing`: a plaintext SIWE message with a `0x…` domain produces valid hex calldata embedding `hashEthereumMessage(message)`; a real 32-byte hash is passed through unchanged; a short `0x…` string (e.g. `0xdeadbeef`) is hashed.
  - `packages/utils/test/cacao.spec.ts`: end-to-end `validateSignedCacao` with `domain: "0xsplits.xyz"` and an `eip1271` signature.
- The new tests were run against the unfixed code first and failed exactly as described (calldata literally `0x1626ba7esplits.xyz wants you to sign in…`).
- `packages/utils` `signatures.spec.ts` + `cacao.spec.ts` with a real `TEST_PROJECT_ID`: **44/44 pass**, including the live `should verify 1271 multi-sig` (pre-hashed path) and `passes for a valid signature`.
- Live RPC probe for a `0xsplits.xyz` message against `rpc.walletconnect.org` (`eip155:1`):

| Before | After |
| ------------ | ------------ |
| `{"error":{"code":-32602,"message":"invalid argument 0: json: cannot unmarshal invalid hex string into Go struct field TransactionArgs.data of type hexutil.Bytes"}}` | `{"error":{"code":3,"message":"execution reverted: TM: Invalid signer"}}` — the call is well-formed and reaches the contract's `isValidSignature` (revert expected: the probe signature was made over a different message) |

- `prettier --check`, `tsc --noEmit -p packages/utils`, and eslint on the touched files: clean, no new warnings.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules (n/a — self-contained change in `@walletconnect/utils`)

# Additional Information (Optional)

Reported via a security report submission. Changeset included: `@walletconnect/utils` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
