### PR TITLE
chore: add changeset for stellar TVF tx hashes

### DIFF
--- a/.changeset/stellar-tvf-tx-hashes.md
+++ b/.changeset/stellar-tvf-tx-hashes.md
@@ -1,0 +1,6 @@
+---
+"@walletconnect/utils": minor
+"@walletconnect/sign-client": minor
+---
+
+Collect TVF transaction hashes for Stellar: compute the canonical transaction hash from signed `stellar_signXDR` envelopes (V0, V1 and fee-bump — with the signature-array scan hardened against signatures ending in zero bytes) and extract `tx_hash` from `stellar_signAndSubmitXDR` responses.


### PR DESCRIPTION
#7318 merged without a changeset, so the pending "version packages" PR (#7303) would release the Stellar TVF feature silently (and as a patch). This adds the missing changeset: **minor** for `@walletconnect/utils` + `@walletconnect/sign-client` — the fixed group takes the whole family 2.23.10 → 2.24.0 with a changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)