### PR TITLE
chore(utils): skip live 1271 multi-sig test after Sepolia Safe threshold change

### DIFF
--- a/packages/utils/test/signatures.spec.ts
+++ b/packages/utils/test/signatures.spec.ts
@@ -101,7 +101,14 @@ Expiration Time: 2022-10-11T23:03:35.700Z`;
         `isValidEip1271Signature failed: chainId must be in CAIP-2 format, received: ${invalidChainIdThree}`,
       );
     });
-    it("should verify 1271 multi-sig", async () => {
+    // Skipped 2026-08-27: live call against Safe 0x9a1148b5D6a2D34CA46111379d0FD1352a0ade4a on
+    // Sepolia. Its owners changed and its threshold was raised from 2 to 3 the same day
+    // (tx 0xaca940ded685d75fec9a8b6afb6519b027bc01f247be2d3b2c4acca741ff9010, block 11577052).
+    // The fixture below carries only 2 signatures, so the Safe now reverts with GS020
+    // ("Signatures data too short") and the test fails deterministically. Re-enable once the
+    // fixture is re-signed by 3 current owners or the test targets a contract with immutable state.
+    // The pre-hashed pass-through path stays covered by the fetch-stubbed "EIP-1271 message hashing" tests.
+    it.skip("should verify 1271 multi-sig", async () => {
       const signature =
         "0x6037120d3995a626caa8dac775220ef5c91ece120a8ffa599bf28dbd1c40f1e1398cb941dd9fc4e880b988f279c603cedf7fe0609aa2b9cad829861d9798803b1be2a4308f50367f32a84baa7965102c87ab22db69a70ba3d3717f951e07007fea5901c524425171f8ff9143b64fe3223155a26ee0aab54b03058ab99187bc5ad71c";
       const message = "0xb48c43838346726a55fe0023cd2fc14b26144b6a9d36284a436b62e934bf382d";


### PR DESCRIPTION
## Description

Skips `signatures.spec.ts › should verify 1271 multi-sig`, which has been failing deterministically in `test (packages/utils)` on every PR since ~09:42 UTC today.

The test makes a live `eth_call` against Safe `0x9a1148b5D6a2D34CA46111379d0FD1352a0ade4a` on Sepolia with a fixed 130-byte payload (2 signatures). On 2026‑08‑27 that Safe's owners were changed (09:26–09:30 UTC) and its **threshold was raised from 2 to 3** ([tx `0xaca940de…9010`](https://sepolia.etherscan.io/tx/0xaca940ded685d75fec9a8b6afb6519b027bc01f247be2d3b2c4acca741ff9010), block 11577052). A 2‑signature payload can no longer satisfy `checkNSignatures`, so the Safe reverts with `GS020` ("Signatures data too short"), `isValidEip1271Signature` sees an RPC error and returns `false`, and the assertion fails.

This is a fixture problem, not a regression: the test fails identically on pre‑#7327 code, and the same calldata reverts `GS020` through an independent public Sepolia node as well as `rpc.walletconnect.org`.

Coverage that remains:
- the mainnet live test `passes for a valid signature` (stable contract, still green) exercises the real `eth_call` path and dynamic-length encoding;
- the fetch-stubbed `EIP-1271 message hashing` tests from #7327 cover the pre-hashed `bytes32` pass-through this test used.

To re-enable: re-sign hash `0xb48c…382d` with 3 current owners of the Safe, restore the Safe's threshold to 2, or point the test at a contract whose state is immutable.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

- `packages/utils` `signatures.spec.ts` + `cacao.spec.ts` with a real `TEST_PROJECT_ID`: **50 passed, 1 skipped**.
- On-chain verification: `getThreshold()` on the Safe returns 3 (7 owners, nonce 217); `ChangedThreshold(3)` event emitted at block 11577052.
- `prettier --check` and eslint on the touched file: clean.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules (n/a — test-only change)

# Additional Information (Optional)

Test-only change, no changeset (same as #7325). Someone on the team appears to be actively using this Safe (owner changes and nonce 217 today) — worth confirming whether it is still meant to serve as a shared test fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
