### PR TITLE
fix(utils): use UTF-8 byte length for the EIP-191 prefix in hashEthereumMessage

### DIFF
--- a/.changeset/eip191-utf8-byte-length.md
+++ b/.changeset/eip191-utf8-byte-length.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/utils": patch
+---
+
+Fix `hashEthereumMessage` prefixing the JavaScript string length (UTF-16 code units) instead of the UTF-8 byte length required by EIP-191. Any SIWE/CACAO message containing a non-ASCII character (e.g. a localized or emoji statement, or a Unicode domain) hashed to a value that no compliant signer produces, so `eip191` and `eip1271` verification deterministically failed for every wallet type. Hashes of ASCII messages are unchanged; this restores the pre-2.18.0 behaviour (`ethers` `hashMessage`). Consumers calling `hashEthereumMessage` directly now receive the standard EIP-191 hash for non-ASCII input.

--- a/packages/utils/src/signatures.ts
+++ b/packages/utils/src/signatures.ts
@@ -22,9 +22,14 @@ function base64ToBytes(b64: string): Uint8Array {
 }
 
 export function hashEthereumMessage(message: string) {
-  const prefix = `\x19Ethereum Signed Message:\n${message.length}`;
-  const prefixedMessage = new TextEncoder().encode(prefix + message);
-  return "0x" + toString(keccak_256(prefixedMessage), "base16");
+  // EIP-191 (version 0x45) prefixes the UTF-8 *byte* length of the message. `message.length`
+  // counts UTF-16 code units instead, which differs for any non-ASCII character (e.g. a SIWE
+  // statement such as `Sign in to Café ☕`) and yields a hash that no compliant signer produces.
+  const messageBytes = new TextEncoder().encode(message);
+  const prefixBytes = new TextEncoder().encode(
+    `\x19Ethereum Signed Message:\n${messageBytes.length}`,
+  );
+  return "0x" + toString(keccak_256(concat([prefixBytes, messageBytes])), "base16");
 }
 
 export async function verifySignature(

--- a/packages/utils/test/cacao.spec.ts
+++ b/packages/utils/test/cacao.spec.ts
@@ -15,6 +15,7 @@ import {
   mergeEncodedRecaps,
   validateSignedCacao,
 } from "../src";
+import { Address, Hex, PersonalMessage, Secp256k1, Signature } from "ox";
 
 describe("URI", () => {
   describe("merge recaps", () => {
@@ -302,6 +303,33 @@ describe("URI", () => {
     };
 
     expect(() => formatMessage(request, iss)).to.throw("Statement must not contain line breaks");
+  });
+
+  it("should validate an eip191 cacao whose statement contains non-ASCII characters", async () => {
+    // Regression: `hashEthereumMessage` prefixed the UTF-16 length instead of the UTF-8 byte
+    // length, so any CACAO with a non-ASCII statement or domain failed verification for every wallet.
+    const privateKey = `0x${"11".repeat(32)}` as const; // test-only key
+    const address = Address.fromPublicKey(Secp256k1.getPublicKey({ privateKey }));
+    const iss = `did:pkh:eip155:1:${address}`;
+    const payload = {
+      iss,
+      domain: "example.com",
+      aud: "https://example.com/login",
+      version: "1",
+      nonce: "32891756",
+      iat: "2024-03-13T09:00:43.888Z",
+      statement: "Sign in to Café ☕ — 登录 🚀",
+    };
+    const message = formatMessage(payload, iss);
+    const signature = Signature.toHex(
+      Secp256k1.sign({
+        payload: PersonalMessage.getSignPayload(Hex.fromString(message)),
+        privateKey,
+      }),
+    );
+    const cacao = { h: { t: "caip122" }, p: payload, s: { t: "eip191" as const, s: signature } };
+
+    expect(await validateSignedCacao({ cacao })).to.eql(true);
   });
 
   it("should return false from validateSignedCacao for statements with line breaks", async () => {

--- a/packages/utils/test/signatures.spec.ts
+++ b/packages/utils/test/signatures.spec.ts
@@ -1,5 +1,5 @@
 import { AuthTypes } from "@walletconnect/types";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildSignedExtrinsicHash,
   extractSolanaTransactionId,
@@ -7,10 +7,12 @@ import {
   getNearTransactionIdFromSignedTransaction,
   getSignDirectHash,
   getSuiDigest,
+  hashEthereumMessage,
   isValidEip1271Signature,
   isValidEip191Signature,
   verifySignature,
 } from "../src";
+import { Address, Hex, PersonalMessage, Secp256k1, Signature } from "ox";
 
 describe("utils/signature", () => {
   describe("EIP-1271 signatures", () => {
@@ -141,6 +143,70 @@ Expiration Time: 2022-10-11T23:03:35.700Z`;
       const message = `Hello AppKit! 0xyadayada`;
       const signature = "0xd7ec09eb8ecb1ba9af45380e14d3ef1a1ec2376e0adfc0a9b591e";
       expect(() => isValidEip191Signature(address, message, signature)).toThrow();
+    });
+  });
+  describe("hashEthereumMessage", () => {
+    // EIP-191 prefixes the UTF-8 *byte* length of the message. `String.prototype.length` counts
+    // UTF-16 code units, so the two diverge for any non-ASCII character. `ox` and a hardcoded
+    // ethers v6 vector serve as independent oracles rather than sharing the implementation.
+    const nonAsciiMessage = "Sign in to Café ☕ — 登录 🚀"; // 25 UTF-16 code units, 36 UTF-8 bytes
+    const privateKey = `0x${"11".repeat(32)}` as const; // test-only key
+    const signer = Address.fromPublicKey(Secp256k1.getPublicKey({ privateKey }));
+    const signPersonal = (message: string) =>
+      Signature.toHex(
+        Secp256k1.sign({
+          payload: PersonalMessage.getSignPayload(Hex.fromString(message)),
+          privateKey,
+        }),
+      );
+
+    it("matches the EIP-191 hash produced by ox for ASCII and non-ASCII messages", () => {
+      const vectors = [
+        "Hello AppKit!",
+        "Sign in to Café ☕",
+        "登录到应用",
+        "Let's go 🚀",
+        "münchen.de wants you to sign in with your Ethereum account:",
+      ];
+      for (const message of vectors) {
+        expect(hashEthereumMessage(message)).toBe(
+          PersonalMessage.getSignPayload(Hex.fromString(message)),
+        );
+      }
+    });
+
+    it("matches a hardcoded ethers v6 `hashMessage` vector for a non-ASCII message", () => {
+      expect(hashEthereumMessage(nonAsciiMessage)).toBe(
+        "0xcd1958ff51f1424d4f13bb000803af76db0321edda656f3c39566d1d46c26113",
+      );
+    });
+
+    it("verifies an eip191 signature over a non-ASCII message from a compliant signer", () => {
+      const signature = signPersonal(nonAsciiMessage);
+      expect(isValidEip191Signature(signer, nonAsciiMessage, signature)).toBe(true);
+      expect(isValidEip191Signature(signer, `${nonAsciiMessage} `, signature)).toBe(false);
+    });
+
+    it("embeds the byte-length EIP-191 hash of a non-ASCII message in EIP-1271 calldata", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        json: () => Promise.resolve({ result: "0x1626ba7e".padEnd(66, "0") }),
+      } as unknown as Response);
+      try {
+        await isValidEip1271Signature(
+          signer,
+          nonAsciiMessage,
+          signPersonal(nonAsciiMessage),
+          "eip155:1",
+          "test-project-id",
+        );
+        const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+        const data: string = body.params[0].data;
+        expect(data.slice(10, 74)).toBe(
+          PersonalMessage.getSignPayload(Hex.fromString(nonAsciiMessage)).slice(2),
+        );
+      } finally {
+        fetchSpy.mockRestore();
+      }
     });
   });
   describe("tvf", () => {


### PR DESCRIPTION
## Description

`hashEthereumMessage` built the EIP-191 prefix with `message.length`, which counts **UTF-16 code units**. EIP-191 (version `0x45`) requires the length of the **UTF-8 encoded** message. The two are equal for ASCII but differ for any non-ASCII character, so a SIWE/CACAO message with a localized or emoji statement (`Sign in to Café ☕`, `登录到应用`, `Let's go 🚀`) or a Unicode domain hashed to a value that no compliant signer produces (ethers, viem/`ox`, MetaMask `eth-sig-util`, web3.js, geth, Safe all hash over bytes). The result was a deterministic `false` from both `isValidEip191Signature` and the non-pre-hashed path of `isValidEip1271Signature` — i.e. `wc_sessionAuthenticate` failed for **every wallet type** against such dApps, on both the wallet and dApp side.

```mermaid
sequenceDiagram
    participant W as Wallet (compliant signer)
    participant S as @walletconnect/utils
    Note over W: bytes = utf8(message)
    W->>W: sign keccak("\x19Ethereum Signed Message:\n" + bytes.length + bytes)
    W->>S: cacao { s: signature }
    rect rgb(255, 235, 235)
    Note over S: before: prefix uses message.length (UTF-16 units)<br/>→ different digest for any non-ASCII char → recovered address ≠ signer → false
    end
    rect rgb(235, 255, 235)
    Note over S: after: prefix uses utf8(message).length<br/>→ identical digest → verification succeeds
    end
```

**Compatibility**
- ASCII messages hash **bit-identically** — nothing that verifies today changes.
- Non-ASCII messages currently fail against every standards-compliant signer, so this can only turn existing false-negatives into passes.
- This restores the behaviour the SDK had before 45189aa1e (shipped in 2.18.0), when it delegated to ethers' `hashMessage`, and matches the other WalletConnect SDKs.
- `hashEthereumMessage` is a public export; consumers calling it directly now get the standard EIP-191 hash for non-ASCII input (noted in the changeset).

Independent of #7327 (different region of the same file); verified with `git merge-tree` that the two branches merge cleanly in either order.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

New tests use **independent oracles** (`ox`, already a `@walletconnect/utils` dependency, and a hardcoded ethers v6.17 vector) rather than sharing the implementation:

- `signatures.spec.ts` › `hashEthereumMessage`
  - matches `ox` `PersonalMessage.getSignPayload` for ASCII, Latin-1, CJK, emoji (surrogate pair) and an IDN-domain SIWE header;
  - matches a hardcoded ethers v6 `hashMessage` vector for `"Sign in to Café ☕ — 登录 🚀"` (25 code units / 36 bytes);
  - `isValidEip191Signature` accepts a signature over a non-ASCII message produced by a compliant signer (and rejects a tampered message);
  - `isValidEip1271Signature` (fetch-stubbed) embeds the byte-length digest in the `eth_call` calldata.
- `cacao.spec.ts`: end-to-end `validateSignedCacao` with a non-ASCII `statement` and an `eip191` signature over `formatMessage()` output.
- All 5 new tests **fail on the current code and pass with the fix**.
- `packages/utils` `signatures.spec.ts` + `cacao.spec.ts` with a real `TEST_PROJECT_ID`: **45/45 pass**, including the pre-existing ASCII vectors (unchanged hashes).
- `prettier --check`, `tsc --noEmit -p packages/utils`, eslint on touched files: clean, no new findings.

## Examples/Screenshots (Optional)

Signature from a compliant signer (`ox`) over each message, verified with `isValidEip191Signature`:

| Message | Before | After |
| ------------ | ------------ | ------------ |
| ASCII statement | ✅ true | ✅ true (identical hash) |
| `Sign in to Café ☕` | ❌ false | ✅ true |
| `登录到应用` | ❌ false | ✅ true |
| `Let's go 🚀` | ❌ false | ✅ true |
| `münchen.de wants you to sign in…` | ❌ false | ✅ true |

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules (n/a — self-contained change in `@walletconnect/utils`)

# Additional Information (Optional)

Found while triaging the `0x`-domain EIP-1271 report fixed in #7327. Changeset included: `@walletconnect/utils` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
